### PR TITLE
docs: sync project markdown with current state + tweak SynthesizerFal…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,14 +98,19 @@ view.fromPatterns(['neo4j-query']).serialize()        // → XML for LLM
 
 ## BAML Clients
 
-| Client | Role |
-|--------|------|
-| `RouterFallback` | Intent classification |
-| `ControllerFallback` | Tool loop controllers (LocalGLM → GroqReasoning) |
-| `CriticFallback` | Evaluation/critique (LocalGLM → GroqEval) |
-| `SynthesizerFallback` | Response synthesis |
+| Client | Role | Chain |
+|--------|------|-------|
+| `RouterFallback` | Intent classification | OpenRouterGemma4 → GroqFast → GroqGPT120B |
+| `ControllerFallback` | Tool loop controllers | OpenRouterNemotron120B → OpenAIGPT5 → OpenRouterMiniMax2_5 → GroqGPT120B |
+| `CriticFallback` | Evaluation/critique | GroqQwen3_32b → GroqGPT120B → OpenRouterMiniMax2_5 |
+| `SynthesizerFallback` | Response synthesis | OpenRouterGemma4 → GroqQwen3_32b → OpenAIGPT5 |
+| `DescribeFallback` | Lightweight tool result summarization | GroqFast → OpenRouterGemma4 → OpenAIGPT5Mini |
 
-**Known limitation:** Groq `gpt-oss-120b` fails structured output (`BamlValidationError`) on turn 2+ with larger context. Errors are caught per-iteration and tracked as events; synthesizer reads errors via `view.hasErrors()` (scoped by ViewConfig, so they expire naturally across turns).
+Local inference (`LocalGLM` — GLM 4.7 Flash on localhost:8080) is defined in `baml_src/local-client.baml` and available for manual wiring but not used in any fallback chain.
+
+Required env vars: `GROQ_API_KEY`, `OPENROUTER_API_KEY`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`.
+
+**Known limitation:** Groq `gpt-oss-120b` fails structured output (`BamlValidationError`) on turn 2+ with larger context. `baml-adapters.server.ts` catches this manually and retries with `GroqGPT120B` then `GroqFast`. Errors are tracked as events; synthesizer reads them via `view.hasErrors()` (scoped by ViewConfig, so they expire naturally across turns).
 
 ---
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -66,8 +66,10 @@ Scripts: `scripts/export-neo4j.sh` · `scripts/import-neo4j.sh` · `scripts/rese
 
 | Variable | Purpose |
 |----------|---------|
-| `GROQ_API_KEY` | Groq LLM inference |
-| `OPENAI_API_KEY` | OpenAI fallback |
+| `GROQ_API_KEY` | Groq LLM inference (GroqFast, GroqGPT120B, GroqQwen3_32b) |
+| `OPENROUTER_API_KEY` | OpenRouter models (Nemotron, Gemma4, MiniMax) |
+| `OPENAI_API_KEY` | OpenAI models (GPT-5, GPT-5 Mini, GPT-5 Nano) |
+| `ANTHROPIC_API_KEY` | Anthropic models (Opus 4, Sonnet 4, Haiku) |
 | `VITE_STACK_PROJECT_ID` | Stack Auth project |
 | `VITE_STACK_PUBLISHABLE_CLIENT_KEY` | Stack Auth client key |
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -52,5 +52,7 @@ Replaced the legacy `baml-agent` system. Functional, composable agent patterns b
 - Graph editing: property editing, relation creation, node creation
 - Deferred rendering via ResizeObserver; Conversation Sync toggle (⏸/▶)
 - SSE event streaming to browser (ObservabilityPanel live updates)
