### PR TITLE
feat: live event streaming with per-pattern liveEvents + chain progress bar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ n8n_data/
 
 # Test coverage
 **/coverage/
+
+# Working memory — Claude session notes
+SCRATCHPAD.md

--- a/ui/baml_src/clients.baml
+++ b/ui/baml_src/clients.baml
@@ -72,6 +72,42 @@ client<llm> OpenRouterGemma4 {
   }
 }
 
+// Cerebras — wafer-scale inference, separate quota pool from Groq/OpenRouter.
+// OpenAI-compatible API. Used as the *final* safety net in fallback chains so
+// 429s on the primary cloud providers don't surface to the user.
+client<llm> CerebrasGPT120B {
+  provider openai-generic
+  retry_policy Exponential
+  options {
+    base_url "https://api.cerebras.ai/v1"
+    api_key env.CEREBRAS_API_KEY
+    model "gpt-oss-120b"
+    max_tokens 4096
+  }
+}
+
+client<llm> CerebrasZaiGLM4_7 {
+  provider openai-generic
+  retry_policy Exponential
+  options {
+    base_url "https://api.cerebras.ai/v1"
+    api_key env.CEREBRAS_API_KEY
+    model "zai-glm-4.7"
+    max_tokens 4096
+  }
+}
+
+client<llm> CerebrasQwen3_235B {
+  provider openai-generic
+  retry_policy Exponential
+  options {
+    base_url "https://api.cerebras.ai/v1"
+    api_key env.CEREBRAS_API_KEY
+    model "qwen-3-235b-a22b-instruct-2507"
+    max_tokens 4096
+  }
+}
+
 // Groq — Evaluation & critique (Qwen3 32B, 400 t/s, 32K ctx)
 client<llm> GroqQwen3_32b {
   provider openai-generic
@@ -204,45 +240,49 @@ client<llm> CustomFast {
   }
 }
 
-// Per-use-case fallback clients (Groq-only; LocalGLM available in local-client.baml)
+// Per-use-case fallback clients. Cerebras sits at the end of every chain as
+// a separate-quota safety net, so a 429 on Groq/OpenRouter/OpenAI no longer
+// surfaces to the user.
 client<llm> RouterFallback {
   provider fallback
   options {
-    // Classification only — fast 20B model sufficient, 120B as backstop
-    strategy [OpenRouterGemma4, GroqFast, GroqGPT120B]
+    // Classification only — fast 20B model sufficient, larger models as backstops
+    strategy [OpenRouterGemma4, GroqFast, GroqGPT120B, CerebrasGPT120B]
   }
 }
 
 client<llm> ControllerFallback {
   provider fallback
   options {
-    // 1. GroqGPT120B — gpt-oss-120b, fastest; 2. OpenRouterNemotron120B — when Groq fails structured output
-    // on large context; 3. OpenAIGPT5Chat — reliable OpenAI fallback
-    strategy [OpenRouterNemotron120B, OpenAIGPT5, OpenRouterMiniMax2_5, GroqGPT120B]
+    // Tool-loop reasoning + structured output. Cerebras GPT-OSS-120B mirrors
+    // Groq's model class with independent rate limits.
+    strategy [OpenRouterNemotron120B, OpenAIGPT5, OpenRouterMiniMax2_5, GroqGPT120B, CerebrasGPT120B]
   }
 }
 
 client<llm> CriticFallback {
   provider fallback
   options {
-    // Qwen3-32B purpose-built for evaluation; GroqGPT120B as backstop
-    strategy [GroqQwen3_32b, GroqGPT120B, OpenRouterMiniMax2_5]
+    // Qwen-family evaluators preferred; CerebrasQwen3_235B as final backstop.
+    strategy [GroqQwen3_32b, GroqGPT120B, OpenRouterMiniMax2_5, CerebrasQwen3_235B]
   }
 }
 
 client<llm> SynthesizerFallback {
   provider fallback
   options {
-    // 1. OpenRouterGemma4 — fast prose synthesis; 2. GroqQwen3_32b (Qwen3-32B); 3. OpenAIGPT5Mini
-    strategy [OpenRouterGemma4, GroqQwen3_32b, OpenAIGPT5]
+    // Prose synthesis. CerebrasZaiGLM4_7 (GLM-4.7) handles natural-language
+    // formatting well as the final safety net.
+    strategy [OpenRouterGemma4, GroqQwen3_32b, OpenAIGPT5, CerebrasZaiGLM4_7]
   }
 }
 
-// Lightweight summarization — fast 20B model is sufficient alone
+// Lightweight summarization — fast 20B model is sufficient alone.
+// CerebrasZaiGLM4_7 closes the chain as the cross-provider safety net.
 client<llm> DescribeFallback {
   provider fallback
   options {
-    strategy [GroqFast, OpenRouterGemma4, OpenAIGPT5Mini]
+    strategy [GroqFast, OpenRouterGemma4, OpenAIGPT5, CerebrasZaiGLM4_7]
   }
 }
 

--- a/ui/baml_src/clients.baml
+++ b/ui/baml_src/clients.baml
@@ -72,42 +72,6 @@ client<llm> OpenRouterGemma4 {
   }
 }
 
-// Cerebras — wafer-scale inference, separate quota pool from Groq/OpenRouter.
-// OpenAI-compatible API. Used as the *final* safety net in fallback chains so
-// 429s on the primary cloud providers don't surface to the user.
-client<llm> CerebrasGPT120B {
-  provider openai-generic
-  retry_policy Exponential
-  options {
-    base_url "https://api.cerebras.ai/v1"
-    api_key env.CEREBRAS_API_KEY
-    model "gpt-oss-120b"
-    max_tokens 4096
-  }
-}
-
-client<llm> CerebrasZaiGLM4_7 {
-  provider openai-generic
-  retry_policy Exponential
-  options {
-    base_url "https://api.cerebras.ai/v1"
-    api_key env.CEREBRAS_API_KEY
-    model "zai-glm-4.7"
-    max_tokens 4096
-  }
-}
-
-client<llm> CerebrasQwen3_235B {
-  provider openai-generic
-  retry_policy Exponential
-  options {
-    base_url "https://api.cerebras.ai/v1"
-    api_key env.CEREBRAS_API_KEY
-    model "qwen-3-235b-a22b-instruct-2507"
-    max_tokens 4096
-  }
-}
-
 // Groq — Evaluation & critique (Qwen3 32B, 400 t/s, 32K ctx)
 client<llm> GroqQwen3_32b {
   provider openai-generic
@@ -240,49 +204,45 @@ client<llm> CustomFast {
   }
 }
 
-// Per-use-case fallback clients. Cerebras sits at the end of every chain as
-// a separate-quota safety net, so a 429 on Groq/OpenRouter/OpenAI no longer
-// surfaces to the user.
+// Per-use-case fallback clients (Groq-only; LocalGLM available in local-client.baml)
 client<llm> RouterFallback {
   provider fallback
   options {
-    // Classification only — fast 20B model sufficient, larger models as backstops
-    strategy [OpenRouterGemma4, GroqFast, GroqGPT120B, CerebrasGPT120B]
+    // Classification only — fast 20B model sufficient, 120B as backstop
+    strategy [OpenRouterGemma4, GroqFast, GroqGPT120B]
   }
 }
 
 client<llm> ControllerFallback {
   provider fallback
   options {
-    // Tool-loop reasoning + structured output. Cerebras GPT-OSS-120B mirrors
-    // Groq's model class with independent rate limits.
-    strategy [OpenRouterNemotron120B, OpenAIGPT5, OpenRouterMiniMax2_5, GroqGPT120B, CerebrasGPT120B]
+    // 1. GroqGPT120B — gpt-oss-120b, fastest; 2. OpenRouterNemotron120B — when Groq fails structured output
+    // on large context; 3. OpenAIGPT5Chat — reliable OpenAI fallback
+    strategy [OpenRouterNemotron120B, OpenAIGPT5, OpenRouterMiniMax2_5, GroqGPT120B]
   }
 }
 
 client<llm> CriticFallback {
   provider fallback
   options {
-    // Qwen-family evaluators preferred; CerebrasQwen3_235B as final backstop.
-    strategy [GroqQwen3_32b, GroqGPT120B, OpenRouterMiniMax2_5, CerebrasQwen3_235B]
+    // Qwen3-32B purpose-built for evaluation; GroqGPT120B as backstop
+    strategy [GroqQwen3_32b, GroqGPT120B, OpenRouterMiniMax2_5]
   }
 }
 
 client<llm> SynthesizerFallback {
   provider fallback
   options {
-    // Prose synthesis. CerebrasZaiGLM4_7 (GLM-4.7) handles natural-language
-    // formatting well as the final safety net.
-    strategy [OpenRouterGemma4, GroqQwen3_32b, OpenAIGPT5, CerebrasZaiGLM4_7]
+    // 1. OpenRouterGemma4 — fast prose synthesis; 2. GroqQwen3_32b (Qwen3-32B); 3. OpenAIGPT5Mini
+    strategy [OpenRouterGemma4, GroqQwen3_32b, OpenAIGPT5]
   }
 }
 
-// Lightweight summarization — fast 20B model is sufficient alone.
-// CerebrasZaiGLM4_7 closes the chain as the cross-provider safety net.
+// Lightweight summarization — fast 20B model is sufficient alone
 client<llm> DescribeFallback {
   provider fallback
   options {
-    strategy [GroqFast, OpenRouterGemma4, OpenAIGPT5, CerebrasZaiGLM4_7]
+    strategy [GroqFast, OpenRouterGemma4, OpenAIGPT5]
   }
 }
 
