### PR TITLE
Tactical fixes + withReferences design doc (#30)

### DIFF
--- a/docs/harness-patterns/with-references.md
+++ b/docs/harness-patterns/with-references.md
@@ -1,0 +1,299 @@
+# withReferences — Design Doc
+
+> **Status:** Draft. Captures decisions reached in [issue #30](https://github.com/mknw/harness-playground/issues/30); precedes implementation.
+> **Supersedes:** #26, #29 (both marked `[SUPERSEDED by #30]`).
+> **Orthogonal:** #19 (synthetic `expand_data` tool — internal cross-turn).
+
+## 1. Problem
+
+Cross-pattern data flow is currently implicit, ad-hoc, and underspecified.
+
+**Concrete failure** (debugging session 2026-04-30, agent `default`):
+
+| Turn | User input | Route | What the controller saw |
+|---|---|---|---|
+| 3 | "search the web for postgres 18 release info" | web-search | (full web results) |
+| 4 | "add this info to the graph" | neo4j-query | `priorResults: []`, `intent: "Add this info to the graph"` |
+
+Turn 4's `neo4j-query` controller had no access to the postgres-18 data from turn 3. It received only "Add this info" as a user message — with no actual content. It spent 5 turns probing the schema and looking for related nodes, never attempted a write, hit `maxTurns` (silently — separate fix), and the synthesizer ended up summarizing turn 3's web results instead of describing the (non-existent) graph mutations.
+
+**Root cause:** there is no mechanism to recognize that data produced by an earlier pattern is relevant to the current one.
+
+The framework currently has *three* partial answers to this, each addressing one slice:
+
+| | Mechanism | Direction | Decision-maker |
+|---|---|---|---|
+| #19 | `expand_data` synthetic tool | Within one loop's execution | Controller LLM mid-loop |
+| #26 | Router pushes `references[]` | Across pattern boundaries | Router LLM at dispatch |
+| #29 | `priorTurnsScope: 'self'` | Across pattern boundaries | Static (patternId equality) |
+
+These are three *policies* for the same underlying question: **which prior data should this pattern see, expressed in what form, and who decides?**
+
+## 2. Goals / non-goals
+
+### Goals
+- Replace #26 and #29 with one declarative wrapper.
+- Keep #19 as the inner-loop counterpart (controller can opt to expand any compact ref mid-loop).
+- Zero changes to existing controller BAML signatures.
+- Operate at *pattern ingress*; egress is already covered by event tracking + `scheduleSummarization`.
+- Observable: every selection decision should leave a trace in `ctx.events`.
+
+### Non-goals
+- Producer-side declaration of refs (no `publishRefs` on patterns; everything in `ctx.events` is implicitly available).
+- Mid-loop relevance recomputation (selection happens once per pattern entry; refresh happens at the next pattern's entry).
+- Egress filtering or summarization (already in place).
+- Determining *which* model writes summaries (handled by existing `scheduleSummarization` / `DescribeFallback`).
+
+## 3. Reference taxonomy
+
+Two distinct kinds of cross-pattern data flow:
+
+```
+                            ╭─────────────────────────────────╮
+                            │  pattern (e.g. simpleLoop)      │
+                            │                                 │
+                            │  ┌─ controller turn 1 ─┐        │
+        external (ingress) ─┼──► priorResults        │  (internal)
+                            │  └─ controller turn 2 ─┘  ◄────┐│
+                            │     │ may call expand_data    ││
+                            │     ├─ tool_call              ││
+                            │     ╰─ tool_result  ──────────┘│
+                            ╰─────────────────────────────────╯
+```
+
+- **External (ingress)** — `withReferences` decides which compact refs to attach when a pattern is entered. Output: a `priorResults` array merged into the controller's BAML input.
+- **Internal (mid-loop)** — `expand_data` (#19) lets the controller, *during* its reasoning, pull the full body of any compact ref it received. Multiple ref_ids per call. Token-budget management is the controller's responsibility (with hard cap from the wrapper).
+
+These compose: `withReferences` attaches **summaries**; the loop optionally expands selected refs to **full content** (or full-but-trimmed) via `expand_data`.
+
+## 4. Mechanism
+
+On pattern entry, the wrapper:
+
+```
+1. Read tool_result events visible per scope/source filter
+   (excluding hidden / archived per existing data-stash semantics)
+2. Build candidate list: [{ ref_id, tool, summary, tool_args, ts }, ...]
+3. Skip if:
+   - Empty candidates → attach nothing, dispatch
+   - Single candidate → attach unconditionally, dispatch
+   - Cache hit on (intent_hash, stash_snapshot_hash) → reuse decision
+4. Otherwise: call b.ReferenceSelector(intent, recentMessages, candidates)
+   - Returns: ranked refs with reasons
+   - Cap by token budget (top-K that fit)
+5. Track reference_attached event with { candidates, selected, reasons }
+6. Set scope.data.attachedRefs (PriorResult[])
+7. Dispatch to wrapped pattern
+```
+
+The adapter layer (`baml-adapters.server.ts`) merges `scope.data.attachedRefs` into the BAML `turns_previous_runs: PriorResult[]` argument. The existing `LoopController` prompt already renders this block under `RESULTS FROM PREVIOUS TASKS:` — **no controller-prompt changes**.
+
+## 5. API
+
+```typescript
+import type { PriorResult, EventView } from '../types'
+
+export interface WithReferencesConfig extends PatternConfig {
+  /** Which patterns' tool_results are eligible. Default: 'global' */
+  scope?: 'self' | 'global'
+
+  /** Explicit patternId allow-list. Overrides scope when set. */
+  source?: string | string[]
+
+  /** Cap on attached refs. Default: 5 */
+  maxRefs?: number
+
+  /** Override default LLM-driven selector */
+  selector?: SelectorFn
+}
+
+export type SelectorFn = (input: {
+  intent: string
+  recentMessages: Array<{ role: 'user' | 'assistant', content: string }>
+  candidates: Array<{ ref_id: string, tool: string, summary: string, tool_args?: string, ts: number }>
+}) => Promise<{
+  selected: Array<{ ref_id: string, reason: string }>
+  reasoning: string
+}>
+
+export function withReferences<T>(
+  pattern: ConfiguredPattern<T>,
+  config?: WithReferencesConfig
+): ConfiguredPattern<T>
+```
+
+### Default selector
+
+```baml
+class ReferenceCandidate {
+  ref_id      string
+  tool        string
+  summary     string
+  tool_args   string?
+  ts_offset_s int  @description("Seconds before now")
+}
+
+class ReferenceSelection {
+  ref_id string
+  reason string
+}
+
+class ReferenceSelectorResult {
+  reasoning string  @description("Why these were chosen / why none were chosen")
+  selected  ReferenceSelection[]
+}
+
+function ReferenceSelector(
+  intent: string,
+  recent_messages: Message[],
+  candidates: ReferenceCandidate[],
+) -> ReferenceSelectorResult {
+  client DescribeFallback
+  prompt #"
+    {{ _.role("system") }}
+    Select prior tool results that are relevant to the user's current intent.
+
+    RULES:
+    - Rank candidates by relevance, but include any that are plausibly useful.
+    - Return zero candidates only if **all** items are completely unrelated to the intent and recent dialogue.
+    - Prefer recent items over older ones when relevance is similar.
+    - Reasons should be one short sentence each.
+
+    {{ _.role("user") }}
+    INTENT: {{ intent }}
+
+    RECENT DIALOGUE:
+    {% for m in recent_messages %}
+    - {{ m.role }}: {{ m.content }}
+    {% endfor %}
+
+    CANDIDATES:
+    {% for c in candidates %}
+    - id: {{ c.ref_id }}
+      tool: {{ c.tool }}
+      summary: {{ c.summary }}
+      {% if c.tool_args %}args: {{ c.tool_args }}{% endif %}
+      ts_offset: {{ c.ts_offset_s }}s ago
+    {% endfor %}
+
+    {{ ctx.output_format }}
+  "#
+}
+```
+
+Bias toward inclusion: cap by **token budget** at the wrapper, never by relevance score. The selector ranks; the wrapper truncates.
+
+## 6. Observability — `reference_attached` event
+
+New `EventType`: `'reference_attached'`. Payload:
+
+```typescript
+interface ReferenceAttachedEventData {
+  candidates: Array<{ ref_id: string, tool: string, summary: string }>
+  selected:   Array<{ ref_id: string, reason: string }>
+  reasoning:  string  // The selector's overall justification
+  skipped?:   'empty' | 'single' | 'cached'  // When the selector wasn't called
+}
+```
+
+UI integration: the observability panel shows attachments as their own row (similar to `controller_action`). Post-mortem flow: filter for `reference_attached` events on the failing turn → confirm selector saw the relevant ref, see why it was/wasn't selected.
+
+## 7. Skip optimizations
+
+| Condition | Behavior |
+|---|---|
+| Empty eligible stash | Skip entirely; track `reference_attached` with `skipped='empty'`, `selected=[]` |
+| Single eligible candidate | Attach unconditionally; track with `skipped='single'`, `selected=[that one]` |
+| Cache hit on `(intent_hash, stash_snapshot_hash)` | Reuse last decision; track with `skipped='cached'` |
+
+`stash_snapshot_hash` = hash of `(eligible_ref_ids.sorted, ref_summaries)`. Both are stable within a turn and slow-changing across turns, so cache hit rate is high.
+
+## 8. Plumbing — adapter merge
+
+```typescript
+// baml-adapters.server.ts (sketch)
+
+// In createLoopControllerAdapter:
+const attachedRefs = (scope.data.attachedRefs as PriorResult[] | undefined) ?? []
+const mergedPriorResults = dedupByRefId([
+  ...attachedRefs,
+  ...priorResultsFromExistingPath
+])
+```
+
+Dedup by `ref_id` — if `withReferences` and the existing `priorTurnCount` mechanism both surface the same event, count it once.
+
+## 9. Eval suite (canonical cases)
+
+A `ui/src/__tests__/lib/harness-patterns/with-references-eval.test.ts` file with manually-curated cases:
+
+| Case | Stash | Intent | Expected selection |
+|---|---|---|---|
+| **postgres-18** (the trigger case) | web-search returned full postgres-18 release content | "Add this info to the graph" | postgres-18 ref **must be selected** |
+| **stale on-topic** | neo4j query result from 5 turns ago about a different schema area | "list all Person nodes" | Could be either; not a hard requirement |
+| **conversational unrelated** | Several tool results from earlier in session | "thanks!" | **Empty selection** (hard floor) |
+| **multiple relevant** | 3 web searches on the same topic | "summarize what we found" | All 3 selected (within budget) |
+| **scope=self** | Mix of neo4j and web results, wrapper on neo4j-query | (anything) | Only neo4j-tagged candidates eligible regardless of selection |
+
+Each case stubs the LLM (or runs against the real fallback model with a recorded fixture) and asserts the `selected` array matches expectations.
+
+## 10. Implementation plan
+
+1. **Types** — `WithReferencesConfig`, `SelectorFn`, `ReferenceAttachedEventData`, new `EventType`.
+2. **BAML** — `b.ReferenceSelector` function in `baml_src/with-references.baml`.
+3. **Pattern** — `ui/src/lib/harness-patterns/patterns/with-references.server.ts`.
+4. **Adapter merge** — extend `baml-adapters.server.ts` to read `scope.data.attachedRefs` and merge into `priorResults`.
+5. **Cache** — small in-memory `Map<sessionId, Map<hash, decision>>` cleared on session end.
+6. **Tests** — unit tests for skip optimizations + eval suite.
+7. **Docs** — update `harness-patterns/README.md` API reference + add an example.
+8. **Migration** — close #26 / #29; update `default` agent to wrap routes with `withReferences`.
+
+## 11. Open questions
+
+- **Default `scope`**: lean `'global'`. Consumers can tighten with `'self'` or explicit `source`.
+- **Token budget source**: ride on existing `MODEL_CONTEXT_WINDOWS` (deduct from inner pattern's budget), or take an explicit `maxTokens` config? Lean: derive from inner pattern's BAML client window minus a fixed reserve.
+- **`expand_data` budget enforcement**: when the loop expands multiple refs in one call, who enforces the cap? Lean: wrapper sets a residual budget on `scope.data.expansionBudget`; `simpleLoop` consumes per call. Out of scope for v1; track as follow-up.
+- **Composition with `parallel`**: each branch enters separately. Should each branch get its own selector call, or share one? Lean: per-branch (different intents may apply).
+- **Cache invalidation**: `(intent_hash, stash_snapshot_hash)` is per-session. What about *across* sessions (e.g., long-lived agent)? Lean: session-scoped only.
+
+## 12. Alternatives considered
+
+### A. Policy-soup wrapper (rejected)
+
+```typescript
+withReferences(pattern, {
+  policy: 'auto-llm' | 'pushed-by-upstream' | 'self-scoped' | 'declared',
+  // ... different fields per policy
+})
+```
+
+Rejected: forces every consumer to learn four mechanisms, even for trivial cases. The taxonomy of policies is *implementer's* mental model, not consumer's.
+
+### B. Producer-side declaration (rejected)
+
+```typescript
+simpleLoop(controller, tools, {
+  publishRefs: 'tool_results' | 'last' | (e) => boolean
+})
+```
+
+Rejected: pollutes every pattern with a new field. UnifiedContext already has every event; making patterns redundantly *publish* refs adds API surface for no gain.
+
+### C. Per-pattern config flags (rejected — current state)
+
+`#26` adds a router field; `#29` adds a simpleLoop field. Each new flag covers one direction of one channel. Doesn't compose; encourages future fragmentation.
+
+### D. Mutate the user_message text inline (rejected)
+
+Inject `[REF: ev-abc summary: ...]` directly into the user message string. Rejected: corrupts the actual user message, makes synthesizer's `view.fromAll().ofType('user_message')` queries return mutated text, complicates downstream display.
+
+## 13. Out of scope
+
+- Cross-session reference reuse (long-term memory).
+- Vector-similarity pre-filtering as cheap heuristic (good v2 optimization).
+- "Ask user for confirmation when budget exceeded" (a separate guardrail-style pattern).
+- Refactoring `priorTurnCount` (orthogonal — the existing turn-window mechanism stays as a different feature).
+
+---
+
+**Last updated:** 2026-04-30

--- a/ui/baml_src/clients.baml
+++ b/ui/baml_src/clients.baml
@@ -90,7 +90,6 @@ client<llm> OpenAIGPT5 {
   options {
     model "gpt-5"
     api_key env.OPENAI_API_KEY
-    max_tokens 4096
   }
 }
 
@@ -100,7 +99,6 @@ client<llm> OpenAIGPT5Mini {
   options {
     model "gpt-5-mini"
     api_key env.OPENAI_API_KEY
-    max_tokens 4096
   }
 }
 
@@ -111,7 +109,6 @@ client<llm> OpenAIGPT5Nano {
   options {
     model "gpt-5-nano"
     api_key env.OPENAI_API_KEY
-    max_tokens 4096
   }
 }
 
@@ -121,7 +118,6 @@ client<llm> OpenAIGPT5Chat {
   options {
     model "gpt-5"
     api_key env.OPENAI_API_KEY
-    max_tokens 4096
   }
 }
 
@@ -218,7 +214,7 @@ client<llm> ControllerFallback {
   options {
     // 1. GroqGPT120B — gpt-oss-120b, fastest; 2. OpenRouterNemotron120B — when Groq fails structured output
     // on large context; 3. OpenAIGPT5Chat — reliable OpenAI fallback
-    strategy [OpenRouterNemotron120B, OpenAIGPT5, OpenRouterMiniMax2_5, GroqGPT120B]
+    strategy [OpenRouterNemotron120B, OpenRouterMiniMax2_5, GroqGPT120B, OpenAIGPT5]
   }
 }
 
@@ -270,6 +266,6 @@ retry_policy Exponential {
     type exponential_backoff
     delay_ms 300
     multiplier 1.5
-    max_delay_ms 10000
+    max_delay_ms 2000
   }
 }

--- a/ui/src/__tests__/lib/harness-patterns/patterns/event-view.test.ts
+++ b/ui/src/__tests__/lib/harness-patterns/patterns/event-view.test.ts
@@ -126,6 +126,46 @@ describe('EventViewImpl', () => {
       expect(result).toHaveLength(0)
     })
 
+    it('should resolve to the most-recently-active pattern across multi-turn sessions', async () => {
+      // Regression test for: in a 4-turn session where web-search ran in turn 3
+      // and neo4j-query ran in turn 4, fromLastPattern() must resolve to
+      // neo4j-query (last *activated*), not web-search (last *introduced*).
+      const { createEventView } = await import('../../../../lib/harness-patterns/patterns/event-view.server')
+
+      const events: ContextEvent[] = [
+        // Turn 2: neo4j-query first appears
+        { type: 'pattern_enter', ts: 10, patternId: 'neo4j-query', data: {} },
+        { type: 'tool_result', ts: 11, patternId: 'neo4j-query', data: { tool: 'read_neo4j_cypher', result: 'turn2-data', success: true } },
+        { type: 'pattern_exit', ts: 12, patternId: 'neo4j-query', data: {} },
+        { type: 'pattern_enter', ts: 13, patternId: 'response-synth', data: {} },
+        { type: 'pattern_exit', ts: 14, patternId: 'response-synth', data: {} },
+        // Turn 3: web-search first appears (LATER first-appearance than neo4j-query)
+        { type: 'pattern_enter', ts: 20, patternId: 'web-search', data: {} },
+        { type: 'tool_result', ts: 21, patternId: 'web-search', data: { tool: 'search', result: 'turn3-web-data', success: true } },
+        { type: 'pattern_exit', ts: 22, patternId: 'web-search', data: {} },
+        { type: 'pattern_enter', ts: 23, patternId: 'response-synth', data: {} },
+        { type: 'pattern_exit', ts: 24, patternId: 'response-synth', data: {} },
+        // Turn 4: neo4j-query runs again (most recent ACTIVATION)
+        { type: 'pattern_enter', ts: 30, patternId: 'neo4j-query', data: {} },
+        { type: 'tool_result', ts: 31, patternId: 'neo4j-query', data: { tool: 'read_neo4j_cypher', result: 'turn4-data', success: true } },
+        { type: 'pattern_exit', ts: 32, patternId: 'neo4j-query', data: {} },
+        // Synthesizer about to evaluate fromLastPattern()
+        { type: 'pattern_enter', ts: 33, patternId: 'response-synth', data: {} },
+      ]
+
+      const ctx = createMockContext(events)
+      const view = createEventView(ctx, undefined, 'response-synth')
+      const result = view.fromLastPattern().get()
+
+      // Must resolve to turn-4 neo4j-query, not turn-3 web-search
+      expect(result.every(e => e.patternId === 'neo4j-query')).toBe(true)
+      const toolResult = result.find(e => e.type === 'tool_result')
+      expect(toolResult).toBeDefined()
+      expect((toolResult!.data as Record<string, unknown>).result).toBe('turn4-data')
+      // Must NOT include web-search events
+      expect(result.find(e => e.patternId === 'web-search')).toBeUndefined()
+    })
+
     it('should only return events from the last execution when a pattern runs multiple times', async () => {
       const { createEventView } = await import('../../../../lib/harness-patterns/patterns/event-view.server')
 

--- a/ui/src/__tests__/lib/harness-patterns/patterns/simpleLoop.test.ts
+++ b/ui/src/__tests__/lib/harness-patterns/patterns/simpleLoop.test.ts
@@ -394,6 +394,100 @@ describe('simpleLoop execution', () => {
     expect(JSON.stringify(errorEvents[0].data)).toContain('Controller crashed')
   })
 
+  it('should track recoverable error event when maxTurns is reached without Return', async () => {
+    const { simpleLoop } = await import('../../../../lib/harness-patterns/patterns/simpleLoop.server')
+    const { createScope } = await import('../../../../lib/harness-patterns/context.server')
+    const { createEventView } = await import('../../../../lib/harness-patterns/patterns')
+
+    // callTool always succeeds — no early break via tool failure
+    callToolMock.mockResolvedValue({
+      success: true,
+      data: { ok: true }
+    })
+
+    // Controller never signals completion (no Return / is_final)
+    const mockController = vi.fn().mockResolvedValue({
+      action: mockAction({ tool_name: 'read_neo4j_cypher', tool_args: '{"query":"x"}' }),
+      llmCall: undefined
+    })
+
+    const pattern = simpleLoop(mockController, ['read_neo4j_cypher', 'Return'], {
+      patternId: 'test',
+      maxTurns: 3
+    })
+
+    const scope = createScope('test', {})
+    const mockContext = {
+      sessionId: 'test',
+      createdAt: Date.now(),
+      events: [
+        { type: 'user_message' as const, ts: Date.now(), patternId: 'harness', data: { content: 'test' } }
+      ],
+      status: 'running' as const,
+      data: {},
+      input: 'test'
+    }
+    const view = createEventView(mockContext)
+
+    const result = await pattern.fn(scope, view)
+
+    // Controller was called exactly maxTurns times (loop never broke early)
+    expect(mockController).toHaveBeenCalledTimes(3)
+
+    // Loop should have tracked a recoverable exhaustion event
+    const errorEvents = result.events.filter(e => e.type === 'error')
+    expect(errorEvents.length).toBe(1)
+    const errData = errorEvents[0].data as { error: string; severity?: string; turn?: number }
+    expect(errData.error).toMatch(/exhausted/i)
+    expect(errData.error).toContain('3')  // maxTurns mentioned
+    expect(errData.severity).toBe('recoverable')
+    // Partial results from completed turns should still exist as tool_result events
+    const toolResults = result.events.filter(e => e.type === 'tool_result')
+    expect(toolResults.length).toBe(3)
+  })
+
+  it('should NOT track exhaustion error when controller signals Return', async () => {
+    const { simpleLoop } = await import('../../../../lib/harness-patterns/patterns/simpleLoop.server')
+    const { createScope } = await import('../../../../lib/harness-patterns/context.server')
+    const { createEventView } = await import('../../../../lib/harness-patterns/patterns')
+
+    callToolMock.mockResolvedValue({ success: true, data: { ok: true } })
+
+    const mockController = vi.fn()
+      .mockResolvedValueOnce({
+        action: mockAction({ tool_name: 'read_neo4j_cypher', tool_args: '{}' }),
+        llmCall: undefined
+      })
+      .mockResolvedValueOnce({
+        action: mockFinalAction('Done'),
+        llmCall: undefined
+      })
+
+    const pattern = simpleLoop(mockController, ['read_neo4j_cypher', 'Return'], {
+      patternId: 'test',
+      maxTurns: 5
+    })
+
+    const scope = createScope('test', {})
+    const mockContext = {
+      sessionId: 'test',
+      createdAt: Date.now(),
+      events: [
+        { type: 'user_message' as const, ts: Date.now(), patternId: 'harness', data: { content: 'test' } }
+      ],
+      status: 'running' as const,
+      data: {},
+      input: 'test'
+    }
+    const view = createEventView(mockContext)
+
+    const result = await pattern.fn(scope, view)
+
+    // Clean exit via Return — no error events should be tracked
+    const errorEvents = result.events.filter(e => e.type === 'error')
+    expect(errorEvents.length).toBe(0)
+  })
+
   it('should accumulate results across iterations', async () => {
     const { simpleLoop } = await import('../../../../lib/harness-patterns/patterns/simpleLoop.server')
     const { createScope } = await import('../../../../lib/harness-patterns/context.server')

--- a/ui/src/lib/harness-patterns/patterns/event-view.server.ts
+++ b/ui/src/lib/harness-patterns/patterns/event-view.server.ts
@@ -395,17 +395,26 @@ export class EventViewImpl implements IEventView {
   // Internal Helpers
   // ─────────────────────────────────────────────────────────────────────────
 
-  /** Get unique pattern IDs in order of first pattern_enter */
+  /**
+   * Get unique pattern IDs ordered by *most recent* pattern_enter.
+   *
+   * Ordering by last-appearance (not first-appearance) is critical for
+   * multi-turn sessions: when a pattern was introduced in an earlier turn
+   * but a different pattern just executed in the current turn,
+   * fromLastPattern() must resolve to the *just-executed* one, not to
+   * whichever pattern happened to be introduced latest historically.
+   */
   private getPatternIds(): string[] {
     const seen = new Set<string>()
-    return this.ctx.events
-      .filter((e) => e.type === 'pattern_enter')
-      .map((e) => e.patternId)
-      .filter((id) => {
-        if (seen.has(id)) return false
-        seen.add(id)
-        return true
-      })
+    const reverseOrder: string[] = []
+    for (let i = this.ctx.events.length - 1; i >= 0; i--) {
+      const e = this.ctx.events[i]
+      if (e.type !== 'pattern_enter') continue
+      if (seen.has(e.patternId)) continue
+      seen.add(e.patternId)
+      reverseOrder.push(e.patternId)
+    }
+    return reverseOrder.reverse()
   }
 
   /** Get the ID of the last pattern that entered (excluding self) */

--- a/ui/src/lib/harness-patterns/patterns/simpleLoop.server.ts
+++ b/ui/src/lib/harness-patterns/patterns/simpleLoop.server.ts
@@ -103,6 +103,7 @@ export function simpleLoop<T extends SimpleLoopData>(
     let hasError = false
     let errorMessage: string | undefined
     let errorTurn: number | undefined
+    let exitedViaReturn = false
 
     // Build structured references to tool results from previous tasks.
     // These are passed as turns_previous_runs (separate from the current task's turns)
@@ -190,6 +191,7 @@ export function simpleLoop<T extends SimpleLoopData>(
             lastAction: action,
             turn
           }
+          exitedViaReturn = true
           break
         }
 
@@ -283,6 +285,16 @@ export function simpleLoop<T extends SimpleLoopData>(
           severity: resolved.errorSeverity,
           hint: getErrorHint(errorMessage ?? ''),
           turn: errorTurn,
+        } as ErrorEventData, true)
+      } else if (!exitedViaReturn && turns.length > 0) {
+        // Loop exhausted maxTurns without controller signaling completion.
+        // Surface as a recoverable error so the synthesizer can warn the user;
+        // partial results from completed turns are still preserved on scope.
+        trackEvent(scope, 'error', {
+          error: `Loop exhausted: reached maxTurns (${maxTurns}) without 'Return' or is_final from the controller. Partial results from ${turns.length} completed turn(s) are preserved.`,
+          severity: 'recoverable',
+          hint: 'The controller may have needed more turns to finish. Consider increasing maxToolTurns in settings, or simplifying the task.',
+          turn: turns.length - 1,
         } as ErrorEventData, true)
       }
 


### PR DESCRIPTION
## Summary

- **fix** `event-view.server.ts` — `getPatternIds()` now orders by *last* `pattern_enter` (was *first*). Resolves a multi-turn bug where `fromLastPattern()` shadowed a pattern that just executed with one introduced earlier in the session. Synthesizer was receiving the prior turn's pattern events.
- **fix** `simpleLoop.server.ts` — track a recoverable `error` event when the loop exhausts `maxTurns` without `Return` / `is_final`. Synthesizer's existing `view.hasErrors()` / `view.lastError()` surfaces it to the user as a warning. Partial results from completed turns are preserved.
- **docs** new design doc `docs/harness-patterns/with-references.md` capturing decisions for the `withReferences` meta-pattern (#30).

Both fixes are listed as prerequisite work in #30's "Next steps" checkbox — they ensure accurate post-mortem inspection before any new pattern lands.

## Issues

- Refs #30 — `withReferences` meta-pattern (this PR delivers two of its checklist items: the tactical fix and the formal design doc).
- Supersedes #26 and #29 (both already amended with `[SUPERSEDED by #30]` and supersession comments; will close once #30 lands — not in this PR).
- Adjacent (filed in the same session, not addressed here): #31 (capture failed-call prompt/variables for post-mortem), #32 (harness-internal data-processing tools).

## Test plan

- [x] `pnpm vitest run src/__tests__/lib/harness-patterns/patterns/event-view.test.ts src/__tests__/lib/harness-patterns/patterns/simpleLoop.test.ts` → 79/79 pass (3 new)
- [x] `pnpm vitest run src/__tests__/lib/harness-patterns` → 391/391 pass
- [ ] Manual: 4-turn conversation against `default` agent — verify multi-turn synthesizer sees the just-active pattern's events
- [x] Manual: force `simpleLoop` exhaustion (set low `maxToolTurns` in settings, ask a question that needs more turns) — verify a "Loop exhausted" warning renders in the chat
- [ ] Skim `docs/harness-patterns/with-references.md` end-to-end before approving — this is the design surface that subsequent implementation will lean on

## Notes

- `baml_src/clients.baml` has unrelated WIP changes in the working tree (max_tokens removal, ControllerFallback strategy reorder, retry max_delay). Intentionally included in this branch as they make testing this branch faster.
- No new dependencies. No type-check regressions in modified files (pre-existing TS errors in unrelated files remain unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