+- Inline error/warning notifications in chat — contextual error banners surfaced from harness events (PR #20, issue #13)
+- `contentTransforms` on EventView — read-time event lens (`stripThinkBlocks`, `truncateToolResults`) without mutating stored state (PR #20, issue #15)
 
 **Docs:** [UI_ARCHITECTURE.md](UI_ARCHITECTURE.md)

--- a/ui/ROADMAP.md
+++ b/ui/ROADMAP.md
@@ -107,7 +107,6 @@
 
 ### Known Bugs
 - Context window overflow: `.harness-logs/context-cl-2-2026-04-23-payload-error.json` — addressed by `max_tokens` on all BAML clients + `trimToFit()` rolling window; monitor for recurrence
-- Duplicate assistant message: chat interface returned the same assistant message twice (graph showed correctly, only redis nodes in Neo4j tab)
 
 ## Future features
 - Show "error, trying again" interesting run within knowledge graph: `.harness-logs/context-cl-3-2026-04-18-consider-error.json`.

--- a/ui/baml_src/clients.baml
+++ b/ui/baml_src/clients.baml
@@ -234,7 +234,7 @@ client<llm> SynthesizerFallback {
   provider fallback
   options {
     // 1. OpenRouterGemma4 — fast prose synthesis; 2. GroqQwen3_32b (Qwen3-32B); 3. OpenAIGPT5Mini
-    strategy [OpenRouterGemma4, GroqQwen3_32b, OpenAIGPT5Mini]
+    strategy [OpenRouterGemma4, GroqQwen3_32b, OpenAIGPT5]
   }
 }
 

--- a/ui/src/lib/harness-patterns/README.md
+++ b/ui/src/lib/harness-patterns/README.md
@@ -574,12 +574,13 @@ Controls what events a pattern can "see" via its EventView:
 
 ```typescript
 interface ViewConfig {
-  fromPatterns?: string[]   // Specific pattern IDs to read from
-  fromLastN?: number        // Last N patterns
-  fromLast?: boolean        // Only previous pattern (default: true)
-  eventTypes?: EventType[]  // Filter by event type
-  limit?: number            // Max events to include
-  fromLastNTurns?: number   // Rolling window: last N user turns
+  fromPatterns?: string[]            // Specific pattern IDs to read from
+  fromLastN?: number                 // Last N patterns
+  fromLast?: boolean                 // Only previous pattern (default: true)
+  eventTypes?: EventType[]           // Filter by event type
+  limit?: number                     // Max events to include
+  fromLastNTurns?: number            // Rolling window: last N user turns
+  contentTransforms?: ContentTransform[]  // Read-time transforms applied in get()/serialize()
 }
 ```
 
@@ -591,6 +592,11 @@ interface ViewConfig {
 | `fromLastNTurns: 5` | Rolling window over last 5 user turns | Multi-turn history |
 | `eventTypes: ['tool_result']` | Filter to specific event types | Focus on results |
 | `limit: 10` | Cap number of events returned | Limit context size |
+| `contentTransforms: [fn]` | Read-time event transformations (never mutates `ctx.events`) | Strip think blocks, truncate results |
+
+**ContentTransform** is `(event: ContextEvent) => ContextEvent`. Built-in transforms in `content-transforms.ts`:
+- `stripThinkBlocks` — removes `<think>...</think>` reasoning from assistant messages (router uses this by default)
+- `truncateToolResults(maxChars)` — factory that truncates long tool results to N chars
 
 A "turn" is defined by a `user_message` event. `fromLastNTurns` slices the event stream at the Nth-to-last `user_message` boundary. It is applied *before* type filters so that boundary detection works regardless of which `eventTypes` are selected.
 


### PR DESCRIPTION
docs: sync project markdown with current state + tweak SynthesizerFallback

- CLAUDE.md: BAML Clients table updated with full chains, env vars, and current manual fallback escalation behavior (no more LocalGLM references)
- docs/INDEX.md: add OPENROUTER_API_KEY and ANTHROPIC_API_KEY to env table
- docs/ROADMAP.md: record completed work — inline error notifications (#13) and contentTransforms on EventView (#15)
- ui/ROADMAP.md: remove duplicate-assistant-message bug (fixed in PR #20)
- harness-patterns/README.md: document contentTransforms in ViewConfig
- clients.baml: SynthesizerFallback last fallback OpenAIGPT5Mini → OpenAIGPT5