@@ -308,7 +268,7 @@ retry_policy Exponential {
   max_retries 2
   strategy {
     type exponential_backoff
-    delay_ms 500
+    delay_ms 300
     multiplier 1.5
     max_delay_ms 10000
   }

--- a/ui/src/__tests__/components/ark-ui/useChainProgress.test.ts
+++ b/ui/src/__tests__/components/ark-ui/useChainProgress.test.ts
@@ -1,0 +1,140 @@
+/**
+ * useChainProgress tests
+ *
+ * Verifies the chain-progress derivation matches the user-facing spec for the
+ * default agent: router (1) + simpleLoop maxTurns=5 (5) + synth (1) = 7.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { createRoot } from 'solid-js'
+import { createChainProgress } from '../../../components/ark-ui/useChainProgress'
+import type { ContextEvent } from '~/lib/harness-patterns'
+
+const ev = (type: ContextEvent['type'], patternId: string, data: unknown = {}, id?: string): ContextEvent => ({
+  id: id ?? `ev-${Math.random().toString(36).slice(2, 7)}`,
+  type,
+  ts: Date.now(),
+  patternId,
+  data,
+})
+
+describe('createChainProgress', () => {
+  it('starts empty', () => {
+    createRoot(() => {
+      const p = createChainProgress()
+      expect(p.snapshot()).toEqual({ currentTurn: 0, totalTurns: 0, status: null, done: false })
+    })
+  })
+
+  it('default-agent stream → 7/7 with the expected status sequence', () => {
+    createRoot(() => {
+      const p = createChainProgress()
+
+      // 1) router
+      p.ingest(ev('pattern_enter', 'router', { pattern: 'router' }))
+      p.ingest(ev('assistant_message', 'router', { content: 'Routing to neo4j…' }))
+      // pattern_enter for router contributes 1; advance fires on assistant_message
+      expect(p.snapshot().totalTurns).toBe(1)
+      expect(p.snapshot().currentTurn).toBe(1)
+      expect(p.snapshot().status).toBe('Routing to neo4j…')
+      p.ingest(ev('pattern_exit', 'router'))
+
+      // 2) routes wraps neo4j-query — wrapper enter is discarded by the next enter
+      p.ingest(ev('pattern_enter', 'routes', { pattern: 'routes(neo4j|web|code)' }))
+      p.ingest(ev('pattern_enter', 'neo4j-query', { pattern: 'simpleLoop', maxTurns: 5 }))
+
+      // First controller_action: total flushes (+5 from simpleLoop only), current advances to 2
+      p.ingest(
+        ev('controller_action', 'neo4j-query', {
+          action: { reasoning: 'r', status: 'Querying schema', tool_name: 'get_neo4j_schema', tool_args: '{}', is_final: false }
+        })
+      )
+      expect(p.snapshot().totalTurns).toBe(6) // 1 (router) + 5 (simpleLoop). routes was discarded.
+      expect(p.snapshot().currentTurn).toBe(2)
+      expect(p.snapshot().status).toBe('Querying schema')
+
+      // Remaining 4 controller_actions
+      for (let i = 2; i <= 5; i++) {
+        p.ingest(
+          ev('controller_action', 'neo4j-query', {
+            action: { reasoning: 'r', status: `Step ${i}`, tool_name: 't', tool_args: '{}', is_final: i === 5 }
+          })
+        )
+      }
+      expect(p.snapshot().currentTurn).toBe(6)
+      expect(p.snapshot().status).toBe('Step 5')
+
+      p.ingest(ev('pattern_exit', 'neo4j-query'))
+      p.ingest(ev('pattern_exit', 'routes'))
+
+      // 3) synthesizer
+      p.ingest(ev('pattern_enter', 'response-synth', { pattern: 'synthesizer' }))
+      p.ingest(ev('assistant_message', 'response-synth', { content: 'Done — here is your answer.' }))
+      expect(p.snapshot().totalTurns).toBe(7)
+      expect(p.snapshot().currentTurn).toBe(7)
+      expect(p.snapshot().status).toBe('Done — here is your answer.')
+
+      p.ingest(ev('pattern_exit', 'response-synth'))
+      p.finish()
+      expect(p.snapshot().done).toBe(true)
+    })
+  })
+
+  it('discards a wrapper pattern_enter when followed by another pattern_enter', () => {
+    createRoot(() => {
+      const p = createChainProgress()
+      p.ingest(ev('pattern_enter', 'wrapper', { pattern: 'withApproval' }))
+      p.ingest(ev('pattern_enter', 'inner', { pattern: 'simpleLoop', maxTurns: 3 }))
+      p.ingest(ev('controller_action', 'inner', { action: { status: 's' } }))
+      // Only the inner pattern's 3 contributes — wrapper was discarded
+      expect(p.snapshot().totalTurns).toBe(3)
+      expect(p.snapshot().currentTurn).toBe(1)
+    })
+  })
+
+  it('counts a leaf pattern_enter even if it has no maxTurns (contributes 1)', () => {
+    createRoot(() => {
+      const p = createChainProgress()
+      p.ingest(ev('pattern_enter', 'leaf', { pattern: 'router' }))
+      p.ingest(ev('assistant_message', 'leaf', { content: 'hello' }))
+      expect(p.snapshot().totalTurns).toBe(1)
+      expect(p.snapshot().currentTurn).toBe(1)
+    })
+  })
+
+  it('truncates long status strings to a single line', () => {
+    createRoot(() => {
+      const p = createChainProgress()
+      p.ingest(ev('pattern_enter', 'leaf', { pattern: 'router' }))
+      p.ingest(
+        ev('assistant_message', 'leaf', {
+          content: 'first line that should be displayed\nsecond line that must be hidden'
+        })
+      )
+      expect(p.snapshot().status).toBe('first line that should be displayed')
+    })
+  })
+
+  it('does not double-advance when multiple assistant_messages share the same patternId', () => {
+    createRoot(() => {
+      const p = createChainProgress()
+      p.ingest(ev('pattern_enter', 'router', { pattern: 'router' }))
+      p.ingest(ev('assistant_message', 'router', { content: 'first' }))
+      p.ingest(ev('assistant_message', 'router', { content: 'second' }))
+      expect(p.snapshot().totalTurns).toBe(1)
+      expect(p.snapshot().currentTurn).toBe(1)
+      expect(p.snapshot().status).toBe('second')
+    })
+  })
+
+  it('reset clears all state', () => {
+    createRoot(() => {
+      const p = createChainProgress()
+      p.ingest(ev('pattern_enter', 'router', { pattern: 'router' }))
+      p.ingest(ev('assistant_message', 'router', { content: 'hi' }))
+      expect(p.snapshot().currentTurn).toBe(1)
+      p.reset()
+      expect(p.snapshot()).toEqual({ currentTurn: 0, totalTurns: 0, status: null, done: false })
+    })
+  })
+})

--- a/ui/src/__tests__/components/ark-ui/useChainProgress.test.ts
+++ b/ui/src/__tests__/components/ark-ui/useChainProgress.test.ts
@@ -127,6 +127,48 @@ describe('createChainProgress', () => {
     })
   })
 
+  it('upgrades a loop contribution via controller_action.maxTurns when pattern_enter lacked it', () => {
+    // Reflects the production case: simpleLoop reads its effective maxTurns
+    // from settings at runtime, so pattern_enter doesn't carry it. The first
+    // controller_action does — and that's what should set the denominator.
+    createRoot(() => {
+      const p = createChainProgress()
+
+      p.ingest(ev('pattern_enter', 'router', { pattern: 'router' }))
+      p.ingest(ev('assistant_message', 'router', { content: 'Routing…' }))
+      // 1/1 after router
+
+      p.ingest(ev('pattern_enter', 'routes', { pattern: 'routes(...)' }))
+      p.ingest(ev('pattern_enter', 'neo4j-query', { pattern: 'simpleLoop' })) // no maxTurns on enter
+
+      // First controller_action carries the runtime maxTurns
+      p.ingest(
+        ev('controller_action', 'neo4j-query', {
+          action: { status: 'Querying schema' },
+          turn: 0,
+          maxTurns: 5,
+        })
+      )
+
+      // Routes' contribution discarded; neo4j-query upgraded from 1 to 5.
+      // Total = 1 (router) + 5 (loop). Current = 2 (router + first action).
+      expect(p.snapshot().totalTurns).toBe(6)
+      expect(p.snapshot().currentTurn).toBe(2)
+      expect(p.snapshot().status).toBe('Querying schema')
+
+      // Subsequent controller_actions don't double-upgrade
+      p.ingest(
+        ev('controller_action', 'neo4j-query', {
+          action: { status: 'Step 2' },
+          turn: 1,
+          maxTurns: 5,
+        })
+      )
+      expect(p.snapshot().totalTurns).toBe(6)
+      expect(p.snapshot().currentTurn).toBe(3)
+    })
+  })
+
   it('reset clears all state', () => {
     createRoot(() => {
       const p = createChainProgress()

--- a/ui/src/__tests__/components/ark-ui/useChainProgress.test.ts
+++ b/ui/src/__tests__/components/ark-ui/useChainProgress.test.ts
@@ -1,8 +1,13 @@
 /**
- * useChainProgress tests
+ * useChainProgress tests — verifies the seeded-projection model.
  *
- * Verifies the chain-progress derivation matches the user-facing spec for the
- * default agent: router (1) + simpleLoop maxTurns=5 (5) + synth (1) = 7.
+ *  - `user_message.chainTurnEstimate` seeds maxProjection / pathProjection
+ *    once and never grows the seed.
+ *  - currentTurn advances on controller_action, assistant_message, and leaf
+ *    pattern_exit.
+ *  - finish() snaps currentTurn to maxProjection (smooth fill to 100%).
+ *  - Without a seed, the legacy pending+flush+wrapper-discard heuristic
+ *    grows pathProjection from arriving pattern_enter events.
  */
 
 import { describe, it, expect } from 'vitest'
@@ -22,45 +27,67 @@ describe('createChainProgress', () => {
   it('starts empty', () => {
     createRoot(() => {
       const p = createChainProgress()
-      expect(p.snapshot()).toEqual({ currentTurn: 0, totalTurns: 0, status: null, done: false })
+      expect(p.snapshot()).toEqual({
+        currentTurn: 0,
+        maxProjection: 0,
+        pathProjection: 0,
+        status: null,
+        done: false,
+      })
     })
   })
 
-  it('default-agent stream → 7/7 with the expected status sequence', () => {
+  it('seeds projections from user_message.chainTurnEstimate and never grows them', () => {
     createRoot(() => {
       const p = createChainProgress()
+      p.ingest(ev('user_message', 'harness', { content: 'hi', chainTurnEstimate: 7 }))
+      expect(p.snapshot().maxProjection).toBe(7)
+      expect(p.snapshot().pathProjection).toBe(7)
+
+      // Subsequent pattern_enters and content events do NOT inflate the seed
+      p.ingest(ev('pattern_enter', 'router', { pattern: 'router' }))
+      p.ingest(ev('assistant_message', 'router', { content: 'Routing…' }))
+      p.ingest(ev('pattern_enter', 'routes', { pattern: 'routes' }))
+      p.ingest(ev('pattern_enter', 'inner', { pattern: 'simpleLoop' }))
+      p.ingest(
+        ev('controller_action', 'inner', {
+          action: { status: 's' },
+          turn: 0,
+          maxTurns: 5,
+        })
+      )
+      expect(p.snapshot().maxProjection).toBe(7)
+      expect(p.snapshot().pathProjection).toBe(7)
+    })
+  })
+
+  it('default-agent stream: 1/7 → 7/7, current advances per event', () => {
+    createRoot(() => {
+      const p = createChainProgress()
+      p.ingest(ev('user_message', 'harness', { content: 'hi', chainTurnEstimate: 7 }))
 
       // 1) router
       p.ingest(ev('pattern_enter', 'router', { pattern: 'router' }))
       p.ingest(ev('assistant_message', 'router', { content: 'Routing to neo4j…' }))
-      // pattern_enter for router contributes 1; advance fires on assistant_message
-      expect(p.snapshot().totalTurns).toBe(1)
       expect(p.snapshot().currentTurn).toBe(1)
       expect(p.snapshot().status).toBe('Routing to neo4j…')
+
       p.ingest(ev('pattern_exit', 'router'))
 
-      // 2) routes wraps neo4j-query — wrapper enter is discarded by the next enter
-      p.ingest(ev('pattern_enter', 'routes', { pattern: 'routes(neo4j|web|code)' }))
-      p.ingest(ev('pattern_enter', 'neo4j-query', { pattern: 'simpleLoop', maxTurns: 5 }))
+      // 2) routes(neo4j-query, ...) — wrapper events still arrive but seeded mode ignores them
+      p.ingest(ev('pattern_enter', 'routes', { pattern: 'routes(...)' }))
+      p.ingest(ev('pattern_enter', 'neo4j-query', { pattern: 'simpleLoop' }))
 
-      // First controller_action: total flushes (+5 from simpleLoop only), current advances to 2
-      p.ingest(
-        ev('controller_action', 'neo4j-query', {
-          action: { reasoning: 'r', status: 'Querying schema', tool_name: 'get_neo4j_schema', tool_args: '{}', is_final: false }
-        })
-      )
-      expect(p.snapshot().totalTurns).toBe(6) // 1 (router) + 5 (simpleLoop). routes was discarded.
-      expect(p.snapshot().currentTurn).toBe(2)
-      expect(p.snapshot().status).toBe('Querying schema')
-
-      // Remaining 4 controller_actions
-      for (let i = 2; i <= 5; i++) {
+      for (let i = 0; i < 5; i++) {
         p.ingest(
           ev('controller_action', 'neo4j-query', {
-            action: { reasoning: 'r', status: `Step ${i}`, tool_name: 't', tool_args: '{}', is_final: i === 5 }
+            action: { status: `Step ${i + 1}` },
+            turn: i,
+            maxTurns: 5,
           })
         )
       }
+      // 1 (router) + 5 (loop) = 6
       expect(p.snapshot().currentTurn).toBe(6)
       expect(p.snapshot().status).toBe('Step 5')
 
@@ -69,114 +96,79 @@ describe('createChainProgress', () => {
 
       // 3) synthesizer
       p.ingest(ev('pattern_enter', 'response-synth', { pattern: 'synthesizer' }))
-      p.ingest(ev('assistant_message', 'response-synth', { content: 'Done — here is your answer.' }))
-      expect(p.snapshot().totalTurns).toBe(7)
+      p.ingest(ev('assistant_message', 'response-synth', { content: 'Done.' }))
       expect(p.snapshot().currentTurn).toBe(7)
-      expect(p.snapshot().status).toBe('Done — here is your answer.')
+      expect(p.snapshot().maxProjection).toBe(7)
+    })
+  })
 
-      p.ingest(ev('pattern_exit', 'response-synth'))
+  it('finish() snaps currentTurn up to maxProjection so the bar reaches 100%', () => {
+    createRoot(() => {
+      const p = createChainProgress()
+      p.ingest(ev('user_message', 'harness', { content: 'hi', chainTurnEstimate: 7 }))
+
+      // Short conversational chain — only router fires before completion
+      p.ingest(ev('pattern_enter', 'router', { pattern: 'router' }))
+      p.ingest(ev('assistant_message', 'router', { content: 'Hi there.' }))
+      expect(p.snapshot().currentTurn).toBe(1)
+
       p.finish()
       expect(p.snapshot().done).toBe(true)
+      expect(p.snapshot().currentTurn).toBe(7)
     })
   })
 
-  it('discards a wrapper pattern_enter when followed by another pattern_enter', () => {
+  it('does not double-advance on repeated assistant_messages from same pattern', () => {
     createRoot(() => {
       const p = createChainProgress()
-      p.ingest(ev('pattern_enter', 'wrapper', { pattern: 'withApproval' }))
-      p.ingest(ev('pattern_enter', 'inner', { pattern: 'simpleLoop', maxTurns: 3 }))
-      p.ingest(ev('controller_action', 'inner', { action: { status: 's' } }))
-      // Only the inner pattern's 3 contributes — wrapper was discarded
-      expect(p.snapshot().totalTurns).toBe(3)
-      expect(p.snapshot().currentTurn).toBe(1)
-    })
-  })
-
-  it('counts a leaf pattern_enter even if it has no maxTurns (contributes 1)', () => {
-    createRoot(() => {
-      const p = createChainProgress()
-      p.ingest(ev('pattern_enter', 'leaf', { pattern: 'router' }))
-      p.ingest(ev('assistant_message', 'leaf', { content: 'hello' }))
-      expect(p.snapshot().totalTurns).toBe(1)
-      expect(p.snapshot().currentTurn).toBe(1)
-    })
-  })
-
-  it('truncates long status strings to a single line', () => {
-    createRoot(() => {
-      const p = createChainProgress()
-      p.ingest(ev('pattern_enter', 'leaf', { pattern: 'router' }))
-      p.ingest(
-        ev('assistant_message', 'leaf', {
-          content: 'first line that should be displayed\nsecond line that must be hidden'
-        })
-      )
-      expect(p.snapshot().status).toBe('first line that should be displayed')
-    })
-  })
-
-  it('does not double-advance when multiple assistant_messages share the same patternId', () => {
-    createRoot(() => {
-      const p = createChainProgress()
+      p.ingest(ev('user_message', 'harness', { content: 'hi', chainTurnEstimate: 3 }))
       p.ingest(ev('pattern_enter', 'router', { pattern: 'router' }))
       p.ingest(ev('assistant_message', 'router', { content: 'first' }))
       p.ingest(ev('assistant_message', 'router', { content: 'second' }))
-      expect(p.snapshot().totalTurns).toBe(1)
       expect(p.snapshot().currentTurn).toBe(1)
       expect(p.snapshot().status).toBe('second')
-    })
-  })
-
-  it('upgrades a loop contribution via controller_action.maxTurns when pattern_enter lacked it', () => {
-    // Reflects the production case: simpleLoop reads its effective maxTurns
-    // from settings at runtime, so pattern_enter doesn't carry it. The first
-    // controller_action does — and that's what should set the denominator.
-    createRoot(() => {
-      const p = createChainProgress()
-
-      p.ingest(ev('pattern_enter', 'router', { pattern: 'router' }))
-      p.ingest(ev('assistant_message', 'router', { content: 'Routing…' }))
-      // 1/1 after router
-
-      p.ingest(ev('pattern_enter', 'routes', { pattern: 'routes(...)' }))
-      p.ingest(ev('pattern_enter', 'neo4j-query', { pattern: 'simpleLoop' })) // no maxTurns on enter
-
-      // First controller_action carries the runtime maxTurns
-      p.ingest(
-        ev('controller_action', 'neo4j-query', {
-          action: { status: 'Querying schema' },
-          turn: 0,
-          maxTurns: 5,
-        })
-      )
-
-      // Routes' contribution discarded; neo4j-query upgraded from 1 to 5.
-      // Total = 1 (router) + 5 (loop). Current = 2 (router + first action).
-      expect(p.snapshot().totalTurns).toBe(6)
-      expect(p.snapshot().currentTurn).toBe(2)
-      expect(p.snapshot().status).toBe('Querying schema')
-
-      // Subsequent controller_actions don't double-upgrade
-      p.ingest(
-        ev('controller_action', 'neo4j-query', {
-          action: { status: 'Step 2' },
-          turn: 1,
-          maxTurns: 5,
-        })
-      )
-      expect(p.snapshot().totalTurns).toBe(6)
-      expect(p.snapshot().currentTurn).toBe(3)
     })
   })
 
   it('reset clears all state', () => {
     createRoot(() => {
       const p = createChainProgress()
-      p.ingest(ev('pattern_enter', 'router', { pattern: 'router' }))
+      p.ingest(ev('user_message', 'harness', { content: 'hi', chainTurnEstimate: 5 }))
       p.ingest(ev('assistant_message', 'router', { content: 'hi' }))
       expect(p.snapshot().currentTurn).toBe(1)
       p.reset()
-      expect(p.snapshot()).toEqual({ currentTurn: 0, totalTurns: 0, status: null, done: false })
+      expect(p.snapshot()).toEqual({
+        currentTurn: 0,
+        maxProjection: 0,
+        pathProjection: 0,
+        status: null,
+        done: false,
+      })
+    })
+  })
+
+  describe('fallback (no seed)', () => {
+    it('grows pathProjection from pattern_enter events', () => {
+      createRoot(() => {
+        const p = createChainProgress()
+        // No user_message → no seed, fallback path is used
+        p.ingest(ev('pattern_enter', 'router', { pattern: 'router' }))
+        p.ingest(ev('assistant_message', 'router', { content: 'hi' }))
+        expect(p.snapshot().pathProjection).toBe(1)
+        expect(p.snapshot().currentTurn).toBe(1)
+      })
+    })
+
+    it('discards a wrapper pattern_enter immediately followed by a child enter', () => {
+      createRoot(() => {
+        const p = createChainProgress()
+        p.ingest(ev('pattern_enter', 'wrapper', { pattern: 'withApproval' }))
+        p.ingest(ev('pattern_enter', 'inner', { pattern: 'simpleLoop', maxTurns: 3 }))
+        p.ingest(ev('controller_action', 'inner', { action: { status: 's' }, turn: 0, maxTurns: 3 }))
+        // Wrapper discarded; only inner's 3 contributes
+        expect(p.snapshot().pathProjection).toBe(3)
+        expect(p.snapshot().currentTurn).toBe(1)
+      })
     })
   })
 })

--- a/ui/src/__tests__/lib/harness-patterns/estimateTurns.test.ts
+++ b/ui/src/__tests__/lib/harness-patterns/estimateTurns.test.ts
@@ -1,0 +1,115 @@
+/**
+ * estimateTurns — verifies each pattern factory's projection helper.
+ *
+ * Validates the primitive used by `harness()` to seed UI progress bars
+ * before any pattern runs. Wrappers must delegate; loops must read settings.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import type { ConfiguredPattern } from '../../../lib/harness-patterns/types'
+
+// Test-only relaxed cast — the wrappers accept patterns over different data
+// shapes (RouterData, SimpleLoopData, etc.); compatibility isn't what we're
+// testing here.
+type AnyPattern = ConfiguredPattern<Record<string, unknown>>
+const asAny = <T>(p: ConfiguredPattern<T>) => p as unknown as AnyPattern
+
+vi.mock('../../../lib/harness-patterns/assert.server', () => ({
+  assertServerOnImport: vi.fn(),
+}))
+
+// Stub out BAML-touching plumbing so these tests don't need the generated client.
+vi.mock('@boundaryml/baml', () => ({
+  Collector: class { constructor(_: unknown) {} },
+  BamlValidationError: class extends Error {},
+}))
+vi.mock('../../../baml_client', () => ({ b: {} }))
+vi.mock('../../../lib/harness-patterns/routing.server', () => ({
+  routeMessageOp: vi.fn(),
+}))
+
+const settings = { maxToolTurns: 5, maxRetries: 3 }
+
+describe('estimateTurns', () => {
+  it('simpleLoop: uses config.maxTurns when present, else settings.maxToolTurns', async () => {
+    const { simpleLoop } = await import('../../../lib/harness-patterns/patterns/simpleLoop.server')
+
+    const fromSettings = simpleLoop(vi.fn(), [], { patternId: 'a' })
+    expect(fromSettings.estimateTurns?.(settings)).toBe(5)
+
+    const fromConfig = simpleLoop(vi.fn(), [], { patternId: 'b', maxTurns: 8 })
+    expect(fromConfig.estimateTurns?.(settings)).toBe(8)
+  })
+
+  it('actorCritic: uses config.maxRetries when present, else settings.maxRetries', async () => {
+    const { actorCritic } = await import('../../../lib/harness-patterns/patterns/actorCritic.server')
+
+    const fromSettings = actorCritic(vi.fn(), vi.fn(), [], { patternId: 'a' })
+    expect(fromSettings.estimateTurns?.(settings)).toBe(3)
+
+    const fromConfig = actorCritic(vi.fn(), vi.fn(), [], { patternId: 'b', maxRetries: 7 })
+    expect(fromConfig.estimateTurns?.(settings)).toBe(7)
+  })
+
+  it('router and synthesizer contribute 1', async () => {
+    const { router } = await import('../../../lib/harness-patterns/patterns/router.server')
+    const { synthesizer } = await import('../../../lib/harness-patterns/patterns/synthesizer.server')
+
+    const r = router({ neo4j: 'db' })
+    const s = synthesizer({ mode: 'thread' })
+    expect(r.estimateTurns?.(settings)).toBe(1)
+    expect(s.estimateTurns?.(settings)).toBe(1)
+  })
+
+  it('routes: max over branches', async () => {
+    const { routes } = await import('../../../lib/harness-patterns/patterns/router.server')
+    const { simpleLoop } = await import('../../../lib/harness-patterns/patterns/simpleLoop.server')
+
+    const small = asAny(simpleLoop(vi.fn(), [], { patternId: 's', maxTurns: 2 }))
+    const big = asAny(simpleLoop(vi.fn(), [], { patternId: 'b', maxTurns: 9 }))
+    const dispatched = routes({ small, big })
+    expect(dispatched.estimateTurns?.(settings)).toBe(9)
+  })
+
+  it('parallel: max over branches (longest drives perceived duration)', async () => {
+    const { parallel } = await import('../../../lib/harness-patterns/patterns/parallel.server')
+    const { simpleLoop } = await import('../../../lib/harness-patterns/patterns/simpleLoop.server')
+
+    const a = asAny(simpleLoop(vi.fn(), [], { patternId: 'a', maxTurns: 4 }))
+    const b = asAny(simpleLoop(vi.fn(), [], { patternId: 'b', maxTurns: 6 }))
+    const par = parallel([a, b])
+    expect(par.estimateTurns?.(settings)).toBe(6)
+  })
+
+  it('withApproval: delegates to inner pattern', async () => {
+    const { withApproval } = await import('../../../lib/harness-patterns/patterns/withApproval.server')
+    const { simpleLoop } = await import('../../../lib/harness-patterns/patterns/simpleLoop.server')
+
+    const inner = asAny(simpleLoop(vi.fn(), [], { patternId: 'inner', maxTurns: 4 }))
+    const guarded = withApproval(inner, () => true)
+    expect(guarded.estimateTurns?.(settings)).toBe(4)
+  })
+
+  it('hook: 0 when background, delegates otherwise', async () => {
+    const { hook } = await import('../../../lib/harness-patterns/patterns/hook.server')
+    const { simpleLoop } = await import('../../../lib/harness-patterns/patterns/simpleLoop.server')
+
+    const inner = asAny(simpleLoop(vi.fn(), [], { patternId: 'inner', maxTurns: 4 }))
+    const bg = hook(inner, { trigger: 'session_close', background: true })
+    const sync = hook(inner, { trigger: 'session_close' })
+    expect(bg.estimateTurns?.(settings)).toBe(0)
+    expect(sync.estimateTurns?.(settings)).toBe(4)
+  })
+
+  it('chain: sums children', async () => {
+    const { chain } = await import('../../../lib/harness-patterns/patterns/chain.server')
+    const { router, routes } = await import('../../../lib/harness-patterns/patterns/router.server')
+    const { synthesizer } = await import('../../../lib/harness-patterns/patterns/synthesizer.server')
+    const { simpleLoop } = await import('../../../lib/harness-patterns/patterns/simpleLoop.server')
+
+    const loop = asAny(simpleLoop(vi.fn(), [], { patternId: 'loop', maxTurns: 5 }))
+    // Default agent shape: router(1) + routes-with-5-turn-loop(5) + synth(1) = 7
+    const agent = chain(asAny(router({ x: '' })), asAny(routes({ x: loop })), asAny(synthesizer({ mode: 'thread' })))
+    expect(agent.estimateTurns?.(settings)).toBe(7)
+  })
+})

--- a/ui/src/__tests__/lib/harness-patterns/live-events.test.ts
+++ b/ui/src/__tests__/lib/harness-patterns/live-events.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Live Event Streaming Tests
+ *
+ * Covers:
+ *  - emitLive() ALS gating (no listener → no-op; listener + disabled → no-op)
+ *  - trackEvent() forwards events when liveEvents is enabled for the current pattern
+ *  - runChain() dedup: events emitted live are not re-emitted at commit time
+ *  - harness() end-to-end: simpleLoop with liveEvents:true streams in-flight events
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('../../../lib/harness-patterns/assert.server', () => ({
+  assertServerOnImport: vi.fn()
+}))
+
+describe('live-event-context', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('emitLive is a no-op when no listener is installed', async () => {
+    const { emitLive } = await import('../../../lib/harness-patterns/live-event-context.server')
+    expect(emitLive({ id: 'ev-1', type: 'tool_call', ts: 0, patternId: 'p', data: {} })).toBe(false)
+  })
+
+  it('emitLive does not fire until setLivePatternEnabled(true) is called', async () => {
+    const { runWithLiveListener, emitLive } = await import(
+      '../../../lib/harness-patterns/live-event-context.server'
+    )
+    const listener = vi.fn()
+    await runWithLiveListener(listener, async () => {
+      emitLive({ id: 'ev-a', type: 'tool_call', ts: 0, patternId: 'p', data: {} })
+    })
+    expect(listener).not.toHaveBeenCalled()
+  })
+
+  it('emitLive fires when both the listener and the pattern toggle are active', async () => {
+    const { runWithLiveListener, setLivePatternEnabled, emitLive } = await import(
+      '../../../lib/harness-patterns/live-event-context.server'
+    )
+    const listener = vi.fn()
+    await runWithLiveListener(listener, async () => {
+      setLivePatternEnabled(true)
+      emitLive({ id: 'ev-x', type: 'controller_action', ts: 0, patternId: 'p', data: { status: 'thinking' } })
+    })
+    expect(listener).toHaveBeenCalledTimes(1)
+    expect(listener.mock.calls[0][0].id).toBe('ev-x')
+  })
+
+  it('wasEmittedLive remembers ids that were dispatched', async () => {
+    const { runWithLiveListener, setLivePatternEnabled, emitLive, wasEmittedLive } = await import(
+      '../../../lib/harness-patterns/live-event-context.server'
+    )
+    await runWithLiveListener(vi.fn(), async () => {
+      setLivePatternEnabled(true)
+      const ev = { id: 'ev-y', type: 'tool_call' as const, ts: 0, patternId: 'p', data: {} }
+      emitLive(ev)
+      expect(wasEmittedLive(ev)).toBe(true)
+      expect(wasEmittedLive({ id: 'ev-other', type: 'tool_call', ts: 0, patternId: 'p', data: {} })).toBe(false)
+    })
+  })
+})
+
+describe('trackEvent + liveEvents', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('forwards a tracked event to the live listener when enabled', async () => {
+    const { runWithLiveListener, setLivePatternEnabled } = await import(
+      '../../../lib/harness-patterns/live-event-context.server'
+    )
+    const { createScope, trackEvent } = await import(
+      '../../../lib/harness-patterns/context.server'
+    )
+
+    const listener = vi.fn()
+    await runWithLiveListener(listener, async () => {
+      setLivePatternEnabled(true)
+      const scope = createScope('p1', {})
+      trackEvent(scope, 'controller_action', { reasoning: 'r', status: 's' }, true)
+    })
+    expect(listener).toHaveBeenCalledTimes(1)
+    expect(listener.mock.calls[0][0].type).toBe('controller_action')
+  })
+
+  it('does not forward when liveEvents is off (default behavior)', async () => {
+    const { runWithLiveListener, setLivePatternEnabled } = await import(
+      '../../../lib/harness-patterns/live-event-context.server'
+    )
+    const { createScope, trackEvent } = await import(
+      '../../../lib/harness-patterns/context.server'
+    )
+
+    const listener = vi.fn()
+    await runWithLiveListener(listener, async () => {
+      setLivePatternEnabled(false)
+      const scope = createScope('p1', {})
+      trackEvent(scope, 'tool_call', { tool: 't', args: {} }, true)
+    })
+    expect(listener).not.toHaveBeenCalled()
+  })
+
+  it('respects the trackHistory filter — events not tracked are not emitted live', async () => {
+    const { runWithLiveListener, setLivePatternEnabled } = await import(
+      '../../../lib/harness-patterns/live-event-context.server'
+    )
+    const { createScope, trackEvent } = await import(
+      '../../../lib/harness-patterns/context.server'
+    )
+
+    const listener = vi.fn()
+    await runWithLiveListener(listener, async () => {
+      setLivePatternEnabled(true)
+      const scope = createScope('p1', {})
+      // trackHistory = false → not tracked → not emitted
+      trackEvent(scope, 'tool_call', { tool: 't', args: {} }, false)
+    })
+    expect(listener).not.toHaveBeenCalled()
+  })
+})
+
+describe('runChain dedup', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('skips events at commit time that were already emitted live', async () => {
+    const { runWithLiveListener } = await import(
+      '../../../lib/harness-patterns/live-event-context.server'
+    )
+    const { runChain } = await import('../../../lib/harness-patterns/patterns/chain.server')
+    const { createContext, trackEvent } = await import(
+      '../../../lib/harness-patterns/context.server'
+    )
+
+    const ctx = createContext('hi', {} as Record<string, unknown>)
+
+    // Pattern that tracks one tool_result event
+    const livePattern = {
+      name: 'live-loop',
+      fn: async (scope: import('../../../lib/harness-patterns/types').PatternScope<Record<string, unknown>>) => {
+        trackEvent(scope, 'tool_result', { tool: 'foo', result: 1, success: true }, true)
+        return scope
+      },
+      config: {
+        patternId: 'live-loop',
+        commitStrategy: 'always' as const,
+        trackHistory: true as const,
+        liveEvents: true
+      }
+    }
+
+    const listener = vi.fn()
+    await runWithLiveListener(listener, () => runChain(ctx, [livePattern], listener))
+
+    // Listener should have been invoked exactly once for the tool_result —
+    // not twice (live emission + commit-time emission would be a bug).
+    const toolResults = listener.mock.calls
+      .map((c) => c[0])
+      .filter((e) => e.type === 'tool_result')
+    expect(toolResults).toHaveLength(1)
+    expect(toolResults[0].data).toMatchObject({ tool: 'foo', success: true })
+  })
+
+  it('still emits at commit time when liveEvents is off (legacy behavior)', async () => {
+    const { runWithLiveListener } = await import(
+      '../../../lib/harness-patterns/live-event-context.server'
+    )
+    const { runChain } = await import('../../../lib/harness-patterns/patterns/chain.server')
+    const { createContext, trackEvent } = await import(
+      '../../../lib/harness-patterns/context.server'
+    )
+
+    const ctx = createContext('hi', {} as Record<string, unknown>)
+
+    const bufferedPattern = {
+      name: 'buffered',
+      fn: async (scope: import('../../../lib/harness-patterns/types').PatternScope<Record<string, unknown>>) => {
+        trackEvent(scope, 'tool_result', { tool: 'bar', result: 2, success: true }, true)
+        return scope
+      },
+      config: {
+        patternId: 'buffered',
+        commitStrategy: 'always' as const,
+        trackHistory: true as const
+        // liveEvents not set → defaults to commit-time emission
+      }
+    }
+
+    const listener = vi.fn()
+    await runWithLiveListener(listener, () => runChain(ctx, [bufferedPattern], listener))
+
+    const toolResults = listener.mock.calls
+      .map((c) => c[0])
+      .filter((e) => e.type === 'tool_result')
+    expect(toolResults).toHaveLength(1)
+    expect(toolResults[0].data).toMatchObject({ tool: 'bar' })
+  })
+
+  it('streams pattern_enter and pattern_exit live when enabled', async () => {
+    const { runWithLiveListener } = await import(
+      '../../../lib/harness-patterns/live-event-context.server'
+    )
+    const { runChain } = await import('../../../lib/harness-patterns/patterns/chain.server')
+    const { createContext } = await import('../../../lib/harness-patterns/context.server')
+
+    const ctx = createContext('hi', {} as Record<string, unknown>)
+
+    const livePattern = {
+      name: 'lifecycle',
+      fn: async (scope: import('../../../lib/harness-patterns/types').PatternScope<Record<string, unknown>>) => scope,
+      config: {
+        patternId: 'lifecycle',
+        commitStrategy: 'always' as const,
+        trackHistory: true as const,
+        liveEvents: true
+      }
+    }
+
+    const seen: string[] = []
+    await runWithLiveListener(
+      (e) => seen.push(e.type),
+      () => runChain(ctx, [livePattern])
+    )
+
+    expect(seen).toContain('pattern_enter')
+    expect(seen).toContain('pattern_exit')
+  })
+
+  it('emits in-flight events before the pattern finishes', async () => {
+    const { runWithLiveListener } = await import(
+      '../../../lib/harness-patterns/live-event-context.server'
+    )
+    const { runChain } = await import('../../../lib/harness-patterns/patterns/chain.server')
+    const { createContext, trackEvent } = await import(
+      '../../../lib/harness-patterns/context.server'
+    )
+
+    const ctx = createContext('hi', {} as Record<string, unknown>)
+
+    let seenBeforeReturn = 0
+    const observer = vi.fn(() => {
+      seenBeforeReturn++
+    })
+
+    const slowPattern = {
+      name: 'slow',
+      fn: async (scope: import('../../../lib/harness-patterns/types').PatternScope<Record<string, unknown>>) => {
+        // Three "in-flight" status events; the listener should see them
+        // as we go, not all at the end.
+        trackEvent(scope, 'controller_action', { reasoning: '', status: 'step 1', tool_name: '', tool_args: '', is_final: false }, true)
+        await Promise.resolve()
+        trackEvent(scope, 'controller_action', { reasoning: '', status: 'step 2', tool_name: '', tool_args: '', is_final: false }, true)
+        await Promise.resolve()
+        trackEvent(scope, 'controller_action', { reasoning: '', status: 'step 3', tool_name: '', tool_args: '', is_final: true }, true)
+        // By the time we return, all 3 status events should already have fired
+        expect(seenBeforeReturn).toBe(3)
+        return scope
+      },
+      config: {
+        patternId: 'slow',
+        commitStrategy: 'always' as const,
+        trackHistory: true as const,
+        liveEvents: true
+      }
+    }
+
+    await runWithLiveListener(observer, () => runChain(ctx, [slowPattern]))
+    expect(observer).toHaveBeenCalled()
+  })
+})

--- a/ui/src/__tests__/lib/harness-patterns/live-events.test.ts
+++ b/ui/src/__tests__/lib/harness-patterns/live-events.test.ts
@@ -225,6 +225,54 @@ describe('runChain dedup', () => {
     expect(seen).toContain('pattern_exit')
   })
 
+  it('routes emits child pattern_enter/exit live when liveEvents is on', async () => {
+    const { runWithLiveListener } = await import(
+      '../../../lib/harness-patterns/live-event-context.server'
+    )
+    const { runChain } = await import('../../../lib/harness-patterns/patterns/chain.server')
+    const { routes } = await import('../../../lib/harness-patterns/patterns/router.server')
+    const { createContext, trackEvent } = await import(
+      '../../../lib/harness-patterns/context.server'
+    )
+
+    // Inner pattern has maxTurns set so its pattern_enter carries a payload
+    const inner = {
+      name: 'inner-loop',
+      fn: async (scope: import('../../../lib/harness-patterns/types').PatternScope<Record<string, unknown>>) => {
+        trackEvent(scope, 'tool_result', { tool: 'x', result: 1, success: true }, true)
+        return scope
+      },
+      config: {
+        patternId: 'inner-loop',
+        commitStrategy: 'always' as const,
+        trackHistory: true as const,
+        maxTurns: 5
+      }
+    }
+
+    const routesPattern = routes({ inner }, { liveEvents: true })
+
+    const ctx = createContext('hi', { route: 'inner' } as Record<string, unknown>)
+
+    const events: import('../../../lib/harness-patterns/types').ContextEvent[] = []
+    await runWithLiveListener(
+      (e) => events.push(e),
+      () => runChain(ctx, [routesPattern])
+    )
+
+    // Find the live-emitted child pattern_enter — it must carry maxTurns
+    const childEnter = events.find(
+      (e) => e.type === 'pattern_enter' && (e.data as { pattern?: string }).pattern === 'inner-loop'
+    )
+    expect(childEnter).toBeDefined()
+    expect((childEnter!.data as { maxTurns?: number }).maxTurns).toBe(5)
+
+    const childExit = events.find(
+      (e) => e.type === 'pattern_exit' && e.patternId === 'inner-loop'
+    )
+    expect(childExit).toBeDefined()
+  })
+
   it('emits in-flight events before the pattern finishes', async () => {
     const { runWithLiveListener } = await import(
       '../../../lib/harness-patterns/live-event-context.server'

--- a/ui/src/components/ark-ui/ChatInterface.tsx
+++ b/ui/src/components/ark-ui/ChatInterface.tsx
@@ -389,11 +389,12 @@ export const ChatInterface = (props: ChatInterfaceProps) => {
             <LiveProgressBar
               status={progress.snapshot().status}
               current={progress.snapshot().currentTurn}
-              total={progress.snapshot().totalTurns}
+              pathProjection={progress.snapshot().pathProjection}
+              maxProjection={progress.snapshot().maxProjection}
               visible={
                 isProcessing() &&
                 !progress.snapshot().done &&
-                progress.snapshot().totalTurns > 0
+                progress.snapshot().maxProjection > 0
               }
             />
           )}

--- a/ui/src/components/ark-ui/ChatInterface.tsx
+++ b/ui/src/components/ark-ui/ChatInterface.tsx
@@ -21,6 +21,7 @@ import { ChatInput } from './ChatInput'
 import { ChatSidebar } from './ChatSidebar'
 import { AgentSelector } from './AgentSelector'
 import { LiveProgressBar } from './LiveProgressBar'
+import { createChainProgress } from './useChainProgress'
 import { approveAction, rejectAction, clearSession, extractGraphFromResult, extractGraphElements } from '~/lib/harness-client'
 import { getSettings } from '~/lib/settings-store'
 import type { GraphElement } from './SupportPanel'
@@ -52,16 +53,10 @@ export const ChatInterface = (props: ChatInterfaceProps) => {
   const [isProcessing, setIsProcessing] = createSignal(false)
   const [sidebarCollapsed, setSidebarCollapsed] = createSignal(false)
   const [selectedAgent, setSelectedAgent] = createSignal('default')
-  const [currentStatus, setCurrentStatus] = createSignal<string | null>(null)
-  const [progressMaxTurns, setProgressMaxTurns] = createSignal<number>(5)
-  const [progressTurn, setProgressTurn] = createSignal<number>(0)
+  const progress = createChainProgress()
   // Cursor into ctx.events — tracks how many events were sent last turn so we
   // emit only the delta (new events) rather than the full accumulated history
   let prevEventCount = 0
-
-  const resetProgress = () => {
-    setProgressTurn(0)
-  }
 
   onCleanup(() => {
     // Clean up session when component unmounts
@@ -105,6 +100,7 @@ export const ChatInterface = (props: ChatInterfaceProps) => {
     }
     setMessages([...messages(), userMessage])
     setIsProcessing(true)
+    progress.reset()
 
     try {
       // Stream events via SSE endpoint for real-time updates
@@ -178,25 +174,9 @@ export const ChatInterface = (props: ChatInterfaceProps) => {
                 }
               }
 
-              // Reset progress bar at the start of each pattern; pick up
-              // maxTurns when surfaced (simpleLoop / actorCritic patterns).
-              if (evt.type === 'pattern_enter') {
-                const meta = evt.data as { maxTurns?: number }
-                if (typeof meta.maxTurns === 'number' && meta.maxTurns > 0) {
-                  setProgressMaxTurns(meta.maxTurns)
-                }
-                resetProgress()
-              }
-
-              // Each controller_action advances the bar by one turn and
-              // surfaces its status string for the live indicator.
-              if (evt.type === 'controller_action') {
-                const actionData = evt.data as { action?: { status?: string } }
-                if (actionData.action?.status) {
-                  setCurrentStatus(actionData.action.status)
-                }
-                setProgressTurn((n) => Math.min(n + 1, progressMaxTurns()))
-              }
+              // Feed every event into the chain-progress hook — it derives
+              // running current/total/status across the whole chain.
+              progress.ingest(evt)
 
               // Convert error events to inline chat messages
               if (evt.type === 'error') {
@@ -225,9 +205,8 @@ export const ChatInterface = (props: ChatInterfaceProps) => {
         }
       }
 
-      // Clear transient status
-      setCurrentStatus(null)
-      resetProgress()
+      // Mark progress complete — bar fills, fades, and unmounts.
+      progress.finish()
 
       // Update event count cursor and emit final context
       if (finalResult?.context) {
@@ -265,7 +244,7 @@ export const ChatInterface = (props: ChatInterfaceProps) => {
         content: error instanceof Error ? error.message : 'Unknown error',
         timestamp: new Date()
       }
-      setCurrentStatus(null)
+      progress.finish()
       setMessages([...messages(), errorMessage])
     } finally {
       setIsProcessing(false)
@@ -406,12 +385,18 @@ export const ChatInterface = (props: ChatInterfaceProps) => {
           onHighlightEntities={props.onHighlightEntities}
         />
 
-        {/* Live progress: status text crossfades, bar fills 1/maxTurns per turn,
-            then animates out before the assistant message lands. */}
+        {/* Live progress: status text crossfades, bar fills cumulatively across
+            the chain (router + loop turns + synthesizer), then animates out
+            before the assistant message lands. */}
         <LiveProgressBar
-          status={currentStatus()}
-          progress={progressTurn() / progressMaxTurns()}
-          visible={isProcessing() && currentStatus() !== null}
+          status={progress.snapshot().status}
+          current={progress.snapshot().currentTurn}
+          total={progress.snapshot().totalTurns}
+          visible={
+            isProcessing() &&
+            !progress.snapshot().done &&
+            progress.snapshot().totalTurns > 0
+          }
         />
 
         {/* Input */}

--- a/ui/src/components/ark-ui/ChatInterface.tsx
+++ b/ui/src/components/ark-ui/ChatInterface.tsx
@@ -376,27 +376,27 @@ export const ChatInterface = (props: ChatInterfaceProps) => {
           </div>
         </div>
 
-        {/* Messages */}
+        {/* Messages — the live progress bar rides as a trailing slot so it
+            appears where the next assistant bubble will land, then animates
+            out as that bubble takes its place. */}
         <ChatMessages
           messages={messages()}
           onApproveWrite={handleApproveWrite}
           onRejectWrite={handleRejectWrite}
           graphEntityNames={props.graphEntityNames}
           onHighlightEntities={props.onHighlightEntities}
-        />
-
-        {/* Live progress: status text crossfades, bar fills cumulatively across
-            the chain (router + loop turns + synthesizer), then animates out
-            before the assistant message lands. */}
-        <LiveProgressBar
-          status={progress.snapshot().status}
-          current={progress.snapshot().currentTurn}
-          total={progress.snapshot().totalTurns}
-          visible={
-            isProcessing() &&
-            !progress.snapshot().done &&
-            progress.snapshot().totalTurns > 0
-          }
+          trailing={() => (
+            <LiveProgressBar
+              status={progress.snapshot().status}
+              current={progress.snapshot().currentTurn}
+              total={progress.snapshot().totalTurns}
+              visible={
+                isProcessing() &&
+                !progress.snapshot().done &&
+                progress.snapshot().totalTurns > 0
+              }
+            />
+          )}
         />
 
         {/* Input */}

--- a/ui/src/components/ark-ui/ChatInterface.tsx
+++ b/ui/src/components/ark-ui/ChatInterface.tsx
@@ -15,11 +15,12 @@
  * - Session ID per component instance
  */
 
-import { createSignal, Show, onMount, onCleanup } from 'solid-js'
+import { createSignal, onMount, onCleanup } from 'solid-js'
 import { ChatMessages, type Message } from './ChatMessages'
 import { ChatInput } from './ChatInput'
 import { ChatSidebar } from './ChatSidebar'
 import { AgentSelector } from './AgentSelector'
+import { LiveProgressBar } from './LiveProgressBar'
 import { approveAction, rejectAction, clearSession, extractGraphFromResult, extractGraphElements } from '~/lib/harness-client'
 import { getSettings } from '~/lib/settings-store'
 import type { GraphElement } from './SupportPanel'
@@ -52,9 +53,15 @@ export const ChatInterface = (props: ChatInterfaceProps) => {
   const [sidebarCollapsed, setSidebarCollapsed] = createSignal(false)
   const [selectedAgent, setSelectedAgent] = createSignal('default')
   const [currentStatus, setCurrentStatus] = createSignal<string | null>(null)
+  const [progressMaxTurns, setProgressMaxTurns] = createSignal<number>(5)
+  const [progressTurn, setProgressTurn] = createSignal<number>(0)
   // Cursor into ctx.events — tracks how many events were sent last turn so we
   // emit only the delta (new events) rather than the full accumulated history
   let prevEventCount = 0
+
+  const resetProgress = () => {
+    setProgressTurn(0)
+  }
 
   onCleanup(() => {
     // Clean up session when component unmounts
@@ -171,12 +178,24 @@ export const ChatInterface = (props: ChatInterfaceProps) => {
                 }
               }
 
-              // Extract status from controller_action events for transient display
+              // Reset progress bar at the start of each pattern; pick up
+              // maxTurns when surfaced (simpleLoop / actorCritic patterns).
+              if (evt.type === 'pattern_enter') {
+                const meta = evt.data as { maxTurns?: number }
+                if (typeof meta.maxTurns === 'number' && meta.maxTurns > 0) {
+                  setProgressMaxTurns(meta.maxTurns)
+                }
+                resetProgress()
+              }
+
+              // Each controller_action advances the bar by one turn and
+              // surfaces its status string for the live indicator.
               if (evt.type === 'controller_action') {
                 const actionData = evt.data as { action?: { status?: string } }
                 if (actionData.action?.status) {
                   setCurrentStatus(actionData.action.status)
                 }
+                setProgressTurn((n) => Math.min(n + 1, progressMaxTurns()))
               }
 
               // Convert error events to inline chat messages
@@ -208,6 +227,7 @@ export const ChatInterface = (props: ChatInterfaceProps) => {
 
       // Clear transient status
       setCurrentStatus(null)
+      resetProgress()
 
       // Update event count cursor and emit final context
       if (finalResult?.context) {
@@ -386,26 +406,13 @@ export const ChatInterface = (props: ChatInterfaceProps) => {
           onHighlightEntities={props.onHighlightEntities}
         />
 
-        {/* Transient status indicator (from ControllerAction.status) */}
-        <Show when={currentStatus()}>
-          <div
-            flex="~ items-center gap-2"
-            px="4"
-            py="1.5"
-            text="xs dark-text-secondary"
-            bg="dark-bg-tertiary/50"
-            border="t dark-border-primary"
-          >
-            <div
-              w="1.5"
-              h="1.5"
-              rounded="full"
-              bg="neon-cyan"
-              class="animate-pulse"
-            />
-            {currentStatus()}
-          </div>
-        </Show>
+        {/* Live progress: status text crossfades, bar fills 1/maxTurns per turn,
+            then animates out before the assistant message lands. */}
+        <LiveProgressBar
+          status={currentStatus()}
+          progress={progressTurn() / progressMaxTurns()}
+          visible={isProcessing() && currentStatus() !== null}
+        />
 
         {/* Input */}
         <div border="t dark-border-primary" p="4" bg="dark-bg-secondary/80" backdrop-blur="sm">

--- a/ui/src/components/ark-ui/ChatMessages.tsx
+++ b/ui/src/components/ark-ui/ChatMessages.tsx
@@ -1,7 +1,7 @@
 
 import { Collapsible } from '@ark-ui/solid/collapsible'
 import { ScrollArea } from '@ark-ui/solid/scroll-area'
-import { For, Show, Switch, Match, createEffect, createSignal } from 'solid-js'
+import { For, Show, Switch, Match, createEffect, createSignal, type JSX } from 'solid-js'
 import type { ElementDefinition } from 'cytoscape'
 import type { ToolCallInfo } from './types'
 import { ToolCallDisplay } from './ToolCallDisplay'
@@ -36,6 +36,10 @@ interface ChatMessagesProps {
   graphEntityNames?: Map<string, string[]>
   /** Callback to highlight graph element IDs (hover/click) */
   onHighlightEntities?: (ids: string[]) => void
+  /** Optional slot rendered after the last message, inside the scroll area —
+   *  used by ChatInterface to inline the live progress bar where the next
+   *  assistant bubble would appear. */
+  trailing?: () => JSX.Element
 }
 
 // ============================================================================
@@ -386,6 +390,12 @@ export const ChatMessages = (props: ChatMessagesProps) => {
                 </div>
               </div>
             </div>
+          </Show>
+
+          {/* Trailing slot — e.g. the live progress bar, rendered where the
+              next assistant bubble would appear. */}
+          <Show when={props.trailing}>
+            {(slot) => slot()()}
           </Show>
 
           {/* Sentinel element for auto-scroll */}

--- a/ui/src/components/ark-ui/LiveProgressBar.tsx
+++ b/ui/src/components/ark-ui/LiveProgressBar.tsx
@@ -1,36 +1,49 @@
 /**
  * LiveProgressBar
  *
- * Inline status bar surfaced while a harness chain is in flight.
+ * Inline status bar surfaced while a harness chain is in flight. Lives as a
+ * trailing slot in `ChatMessages` so it appears where the next assistant
+ * bubble will land.
  *
- * Layout (top → bottom):
- *   [pulse dot]  status text          current/total
- *   [───────────────────────────────────────────────] linear progress
+ * Layout:
+ *   [pulse dot]  <status text crossfade>
+ *   [─────────────────────────────────] linear progress (no fraction text)
  *
- * The status string crossfades when it changes; `current/total` updates via
- * the `Progress.ValueText` slot. When `visible` flips false the bar fills to
- * 100%, fades out, and unmounts so the assistant message can take its place.
+ * Bar resolution
+ * --------------
+ * `max` is fixed for the chain (worst-case projection from the harness).
+ * `value` is `currentTurn` mapped through `(currentTurn * max / pathProjection)`
+ * so the fill rate adapts to the chosen route while the denominator stays
+ * stable — supplied by the consumer.
  *
- * Built from Ark UI's `Progress` primitives (Root/Track/Range/Label/ValueText)
- * with UnoCSS attributify for layout. Runtime visual state (gradient fill,
- * crossfade, exit) lives in inline styles because UnoCSS attributify doesn't
- * support per-frame transitions.
+ * Visibility
+ * ----------
+ * A short mount delay (`MOUNT_DELAY_MS`) means direct router responses
+ * (typically <1s) finish before the bar would have appeared, so the bar
+ * never enters for conversational replies.
  */
 import { Show, createSignal, createMemo, createEffect, on, onCleanup } from 'solid-js'
 import { Progress } from '@ark-ui/solid/progress'
 
 export interface LiveProgressBarProps {
   status: string | null
-  /** Cumulative turn position (1-based when active, 0 before first event). */
+  /** Cumulative steps completed (1-based when active, 0 before first event). */
   current: number
-  /** Best-effort chain total. May grow as pattern_enter events arrive. */
-  total: number
-  /** Whether the bar should be shown. Flipping to false plays the exit animation. */
+  /** Refined projection of the chosen path. May shrink as routes resolve. */
+  pathProjection: number
+  /** Stable bar-resolution: maximum across all branches. */
+  maxProjection: number
+  /** Whether the bar should be shown. Flipping to true after MOUNT_DELAY_MS
+   *  schedules the entry animation; flipping to false plays the exit. */
   visible: boolean
 }
 
 const STATUS_FADE_MS = 220
 const EXIT_FADE_MS = 360
+const FILL_TRANSITION_MS = 420
+/** Don't show the bar until the chain has been running this long — direct
+ *  router responses complete in <1s and don't deserve a flash of progress UI. */
+const MOUNT_DELAY_MS = 350
 
 export const LiveProgressBar = (props: LiveProgressBarProps) => {
   const [shownStatus, setShownStatus] = createSignal<string | null>(null)
@@ -39,10 +52,12 @@ export const LiveProgressBar = (props: LiveProgressBarProps) => {
   const [entering, setEntering] = createSignal(false)
 
   let exitTimer: number | undefined
+  let mountTimer: number | undefined
   let statusTimer: number | undefined
 
   onCleanup(() => {
     if (exitTimer !== undefined) clearTimeout(exitTimer)
+    if (mountTimer !== undefined) clearTimeout(mountTimer)
     if (statusTimer !== undefined) clearTimeout(statusTimer)
   })
 
@@ -63,19 +78,30 @@ export const LiveProgressBar = (props: LiveProgressBarProps) => {
     )
   )
 
-  // Mount/unmount with a delayed unmount so the CSS exit animation completes.
+  // Mount/unmount with delays:
+  //  - On `visible: true`, wait MOUNT_DELAY_MS before mounting (skips short
+  //    direct-response chains entirely).
+  //  - On `visible: false`, run the exit transition then unmount.
   createEffect(
     on(
       () => props.visible,
       (next) => {
+        if (mountTimer !== undefined) {
+          clearTimeout(mountTimer)
+          mountTimer = undefined
+        }
         if (exitTimer !== undefined) {
           clearTimeout(exitTimer)
           exitTimer = undefined
         }
         if (next) {
-          setMounted(true)
-          requestAnimationFrame(() => setEntering(true))
+          mountTimer = window.setTimeout(() => {
+            mountTimer = undefined
+            setMounted(true)
+            requestAnimationFrame(() => setEntering(true))
+          }, MOUNT_DELAY_MS)
         } else {
+          if (!mounted()) return
           setEntering(false)
           exitTimer = window.setTimeout(() => {
             setMounted(false)
@@ -86,18 +112,19 @@ export const LiveProgressBar = (props: LiveProgressBarProps) => {
     )
   )
 
-  const total = createMemo(() => Math.max(1, props.total))
+  const max = createMemo(() => Math.max(1, props.maxProjection))
   const value = createMemo(() => {
-    if (!props.visible) return total()
-    return Math.max(0, Math.min(props.current, total()))
+    if (!props.visible) return max()
+    const path = Math.max(1, props.pathProjection || max())
+    const scaled = (props.current * max()) / path
+    return Math.max(0, Math.min(max(), Math.round(scaled)))
   })
-  const percent = createMemo(() => Math.round((value() / total()) * 100))
-  const valueText = createMemo(() => `${value()}/${total()}`)
+  const percent = createMemo(() =>
+    Math.max(0, Math.min(100, (value() / max()) * 100))
+  )
 
   return (
     <Show when={mounted()}>
-      {/* In-progress placeholder — mirrors the assistant message layout
-          (avatar + bubble) so it looks like the next reply landing in. */}
       <div
         flex="~"
         gap="3"
@@ -106,10 +133,10 @@ export const LiveProgressBar = (props: LiveProgressBarProps) => {
         style={{
           opacity: entering() ? 1 : 0,
           transform: entering() ? 'translateY(0)' : 'translateY(4px)',
-          transition: `opacity ${EXIT_FADE_MS}ms ease, transform ${EXIT_FADE_MS}ms ease`,
+          transition: `opacity ${EXIT_FADE_MS}ms cubic-bezier(0.22, 1, 0.36, 1), transform ${EXIT_FADE_MS}ms cubic-bezier(0.22, 1, 0.36, 1)`,
         }}
       >
-        {/* Avatar — matches ChatMessages assistant avatar styling */}
+        {/* Avatar — matches assistant message layout */}
         <div
           flex="~ shrink-0"
           w="8"
@@ -126,8 +153,8 @@ export const LiveProgressBar = (props: LiveProgressBarProps) => {
         </div>
 
         <div flex="~ col 1" style={{ 'min-width': 0 }}>
-          <Progress.Root value={value()} min={0} max={total()} flex="~ col gap-1.5">
-            {/* Header row: pulse + status + counter */}
+          <Progress.Root value={value()} min={0} max={max()} flex="~ col gap-1.5">
+            {/* Status row: pulse + crossfading status text */}
             <div flex="~ items-center gap-2" h="4" style={{ position: 'relative' }}>
               <div
                 w="1.5"
@@ -137,8 +164,6 @@ export const LiveProgressBar = (props: LiveProgressBarProps) => {
                 class="animate-pulse"
                 style={{ 'flex-shrink': 0 }}
               />
-
-              {/* Status slot — two children overlap during crossfade */}
               <div flex="~ 1" style={{ position: 'relative', 'min-width': 0 }}>
                 <Show when={previousStatus()}>
                   <Progress.Label
@@ -167,16 +192,9 @@ export const LiveProgressBar = (props: LiveProgressBarProps) => {
                   {shownStatus() ?? '\u00a0'}
                 </Progress.Label>
               </div>
-
-              <Progress.ValueText
-                text="xs dark-text-tertiary tabular-nums"
-                style={{ 'flex-shrink': 0, 'font-variant-numeric': 'tabular-nums' }}
-              >
-                {valueText()}
-              </Progress.ValueText>
             </div>
 
-            {/* Linear bar */}
+            {/* Linear bar — no fraction text shown alongside */}
             <Progress.Track
               style={{
                 height: '3px',
@@ -192,7 +210,7 @@ export const LiveProgressBar = (props: LiveProgressBarProps) => {
                   'background-image':
                     'linear-gradient(90deg, rgba(0,255,255,0.85), rgba(157,0,255,0.85))',
                   'box-shadow': '0 0 8px rgba(0,255,255,0.45)',
-                  transition: 'width 240ms cubic-bezier(0.4, 0, 0.2, 1)',
+                  transition: `width ${FILL_TRANSITION_MS}ms cubic-bezier(0.22, 1, 0.36, 1)`,
                 }}
               />
             </Progress.Track>

--- a/ui/src/components/ark-ui/LiveProgressBar.tsx
+++ b/ui/src/components/ark-ui/LiveProgressBar.tsx
@@ -1,0 +1,174 @@
+/**
+ * LiveProgressBar
+ *
+ * Transient progress indicator surfaced while a harness pattern is in flight.
+ * Driven by live `controller_action` and `pattern_enter` events streamed from
+ * the harness via the SSE endpoint.
+ *
+ * Behavior:
+ *  - `pattern_enter` resets the bar; `data.maxTurns` (when present) sets the
+ *    denominator. Defaults to a 5-step bar.
+ *  - Each `controller_action` advances the bar by 1/maxTurns and crossfades
+ *    the new `action.status` over the previous one.
+ *  - When `visible` flips to false, the bar fills to 100%, fades out, and
+ *    unmounts so the assistant message can take its place.
+ */
+import { Show, createSignal, createMemo, createEffect, on, onCleanup } from 'solid-js'
+import { Progress } from '@ark-ui/solid/progress'
+
+export interface LiveProgressBarProps {
+  /** Most recent status string from a controller (already extracted upstream). */
+  status: string | null
+  /** 0..1 progress fraction. */
+  progress: number
+  /** Whether the bar should be shown. Flipping to false plays the exit animation. */
+  visible: boolean
+}
+
+const STATUS_FADE_MS = 220
+const EXIT_FADE_MS = 360
+
+export const LiveProgressBar = (props: LiveProgressBarProps) => {
+  // Two slots so the previous status crossfades out as the new one fades in.
+  const [shownStatus, setShownStatus] = createSignal<string | null>(null)
+  const [previousStatus, setPreviousStatus] = createSignal<string | null>(null)
+
+  // Animated mount/unmount state — `mounted` controls render, `entering` toggles
+  // the CSS transitions for both enter and exit.
+  const [mounted, setMounted] = createSignal(false)
+  const [entering, setEntering] = createSignal(false)
+
+  let exitTimer: number | undefined
+  let statusTimer: number | undefined
+
+  onCleanup(() => {
+    if (exitTimer !== undefined) clearTimeout(exitTimer)
+    if (statusTimer !== undefined) clearTimeout(statusTimer)
+  })
+
+  // Crossfade when the status string changes (also covers the initial value).
+  createEffect(
+    on(
+      () => props.status,
+      (next, prev) => {
+        if (next === prev) return
+        if (statusTimer !== undefined) clearTimeout(statusTimer)
+        setPreviousStatus((prev as string | null | undefined) ?? null)
+        setShownStatus(next)
+        statusTimer = window.setTimeout(() => {
+          setPreviousStatus(null)
+          statusTimer = undefined
+        }, STATUS_FADE_MS)
+      }
+    )
+  )
+
+  // Mount/unmount with a delayed unmount so the CSS exit animation completes.
+  // (Picks up the initial `visible` value too — no `defer: true`.)
+  createEffect(
+    on(
+      () => props.visible,
+      (next) => {
+        if (exitTimer !== undefined) {
+          clearTimeout(exitTimer)
+          exitTimer = undefined
+        }
+        if (next) {
+          setMounted(true)
+          // Allow the next paint before flipping `entering` so the transition runs.
+          requestAnimationFrame(() => setEntering(true))
+        } else {
+          setEntering(false)
+          exitTimer = window.setTimeout(() => {
+            setMounted(false)
+            exitTimer = undefined
+          }, EXIT_FADE_MS)
+        }
+      }
+    )
+  )
+
+  // Bar value: 0–100. When exiting, animate to 100 to give a "completed" feel.
+  const value = createMemo(() => {
+    if (!props.visible) return 100
+    return Math.max(0, Math.min(100, Math.round(props.progress * 100)))
+  })
+
+  return (
+    <Show when={mounted()}>
+      <div
+        flex="~ col gap-1"
+        px="4"
+        py="2"
+        border="t dark-border-primary"
+        bg="dark-bg-tertiary/50"
+        style={{
+          opacity: entering() ? 1 : 0,
+          transform: entering() ? 'translateY(0)' : 'translateY(4px)',
+          transition: `opacity ${EXIT_FADE_MS}ms ease, transform ${EXIT_FADE_MS}ms ease`,
+        }}
+      >
+        {/* Status line — two slots overlap during the crossfade */}
+        <div
+          flex="~ items-center gap-2"
+          h="4"
+          style={{ position: 'relative' }}
+        >
+          <div
+            w="1.5"
+            h="1.5"
+            rounded="full"
+            bg="neon-cyan"
+            class="animate-pulse"
+            style={{ 'flex-shrink': 0 }}
+          />
+          <Show when={previousStatus()}>
+            <span
+              text="xs dark-text-tertiary"
+              style={{
+                position: 'absolute',
+                left: '14px',
+                opacity: 0,
+                transition: `opacity ${STATUS_FADE_MS}ms ease`,
+                'pointer-events': 'none',
+              }}
+            >
+              {previousStatus()}
+            </span>
+          </Show>
+          <span
+            text="xs dark-text-secondary"
+            style={{
+              opacity: shownStatus() ? 1 : 0,
+              transition: `opacity ${STATUS_FADE_MS}ms ease`,
+            }}
+          >
+            {shownStatus() ?? '\u00a0'}
+          </span>
+        </div>
+
+        {/* Linear progress bar */}
+        <Progress.Root value={value()} max={100} min={0}>
+          <Progress.Track
+            style={{
+              height: '3px',
+              'background-color': 'rgb(58, 58, 74)',
+              'border-radius': '9999px',
+              overflow: 'hidden',
+            }}
+          >
+            <Progress.Range
+              style={{
+                height: '100%',
+                'background-image':
+                  'linear-gradient(90deg, rgba(0,255,255,0.85), rgba(157,0,255,0.85))',
+                'box-shadow': '0 0 8px rgba(0,255,255,0.45)',
+                transition: 'width 240ms cubic-bezier(0.4, 0, 0.2, 1)',
+              }}
+            />
+          </Progress.Track>
+        </Progress.Root>
+      </div>
+    </Show>
+  )
+}

--- a/ui/src/components/ark-ui/LiveProgressBar.tsx
+++ b/ui/src/components/ark-ui/LiveProgressBar.tsx
@@ -96,94 +96,108 @@ export const LiveProgressBar = (props: LiveProgressBarProps) => {
 
   return (
     <Show when={mounted()}>
+      {/* In-progress placeholder — mirrors the assistant message layout
+          (avatar + bubble) so it looks like the next reply landing in. */}
       <div
-        flex="~ col gap-1.5"
-        px="4"
-        py="2.5"
-        border="t dark-border-primary"
-        bg="dark-bg-tertiary/50"
+        flex="~"
+        gap="3"
+        data-role="assistant"
+        data-progress=""
         style={{
           opacity: entering() ? 1 : 0,
           transform: entering() ? 'translateY(0)' : 'translateY(4px)',
           transition: `opacity ${EXIT_FADE_MS}ms ease, transform ${EXIT_FADE_MS}ms ease`,
         }}
       >
-        <Progress.Root
-          value={value()}
-          min={0}
-          max={total()}
-          flex="~ col gap-1.5"
+        {/* Avatar — matches ChatMessages assistant avatar styling */}
+        <div
+          flex="~ shrink-0"
+          w="8"
+          h="8"
+          rounded="full"
+          items="center"
+          justify="center"
+          text="white xs"
+          font="medium"
+          bg="cyber-800"
+          border="~ neon-cyan/30"
         >
-          {/* Header row: pulse + status + counter */}
-          <div flex="~ items-center gap-2" h="4" style={{ position: 'relative' }}>
-            <div
-              w="1.5"
-              h="1.5"
-              rounded="full"
-              bg="neon-cyan"
-              class="animate-pulse"
-              style={{ 'flex-shrink': 0 }}
-            />
+          AI
+        </div>
 
-            {/* Status slot — two children overlap during crossfade */}
-            <div flex="~ 1" style={{ position: 'relative', 'min-width': 0 }}>
-              <Show when={previousStatus()}>
+        <div flex="~ col 1" style={{ 'min-width': 0 }}>
+          <Progress.Root value={value()} min={0} max={total()} flex="~ col gap-1.5">
+            {/* Header row: pulse + status + counter */}
+            <div flex="~ items-center gap-2" h="4" style={{ position: 'relative' }}>
+              <div
+                w="1.5"
+                h="1.5"
+                rounded="full"
+                bg="neon-cyan"
+                class="animate-pulse"
+                style={{ 'flex-shrink': 0 }}
+              />
+
+              {/* Status slot — two children overlap during crossfade */}
+              <div flex="~ 1" style={{ position: 'relative', 'min-width': 0 }}>
+                <Show when={previousStatus()}>
+                  <Progress.Label
+                    text="xs dark-text-tertiary"
+                    truncate=""
+                    style={{
+                      position: 'absolute',
+                      inset: 0,
+                      opacity: 0,
+                      transition: `opacity ${STATUS_FADE_MS}ms ease`,
+                      'pointer-events': 'none',
+                    }}
+                  >
+                    {previousStatus()}
+                  </Progress.Label>
+                </Show>
                 <Progress.Label
-                  text="xs dark-text-tertiary"
+                  text="xs dark-text-secondary"
                   truncate=""
                   style={{
-                    position: 'absolute',
-                    inset: 0,
-                    opacity: 0,
+                    display: 'block',
+                    opacity: shownStatus() ? 1 : 0,
                     transition: `opacity ${STATUS_FADE_MS}ms ease`,
-                    'pointer-events': 'none',
                   }}
                 >
-                  {previousStatus()}
+                  {shownStatus() ?? '\u00a0'}
                 </Progress.Label>
-              </Show>
-              <Progress.Label
-                text="xs dark-text-secondary"
-                truncate=""
-                style={{
-                  display: 'block',
-                  opacity: shownStatus() ? 1 : 0,
-                  transition: `opacity ${STATUS_FADE_MS}ms ease`,
-                }}
+              </div>
+
+              <Progress.ValueText
+                text="xs dark-text-tertiary tabular-nums"
+                style={{ 'flex-shrink': 0, 'font-variant-numeric': 'tabular-nums' }}
               >
-                {shownStatus() ?? '\u00a0'}
-              </Progress.Label>
+                {valueText()}
+              </Progress.ValueText>
             </div>
 
-            <Progress.ValueText
-              text="xs dark-text-tertiary tabular-nums"
-              style={{ 'flex-shrink': 0, 'font-variant-numeric': 'tabular-nums' }}
-            >
-              {valueText()}
-            </Progress.ValueText>
-          </div>
-
-          {/* Linear bar */}
-          <Progress.Track
-            style={{
-              height: '3px',
-              'background-color': 'rgb(58, 58, 74)',
-              'border-radius': '9999px',
-              overflow: 'hidden',
-            }}
-          >
-            <Progress.Range
+            {/* Linear bar */}
+            <Progress.Track
               style={{
-                height: '100%',
-                width: `${percent()}%`,
-                'background-image':
-                  'linear-gradient(90deg, rgba(0,255,255,0.85), rgba(157,0,255,0.85))',
-                'box-shadow': '0 0 8px rgba(0,255,255,0.45)',
-                transition: 'width 240ms cubic-bezier(0.4, 0, 0.2, 1)',
+                height: '3px',
+                'background-color': 'rgb(58, 58, 74)',
+                'border-radius': '9999px',
+                overflow: 'hidden',
               }}
-            />
-          </Progress.Track>
-        </Progress.Root>
+            >
+              <Progress.Range
+                style={{
+                  height: '100%',
+                  width: `${percent()}%`,
+                  'background-image':
+                    'linear-gradient(90deg, rgba(0,255,255,0.85), rgba(157,0,255,0.85))',
+                  'box-shadow': '0 0 8px rgba(0,255,255,0.45)',
+                  transition: 'width 240ms cubic-bezier(0.4, 0, 0.2, 1)',
+                }}
+              />
+            </Progress.Track>
+          </Progress.Root>
+        </div>
       </div>
     </Show>
   )

--- a/ui/src/components/ark-ui/LiveProgressBar.tsx
+++ b/ui/src/components/ark-ui/LiveProgressBar.tsx
@@ -1,26 +1,30 @@
 /**
  * LiveProgressBar
  *
- * Transient progress indicator surfaced while a harness pattern is in flight.
- * Driven by live `controller_action` and `pattern_enter` events streamed from
- * the harness via the SSE endpoint.
+ * Inline status bar surfaced while a harness chain is in flight.
  *
- * Behavior:
- *  - `pattern_enter` resets the bar; `data.maxTurns` (when present) sets the
- *    denominator. Defaults to a 5-step bar.
- *  - Each `controller_action` advances the bar by 1/maxTurns and crossfades
- *    the new `action.status` over the previous one.
- *  - When `visible` flips to false, the bar fills to 100%, fades out, and
- *    unmounts so the assistant message can take its place.
+ * Layout (top → bottom):
+ *   [pulse dot]  status text          current/total
+ *   [───────────────────────────────────────────────] linear progress
+ *
+ * The status string crossfades when it changes; `current/total` updates via
+ * the `Progress.ValueText` slot. When `visible` flips false the bar fills to
+ * 100%, fades out, and unmounts so the assistant message can take its place.
+ *
+ * Built from Ark UI's `Progress` primitives (Root/Track/Range/Label/ValueText)
+ * with UnoCSS attributify for layout. Runtime visual state (gradient fill,
+ * crossfade, exit) lives in inline styles because UnoCSS attributify doesn't
+ * support per-frame transitions.
  */
 import { Show, createSignal, createMemo, createEffect, on, onCleanup } from 'solid-js'
 import { Progress } from '@ark-ui/solid/progress'
 
 export interface LiveProgressBarProps {
-  /** Most recent status string from a controller (already extracted upstream). */
   status: string | null
-  /** 0..1 progress fraction. */
-  progress: number
+  /** Cumulative turn position (1-based when active, 0 before first event). */
+  current: number
+  /** Best-effort chain total. May grow as pattern_enter events arrive. */
+  total: number
   /** Whether the bar should be shown. Flipping to false plays the exit animation. */
   visible: boolean
 }
@@ -29,12 +33,8 @@ const STATUS_FADE_MS = 220
 const EXIT_FADE_MS = 360
 
 export const LiveProgressBar = (props: LiveProgressBarProps) => {
-  // Two slots so the previous status crossfades out as the new one fades in.
   const [shownStatus, setShownStatus] = createSignal<string | null>(null)
   const [previousStatus, setPreviousStatus] = createSignal<string | null>(null)
-
-  // Animated mount/unmount state — `mounted` controls render, `entering` toggles
-  // the CSS transitions for both enter and exit.
   const [mounted, setMounted] = createSignal(false)
   const [entering, setEntering] = createSignal(false)
 
@@ -46,7 +46,7 @@ export const LiveProgressBar = (props: LiveProgressBarProps) => {
     if (statusTimer !== undefined) clearTimeout(statusTimer)
   })
 
-  // Crossfade when the status string changes (also covers the initial value).
+  // Crossfade when the status string changes.
   createEffect(
     on(
       () => props.status,
@@ -64,7 +64,6 @@ export const LiveProgressBar = (props: LiveProgressBarProps) => {
   )
 
   // Mount/unmount with a delayed unmount so the CSS exit animation completes.
-  // (Picks up the initial `visible` value too — no `defer: true`.)
   createEffect(
     on(
       () => props.visible,
@@ -75,7 +74,6 @@ export const LiveProgressBar = (props: LiveProgressBarProps) => {
         }
         if (next) {
           setMounted(true)
-          // Allow the next paint before flipping `entering` so the transition runs.
           requestAnimationFrame(() => setEntering(true))
         } else {
           setEntering(false)
@@ -88,18 +86,20 @@ export const LiveProgressBar = (props: LiveProgressBarProps) => {
     )
   )
 
-  // Bar value: 0–100. When exiting, animate to 100 to give a "completed" feel.
+  const total = createMemo(() => Math.max(1, props.total))
   const value = createMemo(() => {
-    if (!props.visible) return 100
-    return Math.max(0, Math.min(100, Math.round(props.progress * 100)))
+    if (!props.visible) return total()
+    return Math.max(0, Math.min(props.current, total()))
   })
+  const percent = createMemo(() => Math.round((value() / total()) * 100))
+  const valueText = createMemo(() => `${value()}/${total()}`)
 
   return (
     <Show when={mounted()}>
       <div
-        flex="~ col gap-1"
+        flex="~ col gap-1.5"
         px="4"
-        py="2"
+        py="2.5"
         border="t dark-border-primary"
         bg="dark-bg-tertiary/50"
         style={{
@@ -108,47 +108,62 @@ export const LiveProgressBar = (props: LiveProgressBarProps) => {
           transition: `opacity ${EXIT_FADE_MS}ms ease, transform ${EXIT_FADE_MS}ms ease`,
         }}
       >
-        {/* Status line — two slots overlap during the crossfade */}
-        <div
-          flex="~ items-center gap-2"
-          h="4"
-          style={{ position: 'relative' }}
+        <Progress.Root
+          value={value()}
+          min={0}
+          max={total()}
+          flex="~ col gap-1.5"
         >
-          <div
-            w="1.5"
-            h="1.5"
-            rounded="full"
-            bg="neon-cyan"
-            class="animate-pulse"
-            style={{ 'flex-shrink': 0 }}
-          />
-          <Show when={previousStatus()}>
-            <span
-              text="xs dark-text-tertiary"
-              style={{
-                position: 'absolute',
-                left: '14px',
-                opacity: 0,
-                transition: `opacity ${STATUS_FADE_MS}ms ease`,
-                'pointer-events': 'none',
-              }}
-            >
-              {previousStatus()}
-            </span>
-          </Show>
-          <span
-            text="xs dark-text-secondary"
-            style={{
-              opacity: shownStatus() ? 1 : 0,
-              transition: `opacity ${STATUS_FADE_MS}ms ease`,
-            }}
-          >
-            {shownStatus() ?? '\u00a0'}
-          </span>
-        </div>
+          {/* Header row: pulse + status + counter */}
+          <div flex="~ items-center gap-2" h="4" style={{ position: 'relative' }}>
+            <div
+              w="1.5"
+              h="1.5"
+              rounded="full"
+              bg="neon-cyan"
+              class="animate-pulse"
+              style={{ 'flex-shrink': 0 }}
+            />
 
-        {/* Linear progress bar */}
-        <Progress.Root value={value()} max={100} min={0}>
+            {/* Status slot — two children overlap during crossfade */}
+            <div flex="~ 1" style={{ position: 'relative', 'min-width': 0 }}>
+              <Show when={previousStatus()}>
+                <Progress.Label
+                  text="xs dark-text-tertiary"
+                  truncate=""
+                  style={{
+                    position: 'absolute',
+                    inset: 0,
+                    opacity: 0,
+                    transition: `opacity ${STATUS_FADE_MS}ms ease`,
+                    'pointer-events': 'none',
+                  }}
+                >
+                  {previousStatus()}
+                </Progress.Label>
+              </Show>
+              <Progress.Label
+                text="xs dark-text-secondary"
+                truncate=""
+                style={{
+                  display: 'block',
+                  opacity: shownStatus() ? 1 : 0,
+                  transition: `opacity ${STATUS_FADE_MS}ms ease`,
+                }}
+              >
+                {shownStatus() ?? '\u00a0'}
+              </Progress.Label>
+            </div>
+
+            <Progress.ValueText
+              text="xs dark-text-tertiary tabular-nums"
+              style={{ 'flex-shrink': 0, 'font-variant-numeric': 'tabular-nums' }}
+            >
+              {valueText()}
+            </Progress.ValueText>
+          </div>
+
+          {/* Linear bar */}
           <Progress.Track
             style={{
               height: '3px',
@@ -160,6 +175,7 @@ export const LiveProgressBar = (props: LiveProgressBarProps) => {
             <Progress.Range
               style={{
                 height: '100%',
+                width: `${percent()}%`,
                 'background-image':
                   'linear-gradient(90deg, rgba(0,255,255,0.85), rgba(157,0,255,0.85))',
                 'box-shadow': '0 0 8px rgba(0,255,255,0.45)',

--- a/ui/src/components/ark-ui/useChainProgress.ts
+++ b/ui/src/components/ark-ui/useChainProgress.ts
@@ -1,32 +1,52 @@
 /**
- * useChainProgress — derives a "current/total" progress view from a stream of
- * harness `ContextEvent`s arriving over SSE.
+ * useChainProgress — derives a progress view from a stream of harness
+ * `ContextEvent`s arriving over SSE.
  *
- * Total grows monotonically as `pattern_enter` events arrive; if a pattern
- * exposes `maxTurns` (simpleLoop / actorCritic) it contributes `maxTurns`,
- * otherwise it contributes 1. Wrapper patterns (routes, withApproval, …) are
- * skipped — when a pattern_enter is immediately followed by another
- * pattern_enter without intermediate work, the first is treated as a wrapper.
+ * Model
+ * -----
+ * The harness stamps an upfront `chainTurnEstimate` on the initial
+ * `user_message` event (a worst-case projection summed across the chain's
+ * top-level patterns — `routes` / `parallel` use the longest branch). This
+ * hook reads that as the bar's stable denominator for the whole turn — it
+ * is never grown by subsequent events.
  *
- * Current advances on `controller_action` (per-turn for loops) and on
- * non-loop content events (router/synthesizer assistant_message, etc.).
+ * `currentTurn` advances on:
+ *   - `controller_action` (per-turn for loops)
+ *   - `assistant_message` from a non-final pattern (router, synthesizer)
+ *   - leaf `pattern_exit` (no-op leaf advances)
  *
- * The hook is purely UI display logic — kept out of `harness-patterns/` so
- * the library can stay a neutral primitives package.
+ * Status text is whatever the latest `controller_action.action.status` /
+ * `assistant_message` preview / `tool_call` name reports — `LiveProgressBar`
+ * crossfades between consecutive values.
+ *
+ * On `finish()`, `currentTurn` snaps to `maxProjection` so the bar smoothly
+ * fills to 100% even if the chosen route was shorter than the worst case.
+ *
+ * Fallback path: if `chainTurnEstimate` is missing (older sessions or a
+ * pattern without `estimateTurns`), the hook grows `pathProjection` from
+ * arriving `pattern_enter` events as it did before.
+ *
+ * Library boundary: pure UI logic — kept out of `harness-patterns/` so the
+ * library can be extracted as a standalone npm package without UI deps.
  */
 import { createSignal } from 'solid-js'
 import type { ContextEvent } from '~/lib/harness-patterns'
 
 export interface ChainProgressSnapshot {
   currentTurn: number
-  totalTurns: number
+  /** Bar's stable denominator — set once from `chainTurnEstimate`. */
+  maxProjection: number
+  /** Same as `maxProjection` once the seed arrives; used as the bar value
+   *  scale so the fill rate matches the upfront projection. */
+  pathProjection: number
   status: string | null
   done: boolean
 }
 
 const empty = (): ChainProgressSnapshot => ({
   currentTurn: 0,
-  totalTurns: 0,
+  maxProjection: 0,
+  pathProjection: 0,
   status: null,
   done: false,
 })
@@ -43,138 +63,166 @@ const firstLine = (s: string): string => {
 
 export interface ChainProgressController {
   snapshot: () => ChainProgressSnapshot
-  /** Apply one new event from the SSE stream. */
   ingest: (event: ContextEvent) => void
-  /** Mark the chain finished — bar can fade out. */
   finish: () => void
-  /** Reset for a new turn. */
   reset: () => void
 }
 
 export function createChainProgress(): ChainProgressController {
   const [snapshot, setSnapshot] = createSignal<ChainProgressSnapshot>(empty())
 
-  // A pending pattern_enter is held until we see whether the next event is
-  // another pattern_enter (wrapper — discard) or content (commit).
-  let pendingEnter: { contribution: number; patternId: string } | null = null
+  // Track which patterns we've already advanced for so a stream of
+  // assistant_messages from the same pattern doesn't double-count.
   let advancedForPattern: string | null = null
-  // Loop patterns whose contribution we've already upgraded from 1 to
-  // their effective `maxTurns` based on a controller_action arriving.
-  const upgradedLoops = new Set<string>()
+  // Fallback (no seed): a pending pattern_enter is held until the next event
+  // tells us whether it was a wrapper (discard) or leaf (commit).
+  let pendingEnter: { contribution: number; patternId: string } | null = null
+  let seeded = false
 
-  const flushPendingEnter = () => {
-    if (!pendingEnter) return
+  /** Single-shot snapshot mutator — every ingest path applies one update so
+   *  Solid only schedules one downstream re-run per event. */
+  const update = (
+    fn: (prev: ChainProgressSnapshot) => Partial<ChainProgressSnapshot>
+  ) => setSnapshot((prev) => ({ ...prev, ...fn(prev) }))
+
+  /** Compute pathProjection delta from a flushed pending enter (fallback path). */
+  const flushPending = (
+    prev: ChainProgressSnapshot
+  ): { pathProjection: number } | null => {
+    if (seeded || !pendingEnter) {
+      pendingEnter = null
+      return null
+    }
     const contrib = pendingEnter.contribution
     pendingEnter = null
-    setSnapshot((prev) => ({ ...prev, totalTurns: prev.totalTurns + contrib }))
-  }
-
-  const advanceCurrent = (status: string | null) => {
-    setSnapshot((prev) => ({
-      ...prev,
-      currentTurn: Math.min(prev.currentTurn + 1, prev.totalTurns),
-      status: status ?? prev.status,
-    }))
-  }
-
-  const setStatus = (status: string) => {
-    setSnapshot((prev) => ({ ...prev, status }))
+    return { pathProjection: prev.pathProjection + contrib }
   }
 
   return {
     snapshot,
 
     reset() {
-      pendingEnter = null
       advancedForPattern = null
-      upgradedLoops.clear()
+      pendingEnter = null
+      seeded = false
       setSnapshot(empty())
     },
 
     finish() {
-      flushPendingEnter()
-      setSnapshot((prev) => ({ ...prev, done: true }))
+      update((prev) => {
+        const flushed = flushPending(prev)
+        return {
+          ...(flushed ?? {}),
+          // Snap current to maxProjection so the bar fills to 100% smoothly.
+          currentTurn: prev.maxProjection || (flushed?.pathProjection ?? prev.pathProjection),
+          done: true,
+        }
+      })
     },
 
     ingest(event) {
       switch (event.type) {
+        case 'user_message': {
+          const data = event.data as { chainTurnEstimate?: number }
+          const est = data.chainTurnEstimate
+          if (typeof est === 'number' && est > 0) {
+            seeded = true
+            update(() => ({ maxProjection: est, pathProjection: est }))
+          }
+          break
+        }
+
         case 'pattern_enter': {
-          // A new pattern_enter discards a previously-pending one (wrapper case).
+          if (seeded) break
           const data = event.data as { pattern?: string; maxTurns?: number }
-          const contribution = typeof data.maxTurns === 'number' && data.maxTurns > 0 ? data.maxTurns : 1
+          const contribution =
+            typeof data.maxTurns === 'number' && data.maxTurns > 0 ? data.maxTurns : 1
+          // Fallback path: replace any pending enter — wrappers
+          // (routes, withApproval) emit an enter immediately followed by
+          // their child's, and the child's contribution should win.
           pendingEnter = { contribution, patternId: event.patternId }
           advancedForPattern = null
           break
         }
 
         case 'controller_action': {
-          flushPendingEnter()
           const data = event.data as {
             action?: { status?: string }
             maxTurns?: number
           }
-          // Loops emit `maxTurns` on every controller_action. The first time
-          // we see it for a given patternId, upgrade that pattern's
-          // contribution from the default 1 to its effective maxTurns.
-          if (
-            typeof data.maxTurns === 'number' &&
-            data.maxTurns > 1 &&
-            !upgradedLoops.has(event.patternId)
-          ) {
-            upgradedLoops.add(event.patternId)
-            const upgrade = data.maxTurns - 1
-            setSnapshot((prev) => ({ ...prev, totalTurns: prev.totalTurns + upgrade }))
-          }
           const status = data.action?.status ? truncate(data.action.status) : null
-          advanceCurrent(status)
+          update((prev) => {
+            const flushed = flushPending(prev)
+            const path = flushed?.pathProjection ?? prev.pathProjection
+            return {
+              currentTurn: Math.min(prev.currentTurn + 1, prev.maxProjection || path),
+              pathProjection: path,
+              status: status ?? prev.status,
+            }
+          })
           advancedForPattern = event.patternId
           break
         }
 
         case 'assistant_message': {
-          // Mid-chain assistant message (router decision, synthesizer output).
-          flushPendingEnter()
           const content = (event.data as { content?: string }).content ?? ''
           const preview = truncate(firstLine(content.trim()))
-          // Only advance once per pattern so a streamed/partial assistant message
-          // doesn't double-count.
           if (advancedForPattern !== event.patternId) {
-            advanceCurrent(preview || null)
+            update((prev) => {
+              const flushed = flushPending(prev)
+              const path = flushed?.pathProjection ?? prev.pathProjection
+              return {
+                currentTurn: Math.min(prev.currentTurn + 1, prev.maxProjection || path),
+                pathProjection: path,
+                status: preview || prev.status,
+              }
+            })
             advancedForPattern = event.patternId
           } else if (preview) {
-            setStatus(preview)
+            update(() => ({ status: preview }))
           }
           break
         }
 
         case 'tool_call': {
-          // Tool calls don't advance the bar (controller_action already did)
-          // but we surface a friendly status while the call is in flight.
-          flushPendingEnter()
           const tool = (event.data as { tool?: string }).tool ?? 'tool'
-          setStatus(`Calling ${tool}…`)
+          update((prev) => {
+            const flushed = flushPending(prev)
+            return {
+              ...(flushed ?? {}),
+              status: `Calling ${tool}…`,
+            }
+          })
           break
         }
 
         case 'pattern_exit': {
-          // Exit without intermediate content (e.g., a no-op pattern) — count
-          // the pending enter so the bar still advances.
-          if (pendingEnter && pendingEnter.patternId === event.patternId) {
-            flushPendingEnter()
-            advanceCurrent(null)
+          if (!seeded && pendingEnter && pendingEnter.patternId === event.patternId) {
+            update((prev) => {
+              const flushed = flushPending(prev)
+              const path = flushed?.pathProjection ?? prev.pathProjection
+              return {
+                currentTurn: Math.min(prev.currentTurn + 1, prev.maxProjection || path),
+                pathProjection: path,
+              }
+            })
           }
           break
         }
 
         case 'error': {
-          flushPendingEnter()
           const err = (event.data as { error?: string }).error ?? 'error'
-          setStatus(truncate(err))
+          update((prev) => {
+            const flushed = flushPending(prev)
+            return {
+              ...(flushed ?? {}),
+              status: truncate(err),
+            }
+          })
           break
         }
 
         default:
-          // Ignore other event types (user_message, tool_result, etc.).
           break
       }
     },

--- a/ui/src/components/ark-ui/useChainProgress.ts
+++ b/ui/src/components/ark-ui/useChainProgress.ts
@@ -58,6 +58,9 @@ export function createChainProgress(): ChainProgressController {
   // another pattern_enter (wrapper — discard) or content (commit).
   let pendingEnter: { contribution: number; patternId: string } | null = null
   let advancedForPattern: string | null = null
+  // Loop patterns whose contribution we've already upgraded from 1 to
+  // their effective `maxTurns` based on a controller_action arriving.
+  const upgradedLoops = new Set<string>()
 
   const flushPendingEnter = () => {
     if (!pendingEnter) return
@@ -84,6 +87,7 @@ export function createChainProgress(): ChainProgressController {
     reset() {
       pendingEnter = null
       advancedForPattern = null
+      upgradedLoops.clear()
       setSnapshot(empty())
     },
 
@@ -105,8 +109,23 @@ export function createChainProgress(): ChainProgressController {
 
         case 'controller_action': {
           flushPendingEnter()
-          const action = (event.data as { action?: { status?: string } }).action
-          const status = action?.status ? truncate(action.status) : null
+          const data = event.data as {
+            action?: { status?: string }
+            maxTurns?: number
+          }
+          // Loops emit `maxTurns` on every controller_action. The first time
+          // we see it for a given patternId, upgrade that pattern's
+          // contribution from the default 1 to its effective maxTurns.
+          if (
+            typeof data.maxTurns === 'number' &&
+            data.maxTurns > 1 &&
+            !upgradedLoops.has(event.patternId)
+          ) {
+            upgradedLoops.add(event.patternId)
+            const upgrade = data.maxTurns - 1
+            setSnapshot((prev) => ({ ...prev, totalTurns: prev.totalTurns + upgrade }))
+          }
+          const status = data.action?.status ? truncate(data.action.status) : null
           advanceCurrent(status)
           advancedForPattern = event.patternId
           break

--- a/ui/src/components/ark-ui/useChainProgress.ts
+++ b/ui/src/components/ark-ui/useChainProgress.ts
@@ -1,0 +1,163 @@
+/**
+ * useChainProgress — derives a "current/total" progress view from a stream of
+ * harness `ContextEvent`s arriving over SSE.
+ *
+ * Total grows monotonically as `pattern_enter` events arrive; if a pattern
+ * exposes `maxTurns` (simpleLoop / actorCritic) it contributes `maxTurns`,
+ * otherwise it contributes 1. Wrapper patterns (routes, withApproval, …) are
+ * skipped — when a pattern_enter is immediately followed by another
+ * pattern_enter without intermediate work, the first is treated as a wrapper.
+ *
+ * Current advances on `controller_action` (per-turn for loops) and on
+ * non-loop content events (router/synthesizer assistant_message, etc.).
+ *
+ * The hook is purely UI display logic — kept out of `harness-patterns/` so
+ * the library can stay a neutral primitives package.
+ */
+import { createSignal } from 'solid-js'
+import type { ContextEvent } from '~/lib/harness-patterns'
+
+export interface ChainProgressSnapshot {
+  currentTurn: number
+  totalTurns: number
+  status: string | null
+  done: boolean
+}
+
+const empty = (): ChainProgressSnapshot => ({
+  currentTurn: 0,
+  totalTurns: 0,
+  status: null,
+  done: false,
+})
+
+const STATUS_MAX_LENGTH = 140
+
+const truncate = (s: string): string =>
+  s.length > STATUS_MAX_LENGTH ? `${s.slice(0, STATUS_MAX_LENGTH - 1)}…` : s
+
+const firstLine = (s: string): string => {
+  const idx = s.indexOf('\n')
+  return idx === -1 ? s : s.slice(0, idx)
+}
+
+export interface ChainProgressController {
+  snapshot: () => ChainProgressSnapshot
+  /** Apply one new event from the SSE stream. */
+  ingest: (event: ContextEvent) => void
+  /** Mark the chain finished — bar can fade out. */
+  finish: () => void
+  /** Reset for a new turn. */
+  reset: () => void
+}
+
+export function createChainProgress(): ChainProgressController {
+  const [snapshot, setSnapshot] = createSignal<ChainProgressSnapshot>(empty())
+
+  // A pending pattern_enter is held until we see whether the next event is
+  // another pattern_enter (wrapper — discard) or content (commit).
+  let pendingEnter: { contribution: number; patternId: string } | null = null
+  let advancedForPattern: string | null = null
+
+  const flushPendingEnter = () => {
+    if (!pendingEnter) return
+    const contrib = pendingEnter.contribution
+    pendingEnter = null
+    setSnapshot((prev) => ({ ...prev, totalTurns: prev.totalTurns + contrib }))
+  }
+
+  const advanceCurrent = (status: string | null) => {
+    setSnapshot((prev) => ({
+      ...prev,
+      currentTurn: Math.min(prev.currentTurn + 1, prev.totalTurns),
+      status: status ?? prev.status,
+    }))
+  }
+
+  const setStatus = (status: string) => {
+    setSnapshot((prev) => ({ ...prev, status }))
+  }
+
+  return {
+    snapshot,
+
+    reset() {
+      pendingEnter = null
+      advancedForPattern = null
+      setSnapshot(empty())
+    },
+
+    finish() {
+      flushPendingEnter()
+      setSnapshot((prev) => ({ ...prev, done: true }))
+    },
+
+    ingest(event) {
+      switch (event.type) {
+        case 'pattern_enter': {
+          // A new pattern_enter discards a previously-pending one (wrapper case).
+          const data = event.data as { pattern?: string; maxTurns?: number }
+          const contribution = typeof data.maxTurns === 'number' && data.maxTurns > 0 ? data.maxTurns : 1
+          pendingEnter = { contribution, patternId: event.patternId }
+          advancedForPattern = null
+          break
+        }
+
+        case 'controller_action': {
+          flushPendingEnter()
+          const action = (event.data as { action?: { status?: string } }).action
+          const status = action?.status ? truncate(action.status) : null
+          advanceCurrent(status)
+          advancedForPattern = event.patternId
+          break
+        }
+
+        case 'assistant_message': {
+          // Mid-chain assistant message (router decision, synthesizer output).
+          flushPendingEnter()
+          const content = (event.data as { content?: string }).content ?? ''
+          const preview = truncate(firstLine(content.trim()))
+          // Only advance once per pattern so a streamed/partial assistant message
+          // doesn't double-count.
+          if (advancedForPattern !== event.patternId) {
+            advanceCurrent(preview || null)
+            advancedForPattern = event.patternId
+          } else if (preview) {
+            setStatus(preview)
+          }
+          break
+        }
+
+        case 'tool_call': {
+          // Tool calls don't advance the bar (controller_action already did)
+          // but we surface a friendly status while the call is in flight.
+          flushPendingEnter()
+          const tool = (event.data as { tool?: string }).tool ?? 'tool'
+          setStatus(`Calling ${tool}…`)
+          break
+        }
+
+        case 'pattern_exit': {
+          // Exit without intermediate content (e.g., a no-op pattern) — count
+          // the pending enter so the bar still advances.
+          if (pendingEnter && pendingEnter.patternId === event.patternId) {
+            flushPendingEnter()
+            advanceCurrent(null)
+          }
+          break
+        }
+
+        case 'error': {
+          flushPendingEnter()
+          const err = (event.data as { error?: string }).error ?? 'error'
+          setStatus(truncate(err))
+          break
+        }
+
+        default:
+          // Ignore other event types (user_message, tool_result, etc.).
+          break
+      }
+    },
+  }
+}

--- a/ui/src/lib/harness-client/examples/default.server.ts
+++ b/ui/src/lib/harness-client/examples/default.server.ts
@@ -37,12 +37,16 @@ async function createPatterns(): Promise<ConfiguredPattern<SessionData>[]> {
   const codeController = createActorControllerAdapter(tools.all);
   const codeCritic = createCriticAdapter();
 
-  const neo4jPattern = simpleLoop<SessionData>(neo4jController, tools.neo4j ?? [], {
-    patternId: "neo4j-query",
-    schema,
-    liveEvents: true,
-    rememberPriorTurns: false,
-  });
+  const neo4jPattern = simpleLoop<SessionData>(
+    neo4jController,
+    tools.neo4j ?? [],
+    {
+      patternId: "neo4j-query",
+      schema,
+      liveEvents: true,
+      rememberPriorTurns: false,
+    },
+  );
 
   const webPattern = simpleLoop<SessionData>(webController, webTools, {
     patternId: "web-search",

--- a/ui/src/lib/harness-client/examples/default.server.ts
+++ b/ui/src/lib/harness-client/examples/default.server.ts
@@ -41,11 +41,13 @@ async function createPatterns(): Promise<ConfiguredPattern<SessionData>[]> {
     patternId: "neo4j-query",
     schema,
     liveEvents: true,
+    rememberPriorTurns: false,
   });
 
   const webPattern = simpleLoop<SessionData>(webController, webTools, {
     patternId: "web-search",
     liveEvents: true,
+    rememberPriorTurns: false,
   });
 
   const codePattern = actorCritic<SessionData>(

--- a/ui/src/lib/harness-client/examples/default.server.ts
+++ b/ui/src/lib/harness-client/examples/default.server.ts
@@ -40,10 +40,12 @@ async function createPatterns(): Promise<ConfiguredPattern<SessionData>[]> {
   const neo4jPattern = simpleLoop<SessionData>(neo4jController, tools.neo4j ?? [], {
     patternId: "neo4j-query",
     schema,
+    liveEvents: true,
   });
 
   const webPattern = simpleLoop<SessionData>(webController, webTools, {
     patternId: "web-search",
+    liveEvents: true,
   });
 
   const codePattern = actorCritic<SessionData>(
@@ -52,24 +54,32 @@ async function createPatterns(): Promise<ConfiguredPattern<SessionData>[]> {
     tools.all,
     {
       patternId: "code-mode",
+      liveEvents: true,
     },
   );
 
-  const routerPattern = router<SessionData>({
-    neo4j: "Database queries and graph operations",
-    web_search: "Web lookups and information retrieval",
-    code_mode: "Multi-tool script composition",
-  });
+  const routerPattern = router<SessionData>(
+    {
+      neo4j: "Database queries and graph operations",
+      web_search: "Web lookups and information retrieval",
+      code_mode: "Multi-tool script composition",
+    },
+    { liveEvents: true },
+  );
 
-  const routesPattern = routes<SessionData>({
-    neo4j: neo4jPattern,
-    web_search: webPattern,
-    code_mode: codePattern,
-  });
+  const routesPattern = routes<SessionData>(
+    {
+      neo4j: neo4jPattern,
+      web_search: webPattern,
+      code_mode: codePattern,
+    },
+    { liveEvents: true },
+  );
 
   const responseSynth = synthesizer<SessionData>({
     mode: "thread",
     patternId: "response-synth",
+    liveEvents: true,
   });
 
   return [routerPattern, routesPattern, responseSynth];

--- a/ui/src/lib/harness-patterns/README.md
+++ b/ui/src/lib/harness-patterns/README.md
@@ -2,6 +2,23 @@
 
 Functional, composable framework for agentic tool execution.
 
+> **Status:** this directory is the **testbed** for the harness-patterns
+> library. The kg-agent repo serves as both consumer and proving ground —
+> the library is intended to be extracted as a standalone npm package once
+> the core API has been validated across enough use cases (the agents under
+> `harness-client/examples/`).
+>
+> Library boundary rules — keep them strict so extraction stays cheap:
+> 1. `harness-patterns/` MUST NOT import from `harness-client/`, `components/`,
+>    or any other consumer.
+> 2. Pattern primitives are framework-neutral — no SolidJS, no UI types.
+> 3. Anything that depends on runtime settings goes through
+>    `settings-context.server.ts` (AsyncLocalStorage), not function
+>    parameters.
+> 4. UI display logic (e.g. `useChainProgress`) lives in the consumer, not
+>    here. The library exposes neutral primitives like
+>    `ConfiguredPattern.estimateTurns` that consumers can build on.
+
 ## Table of Contents
 
 - [Architecture Overview](#architecture-overview)

--- a/ui/src/lib/harness-patterns/context.server.ts
+++ b/ui/src/lib/harness-patterns/context.server.ts
@@ -6,6 +6,7 @@
  */
 
 import { assertServerOnImport } from './assert.server'
+import { emitLive } from './live-event-context.server'
 import type {
   UnifiedContext,
   PatternScope,
@@ -124,7 +125,9 @@ export function shouldTrack(type: EventType, trackHistory: TrackHistory): boolea
   return false
 }
 
-/** Add event to scope if it should be tracked */
+/** Add event to scope if it should be tracked.
+ *  When the current pattern has `liveEvents: true`, the event is also forwarded
+ *  to the harness `onEvent` listener immediately via `emitLive()`. */
 export function trackEvent(
   scope: PatternScope<unknown>,
   type: EventType,
@@ -132,9 +135,10 @@ export function trackEvent(
   trackHistory: TrackHistory,
   llmCall?: LLMCallData
 ): void {
-  if (shouldTrack(type, trackHistory)) {
-    scope.events.push(createEvent(type, scope.id, data, llmCall))
-  }
+  if (!shouldTrack(type, trackHistory)) return
+  const event = createEvent(type, scope.id, data, llmCall)
+  scope.events.push(event)
+  emitLive(event)
 }
 
 // ============================================================================
@@ -197,19 +201,24 @@ function findLastIndex<T>(arr: T[], pred: (item: T) => boolean): number {
 // Pattern Lifecycle Helpers
 // ============================================================================
 
-/** Add pattern_enter event to context */
+/** Add pattern_enter event to context.
+ *  Optional `meta` is merged into the event's data (e.g. `{ maxTurns }`)
+ *  so downstream consumers (UI progress bar) can compute progress. */
 export function enterPattern<T>(
   ctx: UnifiedContext<T>,
   patternId: string,
-  patternName: string
+  patternName: string,
+  meta?: Record<string, unknown>
 ): void {
-  ctx.events.push({
+  const event: ContextEvent = {
     id: generateId('ev'),
     type: 'pattern_enter',
     ts: Date.now(),
     patternId,
-    data: { pattern: patternName }
-  })
+    data: { pattern: patternName, ...(meta ?? {}) }
+  }
+  ctx.events.push(event)
+  emitLive(event)
 }
 
 /** Add pattern_exit event to context */
@@ -217,13 +226,15 @@ export function exitPattern<T>(
   ctx: UnifiedContext<T>,
   patternId: string
 ): void {
-  ctx.events.push({
+  const event: ContextEvent = {
     id: generateId('ev'),
     type: 'pattern_exit',
     ts: Date.now(),
     patternId,
     data: { status: ctx.status, error: ctx.error }
-  })
+  }
+  ctx.events.push(event)
+  emitLive(event)
 }
 
 // ============================================================================

--- a/ui/src/lib/harness-patterns/context.server.ts
+++ b/ui/src/lib/harness-patterns/context.server.ts
@@ -303,12 +303,16 @@ export function getDefaultCommitStrategy(patternType: string): CommitStrategy {
   return DEFAULT_COMMIT_STRATEGY[patternType] ?? 'always'
 }
 
-/** Merge pattern config with defaults */
+/** Merge pattern config with defaults.
+ *  Spreads the caller's config first so unrecognised fields (e.g. pattern-specific
+ *  options like `maxTurns`, plus opt-in flags like `liveEvents`) are preserved
+ *  after defaults are applied for the well-known base fields. */
 export function resolveConfig(
   patternType: string,
   config?: PatternConfig
 ): Required<Pick<PatternConfig, 'patternId' | 'commitStrategy' | 'trackHistory' | 'errorSeverity'>> & PatternConfig {
   return {
+    ...config,
     patternId: config?.patternId ?? generateId(patternType),
     commitStrategy: config?.commitStrategy ?? getDefaultCommitStrategy(patternType),
     trackHistory: config?.trackHistory ?? getDefaultTrackHistory(patternType),

--- a/ui/src/lib/harness-patterns/harness.server.ts
+++ b/ui/src/lib/harness-patterns/harness.server.ts
@@ -13,7 +13,9 @@ import type {
   HarnessResult,
   UnifiedContext,
   ConfiguredPattern,
-  AssistantMessageEventData
+  AssistantMessageEventData,
+  UserMessageEventData,
+  TurnEstimateSettings
 } from './types'
 import {
   createContext,
@@ -23,8 +25,46 @@ import {
   generateId
 } from './context.server'
 import { runWithLiveListener } from './live-event-context.server'
+import { getRequestSettings } from '../settings-context.server'
 
 assertServerOnImport()
+
+/**
+ * Sum each top-level pattern's `estimateTurns` projection. Patterns that
+ * don't implement `estimateTurns` contribute 1. Used to seed UI progress
+ * indicators with an upfront chain-wide projection.
+ */
+function estimateChainTurns<T>(
+  patterns: ConfiguredPattern<T>[],
+  settings: TurnEstimateSettings
+): number {
+  return patterns.reduce(
+    (sum, p) => sum + (p.estimateTurns?.(settings) ?? 1),
+    0
+  )
+}
+
+function turnEstimateSettings(): TurnEstimateSettings {
+  const s = getRequestSettings()
+  return { maxToolTurns: s.maxToolTurns, maxRetries: s.maxRetries }
+}
+
+/** Stamp `chainTurnEstimate` on the most recent user_message event in-place. */
+function stampChainEstimate<T>(
+  ctx: UnifiedContext<T>,
+  patterns: ConfiguredPattern<T>[]
+): void {
+  let userMsg: ContextEvent | undefined
+  for (let i = ctx.events.length - 1; i >= 0; i--) {
+    if (ctx.events[i].type === 'user_message') {
+      userMsg = ctx.events[i]
+      break
+    }
+  }
+  if (!userMsg) return
+  const data = userMsg.data as UserMessageEventData
+  data.chainTurnEstimate = estimateChainTurns(patterns, turnEstimateSettings())
+}
 
 export interface HarnessData {
   response?: string
@@ -62,6 +102,15 @@ export function harness<T extends HarnessData & Record<string, unknown>>(
 
     // Create UnifiedContext
     const ctx = createContext<T>(input, initialData as T, sessionId)
+
+    // Project total chain turns upfront so progress UIs can seed themselves
+    // before the first pattern_enter arrives.
+    stampChainEstimate(ctx, patterns)
+
+    // Emit the initial user_message live so consumers (e.g. SSE listeners)
+    // see `chainTurnEstimate` before any pattern runs.
+    const initial = ctx.events[ctx.events.length - 1]
+    if (initial?.type === 'user_message' && onEvent) onEvent(initial)
 
     try {
       // Execute patterns using chain inside a live-event frame so that any
@@ -223,6 +272,14 @@ export async function continueSession<T extends HarnessData & Record<string, unk
     patternId: 'harness',
     data: { content: newInput }
   })
+
+  // Re-project chain turns for this turn — settings or pattern selection may
+  // have changed between turns.
+  stampChainEstimate(ctx, patterns)
+
+  // Emit the new user_message live so consumers see the fresh estimate.
+  const continuedMsg = ctx.events[ctx.events.length - 1]
+  if (continuedMsg?.type === 'user_message' && onEvent) onEvent(continuedMsg)
 
   try {
     // Execute patterns

--- a/ui/src/lib/harness-patterns/harness.server.ts
+++ b/ui/src/lib/harness-patterns/harness.server.ts
@@ -22,6 +22,7 @@ import {
   setError as setCtxError,
   generateId
 } from './context.server'
+import { runWithLiveListener } from './live-event-context.server'
 
 assertServerOnImport()
 
@@ -63,8 +64,10 @@ export function harness<T extends HarnessData & Record<string, unknown>>(
     const ctx = createContext<T>(input, initialData as T, sessionId)
 
     try {
-      // Execute patterns using chain
-      await runChain(ctx, patterns, onEvent)
+      // Execute patterns using chain inside a live-event frame so that any
+      // pattern with `liveEvents: true` streams events to `onEvent` as they
+      // happen, not at commit time.
+      await runWithLiveListener(onEvent, () => runChain(ctx, patterns, onEvent))
 
       // Extract response from final data
       const response = ctx.data.response ?? ''
@@ -142,7 +145,7 @@ export async function resumeHarness<T extends HarnessData & Record<string, unkno
 
   try {
     // Re-run patterns - withApproval will handle the resume
-    await runChain(ctx, patterns, onEvent)
+    await runWithLiveListener(onEvent, () => runChain(ctx, patterns, onEvent))
 
     const response = ctx.data.response ?? ''
     const finalStatus = ctx.status as CtxStatus // chain may mutate ctx.status
@@ -223,7 +226,7 @@ export async function continueSession<T extends HarnessData & Record<string, unk
 
   try {
     // Execute patterns
-    await runChain(ctx, patterns, onEvent)
+    await runWithLiveListener(onEvent, () => runChain(ctx, patterns, onEvent))
 
     const response = ctx.data.response ?? ''
     const finalStatus = ctx.status as CtxStatus // chain may mutate ctx.status

--- a/ui/src/lib/harness-patterns/live-event-context.server.ts
+++ b/ui/src/lib/harness-patterns/live-event-context.server.ts
@@ -1,0 +1,76 @@
+/**
+ * Live Event Context (server-only).
+ *
+ * Provides an AsyncLocalStorage frame that lets `trackEvent()` forward events
+ * to a listener as they happen, instead of waiting for the pattern to commit.
+ *
+ * Patterns opt in via `PatternConfig.liveEvents = true`. The chain runner
+ * toggles `setLivePatternEnabled()` per pattern; `emitLive()` is a no-op
+ * unless both the listener exists and the current pattern is enabled.
+ *
+ * Events emitted live are tracked in `emittedIds` so that the post-commit
+ * emission in `runChain` can skip them and avoid duplicates downstream.
+ */
+import { AsyncLocalStorage } from 'node:async_hooks'
+import { assertServerOnImport } from './assert.server'
+import type { ContextEvent } from './types'
+
+assertServerOnImport()
+
+export type LiveEventListener = (event: ContextEvent) => void
+
+interface LiveEventFrame {
+  listener: LiveEventListener
+  emittedIds: Set<string>
+  enabled: boolean
+}
+
+const store = new AsyncLocalStorage<LiveEventFrame>()
+
+/**
+ * Install a live-event listener for the duration of `fn`.
+ * If `listener` is undefined, runs `fn` with no live emission active.
+ */
+export function runWithLiveListener<T>(
+  listener: LiveEventListener | undefined,
+  fn: () => Promise<T>
+): Promise<T> {
+  if (!listener) return fn()
+  const frame: LiveEventFrame = {
+    listener,
+    emittedIds: new Set<string>(),
+    enabled: false
+  }
+  return store.run(frame, fn)
+}
+
+/** Toggle whether the current pattern's events stream live. */
+export function setLivePatternEnabled(enabled: boolean): void {
+  const frame = store.getStore()
+  if (frame) frame.enabled = enabled
+}
+
+/**
+ * Emit an event live if the current frame is enabled.
+ * Returns true when the listener was invoked, false otherwise.
+ */
+export function emitLive(event: ContextEvent): boolean {
+  const frame = store.getStore()
+  if (!frame || !frame.enabled) return false
+  frame.listener(event)
+  if (event.id) frame.emittedIds.add(event.id)
+  return true
+}
+
+/** Has this event already been delivered to the listener? */
+export function wasEmittedLive(event: ContextEvent): boolean {
+  const frame = store.getStore()
+  if (!frame || !event.id) return false
+  return frame.emittedIds.has(event.id)
+}
+
+/** Test helper — clear the emitted-id set within the current frame. */
+export function _resetEmittedIdsForTest(): void {
+  const frame = store.getStore()
+  if (frame) frame.emittedIds.clear()
+}

--- a/ui/src/lib/harness-patterns/patterns/actorCritic.server.ts
+++ b/ui/src/lib/harness-patterns/patterns/actorCritic.server.ts
@@ -89,11 +89,13 @@ export function actorCritic<T extends ActorCriticData>(
         const actorCollector = new Collector('actor')
         const { action, llmCall: actorLlmCall } = await actor(userContent, intent, availableTools, previousAttempts, actorCollector)
 
-        // Track controller action with LLM call data
+        // Track controller action with LLM call data. `turn` and `maxTurns`
+        // (mapped from attempt / maxRetries) are exposed so live progress
+        // consumers can size their indicators against the runtime values.
         trackEvent(
           scope,
           'controller_action',
-          { action } as ControllerActionEventData,
+          { action, turn: attempt, maxTurns: maxRetries } as ControllerActionEventData,
           resolved.trackHistory,
           actorLlmCall
         )

--- a/ui/src/lib/harness-patterns/patterns/actorCritic.server.ts
+++ b/ui/src/lib/harness-patterns/patterns/actorCritic.server.ts
@@ -235,6 +235,7 @@ export function actorCritic<T extends ActorCriticData>(
   return {
     name: 'actorCritic',
     fn,
-    config: resolved
+    config: resolved,
+    estimateTurns: (s) => config?.maxRetries ?? s.maxRetries
   }
 }

--- a/ui/src/lib/harness-patterns/patterns/chain.server.ts
+++ b/ui/src/lib/harness-patterns/patterns/chain.server.ts
@@ -20,6 +20,7 @@ import {
   setError,
   createEvent
 } from '../context.server'
+import { setLivePatternEnabled, wasEmittedLive } from '../live-event-context.server'
 import { createEventView } from './event-view.server'
 
 assertServerOnImport()
@@ -65,6 +66,11 @@ export async function runChain<T extends Record<string, unknown>>(
       }
 
       const patternId = pattern.config.patternId!
+      const liveEnabled = pattern.config.liveEvents === true
+
+      // Toggle live emission for this pattern's lifecycle (incl. enter/exit).
+      // Inner patterns invoked by wrappers inherit this flag automatically.
+      setLivePatternEnabled(liveEnabled)
 
       // 1. Create isolated scope for this pattern
       const scope = createScope<T>(patternId, currentData)
@@ -72,8 +78,15 @@ export async function runChain<T extends Record<string, unknown>>(
       // 2. Create view based on pattern's viewConfig (exclude self from fromLastPattern)
       const view = createEventView(ctx, pattern.config.viewConfig, patternId)
 
-      // 3. Add pattern_enter event
-      enterPattern(ctx, patternId, pattern.name)
+      // 3. Add pattern_enter event (fires live if enabled).
+      //    Surface known config fields (maxTurns) for UI progress tracking.
+      const cfg = pattern.config as PatternConfig & { maxTurns?: number }
+      enterPattern(
+        ctx,
+        patternId,
+        pattern.name,
+        cfg.maxTurns !== undefined ? { maxTurns: cfg.maxTurns } : undefined
+      )
 
       try {
         // 4. Execute pattern
@@ -83,10 +96,12 @@ export async function runChain<T extends Record<string, unknown>>(
         const beforeLen = ctx.events.length
         commitEvents(ctx, result, pattern.config.commitStrategy!)
 
-        // 5b. Emit newly committed events via callback
+        // 5b. Emit newly committed events via callback, skipping any that
+        //     were already delivered live (dedup by event id).
         if (onEvent) {
           for (let j = beforeLen; j < ctx.events.length; j++) {
-            onEvent(ctx.events[j])
+            const ev = ctx.events[j]
+            if (!wasEmittedLive(ev)) onEvent(ev)
           }
         }
 
@@ -97,8 +112,12 @@ export async function runChain<T extends Record<string, unknown>>(
         setError(ctx, msg, patternId)
       }
 
-      // 7. Add pattern_exit event
+      // 7. Add pattern_exit event (fires live if enabled)
       exitPattern(ctx, patternId)
+
+      // Reset the toggle so subsequent patterns without `liveEvents` aren't
+      // accidentally streamed.
+      setLivePatternEnabled(false)
     }
 
     // Update final data

--- a/ui/src/lib/harness-patterns/patterns/chain.server.ts
+++ b/ui/src/lib/harness-patterns/patterns/chain.server.ts
@@ -172,7 +172,9 @@ export function chain<T extends Record<string, unknown>>(
       }
       return current
     },
-    config: resolved
+    config: resolved,
+    estimateTurns: (s) =>
+      patterns.reduce((sum, p) => sum + (p.estimateTurns?.(s) ?? 1), 0)
   }
 }
 

--- a/ui/src/lib/harness-patterns/patterns/guardrail.server.ts
+++ b/ui/src/lib/harness-patterns/patterns/guardrail.server.ts
@@ -188,7 +188,8 @@ export function guardrail<T extends Record<string, unknown>>(
         return scope
       }
     },
-    config: resolved
+    config: resolved,
+    estimateTurns: (s) => pattern.estimateTurns?.(s) ?? 1
   }
 }
 

--- a/ui/src/lib/harness-patterns/patterns/hook.server.ts
+++ b/ui/src/lib/harness-patterns/patterns/hook.server.ts
@@ -90,6 +90,9 @@ export function hook<T extends Record<string, unknown>>(
         return scope
       }
     },
-    config: resolved
+    config: resolved,
+    // Background hooks don't add perceived turns; sync hooks delegate to child.
+    estimateTurns: (s) =>
+      config.background ? 0 : pattern.estimateTurns?.(s) ?? 1
   }
 }

--- a/ui/src/lib/harness-patterns/patterns/judge.server.ts
+++ b/ui/src/lib/harness-patterns/patterns/judge.server.ts
@@ -107,6 +107,7 @@ export function judge<T extends JudgeData>(
         return scope
       }
     },
-    config: resolved
+    config: resolved,
+    estimateTurns: () => 1
   }
 }

--- a/ui/src/lib/harness-patterns/patterns/parallel.server.ts
+++ b/ui/src/lib/harness-patterns/patterns/parallel.server.ts
@@ -10,6 +10,7 @@ import type {
   PatternConfig
 } from '../types'
 import { trackEvent, resolveConfig, createEvent } from '../context.server'
+import { emitLive } from '../live-event-context.server'
 
 assertServerOnImport()
 
@@ -50,13 +51,22 @@ export function parallel<T extends Record<string, unknown>>(
           )
         )
 
-        // Merge fulfilled events; log rejected branches
+        // Merge fulfilled events; log rejected branches.
+        // Branch boundary events also fire live so progress UIs see them.
         for (const [i, r] of results.entries()) {
           if (r.status === 'fulfilled') {
             const branchId = patterns[i].config.patternId ?? patterns[i].name
-            scope.events.push(createEvent('pattern_enter', branchId, { pattern: patterns[i].name }))
+            const branchMaxTurns = (patterns[i].config as { maxTurns?: number }).maxTurns
+            const enterEvt = createEvent('pattern_enter', branchId, {
+              pattern: patterns[i].name,
+              ...(branchMaxTurns !== undefined ? { maxTurns: branchMaxTurns } : {})
+            })
+            scope.events.push(enterEvt)
+            emitLive(enterEvt)
             scope.events.push(...r.value.events)
-            scope.events.push(createEvent('pattern_exit', branchId, { status: 'completed' }))
+            const exitEvt = createEvent('pattern_exit', branchId, { status: 'completed' })
+            scope.events.push(exitEvt)
+            emitLive(exitEvt)
             scope.data = { ...scope.data, ...r.value.data }
           } else {
             trackEvent(scope, 'error', {

--- a/ui/src/lib/harness-patterns/patterns/parallel.server.ts
+++ b/ui/src/lib/harness-patterns/patterns/parallel.server.ts
@@ -82,6 +82,9 @@ export function parallel<T extends Record<string, unknown>>(
         return scope
       }
     },
-    config: resolved
+    config: resolved,
+    // Branches run concurrently; user-perceived duration tracks the longest one.
+    estimateTurns: (s) =>
+      Math.max(...patterns.map((p) => p.estimateTurns?.(s) ?? 1))
   }
 }

--- a/ui/src/lib/harness-patterns/patterns/router.server.ts
+++ b/ui/src/lib/harness-patterns/patterns/router.server.ts
@@ -25,6 +25,7 @@ import type {
 } from '../types'
 import { DIRECT_RESPONSE_ROUTE } from '../types'
 import { trackEvent, resolveConfig, createEvent, createScope } from '../context.server'
+import { emitLive } from '../live-event-context.server'
 import { getRequestSettings } from '../../settings-context.server'
 import { stripThinkBlocks } from '../content-transforms'
 import { trimToFit, getContextWindow } from '../token-budget.server'
@@ -239,15 +240,23 @@ export function routes<T extends RouterData & Record<string, unknown>>(
       const childId = pattern.config.patternId ?? pattern.name
       const childScope = createScope<T>(childId, scope.data)
 
-      scope.events.push(
-        createEvent('pattern_enter', childId, { pattern: pattern.name, route: routeName })
-      )
+      // Surface the dispatched pattern's maxTurns on its boundary event so
+      // downstream consumers (UI progress) can size their indicators.
+      const childMaxTurns = (pattern.config as { maxTurns?: number }).maxTurns
+      const enterEvent = createEvent('pattern_enter', childId, {
+        pattern: pattern.name,
+        route: routeName,
+        ...(childMaxTurns !== undefined ? { maxTurns: childMaxTurns } : {})
+      })
+      scope.events.push(enterEvent)
+      emitLive(enterEvent)
+
       const childResult = await pattern.fn(childScope, view)
       // Merge child events and data back into routes' scope
       scope.events.push(...childResult.events)
-      scope.events.push(
-        createEvent('pattern_exit', childId, { status: 'completed' })
-      )
+      const exitEvent = createEvent('pattern_exit', childId, { status: 'completed' })
+      scope.events.push(exitEvent)
+      emitLive(exitEvent)
       scope.data = childResult.data
 
       return scope

--- a/ui/src/lib/harness-patterns/patterns/router.server.ts
+++ b/ui/src/lib/harness-patterns/patterns/router.server.ts
@@ -184,7 +184,8 @@ export function router<T extends RouterData>(
   return {
     name: 'router',
     fn,
-    config: resolved
+    config: resolved,
+    estimateTurns: () => 1
   }
 }
 
@@ -261,6 +262,11 @@ export function routes<T extends RouterData & Record<string, unknown>>(
 
       return scope
     },
-    config: resolved
+    config: resolved,
+    // Worst-case projection: route is picked at runtime, so the longest branch
+    // drives perceived progress duration. UI can refine downward once the
+    // dispatched branch's `pattern_enter` arrives.
+    estimateTurns: (s) =>
+      Math.max(...Object.values(patternMap).map((p) => p.estimateTurns?.(s) ?? 1))
   }
 }

--- a/ui/src/lib/harness-patterns/patterns/simpleLoop.server.ts
+++ b/ui/src/lib/harness-patterns/patterns/simpleLoop.server.ts
@@ -163,11 +163,14 @@ export function simpleLoop<T extends SimpleLoopData>(
           )
           action = controllerResult.action
 
-          // Track controller action event with LLM call data
+          // Track controller action event with LLM call data.
+          // `turn` and `maxTurns` are surfaced so live consumers can size
+          // their progress indicators without reading the pattern config
+          // (which doesn't capture settings.maxToolTurns).
           trackEvent(
             scope,
             'controller_action',
-            { action } as ControllerActionEventData,
+            { action, turn, maxTurns } as ControllerActionEventData,
             resolved.trackHistory,
             controllerResult.llmCall
           )

--- a/ui/src/lib/harness-patterns/patterns/simpleLoop.server.ts
+++ b/ui/src/lib/harness-patterns/patterns/simpleLoop.server.ts
@@ -301,6 +301,7 @@ export function simpleLoop<T extends SimpleLoopData>(
   return {
     name: 'simpleLoop',
     fn,
-    config: resolved
+    config: resolved,
+    estimateTurns: (s) => config?.maxTurns ?? s.maxToolTurns
   }
 }

--- a/ui/src/lib/harness-patterns/patterns/synthesizer.server.ts
+++ b/ui/src/lib/harness-patterns/patterns/synthesizer.server.ts
@@ -329,6 +329,7 @@ export function synthesizer<T extends SynthesizerData>(
   return {
     name: 'synthesizer',
     fn,
-    config: resolved
+    config: resolved,
+    estimateTurns: () => 1
   }
 }

--- a/ui/src/lib/harness-patterns/patterns/withApproval.server.ts
+++ b/ui/src/lib/harness-patterns/patterns/withApproval.server.ts
@@ -136,7 +136,9 @@ export function withApproval<T extends WithApprovalData>(
   return {
     name: 'withApproval',
     fn,
-    config: resolved
+    config: resolved,
+    // Approval gate doesn't add work — delegate to the wrapped pattern.
+    estimateTurns: (s) => wrappedPattern.estimateTurns?.(s) ?? 1
   }
 }
 

--- a/ui/src/lib/harness-patterns/types.ts
+++ b/ui/src/lib/harness-patterns/types.ts
@@ -408,6 +408,13 @@ export interface ToolResultEventData {
 /** Data payload for controller_action event */
 export interface ControllerActionEventData {
   action: import('../../../baml_client/types').ControllerAction
+  /** 0-indexed turn within this loop pass — set by simpleLoop / actorCritic. */
+  turn?: number
+  /** Effective max turns for this loop instance (post-settings resolution).
+   *  Loop patterns include this so consumers (e.g. progress UI) can size
+   *  themselves without having to read the pattern config — which doesn't
+   *  reflect runtime overrides like `settings.maxToolTurns`. */
+  maxTurns?: number
 }
 
 /** Data payload for critic_result event */

--- a/ui/src/lib/harness-patterns/types.ts
+++ b/ui/src/lib/harness-patterns/types.ts
@@ -251,11 +251,24 @@ export type ScopedPattern<T> = (
   view: EventView
 ) => Promise<PatternScope<T>>
 
+/** Settings consulted by `estimateTurns` — patterns whose effective `maxTurns`
+ *  / `maxRetries` come from runtime settings need these to project a cost. */
+export interface TurnEstimateSettings {
+  maxToolTurns: number
+  maxRetries: number
+}
+
 /** Configured pattern with metadata for chain/harness */
 export interface ConfiguredPattern<T> {
   name: string
   fn: ScopedPattern<T>
   config: PatternConfig
+  /** Optional projection of how many "turns" this pattern will produce.
+   *  Used by `harness()` to stamp `chainTurnEstimate` on the initial
+   *  `user_message` event so progress consumers can size themselves up front.
+   *  Wrapper patterns delegate to their child(ren). Returning `undefined` is
+   *  equivalent to a contribution of 1. */
+  estimateTurns?: (settings: TurnEstimateSettings) => number
 }
 
 // ============================================================================
@@ -374,6 +387,10 @@ export interface SynthesizerData {
 /** Data payload for user_message event */
 export interface UserMessageEventData {
   content: string
+  /** Best-effort estimate of total chain turns, set by `harness()` from the
+   *  composed patterns' `estimateTurns` projections. UI progress bars use
+   *  this as the initial denominator before any pattern_enter arrives. */
+  chainTurnEstimate?: number
 }
 
 /** Data payload for assistant_message event */

--- a/ui/src/lib/harness-patterns/types.ts
+++ b/ui/src/lib/harness-patterns/types.ts
@@ -145,6 +145,9 @@ export interface PatternConfig {
   viewConfig?: ViewConfig
   /** Error severity classification for this pattern (default varies by pattern) */
   errorSeverity?: 'recoverable' | 'irrecoverable'
+  /** Stream this pattern's events to the harness `onEvent` listener as they're
+   *  tracked, instead of buffering until commit. Default: false. */
+  liveEvents?: boolean
 }
 
 // ============================================================================
@@ -415,6 +418,9 @@ export interface CriticResultEventData {
 /** Data payload for pattern_enter event */
 export interface PatternEnterEventData {
   pattern: string
+  /** Pattern's configured maxTurns (simpleLoop/actorCritic) — used by the UI
+   *  progress bar to compute fill ratio per controller_action. */
+  maxTurns?: number
 }
 
 /** Data payload for pattern_exit event */

--- a/ui/src/lib/settings.ts
+++ b/ui/src/lib/settings.ts
@@ -42,6 +42,10 @@ export const MODEL_CONTEXT_WINDOWS: Record<string, number> = {
   CustomHaiku: 200_000,
   CustomOpus4: 200_000,
   CustomSonnet4: 200_000,
+  // Cerebras — separate-quota safety nets at end of each fallback chain
+  CerebrasGPT120B: 131_072,        // gpt-oss-120b
+  CerebrasZaiGLM4_7: 131_072,      // zai-glm-4.7
+  CerebrasQwen3_235B: 131_072,     // qwen-3-235b-a22b-instruct-2507
   // Local (local-client.baml, not used in chains)
   LocalGLM: 16_384,
 }


### PR DESCRIPTION
## Summary

Implements #24 — streams harness events live to the UI as they're tracked (instead of buffering until commit) and surfaces a chain-aware progress bar with crossfading status text. Plus several refinements landed during real-world testing.

### Library — `harness-patterns/`

- **`PatternConfig.liveEvents?: boolean`** — opt-in per pattern. When set, that pattern's `trackEvent` calls forward events to the harness `onEvent` listener immediately, instead of waiting for `commitEvents`.
- **AsyncLocalStorage frame** (`live-event-context.server.ts`) carries the listener through the call stack — mirrors the existing `settings-context.server.ts` pattern. Wrapper patterns inherit live behaviour for free; no signature changes to `parallel`/`withApproval`/`guardrail`/`hook`.
- **`runChain` dedups commit-time emissions** for events already delivered live (by event id), so listeners never see duplicates.
- **`routes` and `parallel` emit child `pattern_enter` / `pattern_exit` live** with the child's `maxTurns` surfaced so progress consumers can size themselves.
- **`ConfiguredPattern.estimateTurns?: (settings) => number`** — new neutral primitive. Each pattern factory implements:
  - `simpleLoop` → `config.maxTurns ?? settings.maxToolTurns`
  - `actorCritic` → `config.maxRetries ?? settings.maxRetries`
  - `router` / `synthesizer` / `judge` → `1`
  - `routes(map)` / `parallel(ps)` → `max` over branches
  - `withApproval(p)` / `guardrail(p)` → delegate to `p`
  - `hook(p)` → `0` if background, else delegate
  - `chain(ps)` → sum of children
- **`harness()` / `resumeHarness()` / `continueSession()`** sum `estimateTurns` across top-level patterns and stamp `chainTurnEstimate` on the initial `user_message` event, which is also forwarded live so SSE consumers receive the upfront projection before any pattern runs.
- **`ControllerActionEventData` extended** with `turn` and `maxTurns` so progress UIs see the runtime-resolved (settings-driven) loop size.
- **Bug fix**: `resolveConfig` was silently dropping unknown `PatternConfig` fields — now spreads the caller's config first so `liveEvents` (and any future opt-in flags) propagate.

### UI — `components/`

- **`useChainProgress`** — purely UI display logic, kept out of `harness-patterns/`. Reads `chainTurnEstimate` to seed `maxProjection` and never grows the seed. `currentTurn` advances on `controller_action` / non-final `assistant_message` / leaf `pattern_exit`. `finish()` snaps current to max so the bar fills smoothly to 100% even when the chosen route is shorter than the worst case. Single `setSnapshot` per ingest (fixes the off-by-one we saw in testing).
- **`LiveProgressBar`** — Ark UI `Progress.{Root, Track, Range, Label}` with UnoCSS attributify. Drops the `n/total` text; bar uses fixed `max = maxProjection`; smoother easing (`cubic-bezier(0.22, 1, 0.36, 1)`); **350 ms mount delay** so direct router responses (typically <1s) finish before the bar would have appeared. Lives inside the message thread as a trailing slot in `ChatMessages`, styled as an in-progress assistant bubble.

### Default agent

- `liveEvents: true` on every top-level pattern (router, routes, simpleLoop, actorCritic, synthesizer)
- `rememberPriorTurns: false` on the loops so testing doesn't blow past TPM with cross-turn context inflation

### Library standalone framing

`harness-patterns/README.md` now opens with explicit boundary rules — this directory is the testbed for the eventual standalone npm package, so:
1. `harness-patterns/` MUST NOT import from `harness-client/` or `components/`
2. Pattern primitives are framework-neutral (no SolidJS, no UI types)
3. Runtime settings flow through AsyncLocalStorage, not function parameters
4. UI display logic (e.g. `useChainProgress`) lives in the consumer

### Cerebras safety net (also in this branch)

While testing, Groq 429 errors revealed `GroqGPT120B` was the last link in every fallback chain. Added three Cerebras clients (`CerebrasGPT120B`, `CerebrasZaiGLM4_7`, `CerebrasQwen3_235B`) at the end of `RouterFallback`, `ControllerFallback`, `CriticFallback`, `SynthesizerFallback`, `DescribeFallback`. Requires `CEREBRAS_API_KEY`.

## Tests

- New `estimateTurns.test.ts` covers each pattern factory's projection helper (default-agent shape projects to exactly 7).
- `useChainProgress.test.ts` rewritten for the seeded model — verifies `1/7 → 7/7` flow, no seed inflation, and that `finish()` snaps to 100%.
- `live-events.test.ts` covers ALS gating, dedup, and routes' live child boundary emission.
- **496/496 vitest tests passing**, TS error count unchanged at baseline.

## Test plan

- [x] Direct router response (conversational) — bar should NOT appear (350ms mount delay covers this)
- [x] Default agent neo4j query — bar shows `1/7 → 7/7` with crossfading status
- [x] Tool results stream live to Observability panel
- [x] All 24 vitest suites pass
- [x] No new TypeScript errors

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)