### PR TITLE
fix(ui): observability tab overhaul

### DIFF
--- a/docs/UI_ARCHITECTURE.md
+++ b/docs/UI_ARCHITECTURE.md
@@ -316,14 +316,14 @@ Main container combining sidebar and chat area:
 - Clearing the session on agent switch
 
 #### 6. SupportPanel.tsx
-Tabbed right panel. **Observability is the default tab.** Uses `lazyMount` + `unmountOnExit` so inactive tabs don't hold Cytoscape instances in memory.
+Tabbed right panel. **Context manager is the default tab.** Uses `lazyMount` + `unmountOnExit` so inactive tabs don't hold Cytoscape instances in memory.
 
 | Tab | Content |
 |-----|---------|
 | Neo4j | Graph visualization for Neo4j query results (accumulated, live sync) |
 | Memory | Graph visualization for Memory MCP entities |
 | All (Turn Explorer) | Turn-based graph explorer — select specific turns, color-coded |
-| **Observability** *(default)* | Event timeline + LLM call detail |
+| **Context manager** *(default)* | Event timeline + LLM call detail |
 | Data | Data Stash — tool result icons, hide/archive controls |
 | Tools | MCP tool configuration via `ToolsPanel` |
 
@@ -377,6 +377,7 @@ Cytoscape.js graph component with dark futuristic theme.
 Displays the full agent event timeline:
 - Events are merged into `TimelineItem[]` via `buildTimelineItems()`: `tool_call` + `tool_result` pairs sharing the same `callId` appear as a single merged row
 - Click any row → detail overlay with args / result / LLM call data
+- **LLM call detail** (events with `llmCall`): two-tab layout — **Prompt** | **Output**. The Prompt tab uses an Ark UI Accordion with three sections: *Template* (Jinja source with `{{ vars }}` and `{% if %}` / `{% for %}` blocks, sourced from `baml_src/`), *Variables* (function inputs), *Rendered messages* (HTTP body parsed into role/content bubbles via `ParsedPromptView`). Sourced from `LLMCallData` in `baml-adapters.server.ts` — `httpRequest.body` is read via `body.text()` because BAML returns an `HttpBody` class instance, not a plain object.
 - **Save button** (floating, bottom-right): calls `showSaveFilePicker()` to save the full `UnifiedContext` as a named JSON file; falls back to `<a download>` on browsers without File System Access API
 - Requires `context?: UnifiedContext` prop threaded down from `index.tsx` → `SupportPanel` → `ObservabilityPanel`
 

--- a/ui/README.md
+++ b/ui/README.md
@@ -22,7 +22,7 @@ src/
 │   ├── ChatInterface.tsx      # Sends messages, streams SSE, entity highlighting
 │   ├── ChatMessages.tsx       # Markdown rendering with interactive graph entity spans
 │   ├── GraphVisualization.tsx  # Cytoscape.js graph with controls, editing, extraStyles
-│   ├── SupportPanel.tsx       # Tabbed panel (lazyMount): Neo4j, Memory, All, Observability, Tools
+│   ├── SupportPanel.tsx       # Tabbed panel (lazyMount): Neo4j, Memory, All, Context manager, Tools
 │   ├── AllGraphTab.tsx        # Turn-based graph explorer (FloatingPanel + color-coded Cytoscape)
 │   ├── SettingsPanel.tsx      # Harness settings FloatingPanel (sliders, number inputs)
 │   └── ObservabilityPanel.tsx  # Event timeline + LLM call detail

--- a/ui/src/__tests__/lib/harness-patterns/baml-adapters.test.ts
+++ b/ui/src/__tests__/lib/harness-patterns/baml-adapters.test.ts
@@ -459,6 +459,89 @@ describe('extractLLMCallData', () => {
     expect(result!.provider).toBeUndefined()
     expect(result!.clientName).toBeUndefined()
   })
+
+  it('should call body.text() when httpRequest.body is an HttpBody class instance', async () => {
+    const { extractLLMCallData } = await import('../../../lib/harness-patterns/baml-adapters.server')
+
+    // Mirrors @boundaryml/baml's HttpBody: class instance with no enumerable own
+    // props — JSON.stringify would yield "{}", which is the regression we're guarding against
+    const bodyText = '{"messages":[{"role":"user","content":"hello"}]}'
+    const httpBody = Object.create({ text: () => bodyText, json: () => JSON.parse(bodyText) })
+
+    const collector = {
+      last: {
+        rawLlmResponse: 'output',
+        calls: [{ httpRequest: { body: httpBody }, selected: true, provider: 'openrouter', clientName: 'OpenRouterNemotron120B' }]
+      }
+    }
+
+    const result = extractLLMCallData(
+      collector as never,
+      'LoopController',
+      {},
+      Date.now()
+    )
+
+    expect(result).toBeDefined()
+    expect(result!.rawInput).toBe(bodyText)
+    expect(result!.rawInput).not.toBe('{}')
+    expect(result!.provider).toBe('openrouter')
+    expect(result!.clientName).toBe('OpenRouterNemotron120B')
+  })
+
+  it('should prefer the selected call when fallbacks produce multiple entries', async () => {
+    const { extractLLMCallData } = await import('../../../lib/harness-patterns/baml-adapters.server')
+
+    const failedBody = Object.create({ text: () => 'FAILED_BODY' })
+    const goodBody = Object.create({ text: () => 'GOOD_BODY' })
+
+    const collector = {
+      last: {
+        rawLlmResponse: 'output',
+        calls: [
+          { httpRequest: { body: failedBody }, selected: false, provider: 'groq', clientName: 'GroqFast' },
+          { httpRequest: { body: goodBody }, selected: true, provider: 'openai', clientName: 'OpenAIGPT5' }
+        ]
+      }
+    }
+
+    const result = extractLLMCallData(
+      collector as never,
+      'LoopController',
+      {},
+      Date.now()
+    )
+
+    expect(result!.rawInput).toBe('GOOD_BODY')
+    expect(result!.clientName).toBe('OpenAIGPT5')
+  })
+
+  it('should populate promptTemplate with the Jinja template (placeholders intact)', async () => {
+    const { extractLLMCallData } = await import('../../../lib/harness-patterns/baml-adapters.server')
+
+    const collector = {
+      last: {
+        rawLlmResponse: 'output',
+        calls: [{ httpRequest: { body: '{"messages":[{"role":"user","content":"INTENT: hello"}]}' } }]
+      }
+    }
+
+    const result = extractLLMCallData(
+      collector as never,
+      'LoopController',
+      { user_message: 'hello' },
+      Date.now()
+    )
+
+    expect(result).toBeDefined()
+    // Raw prompt = the BAML template with placeholders intact
+    expect(result!.promptTemplate).toBeDefined()
+    expect(result!.promptTemplate).toMatch(/\{\{\s*intent\s*\}\}/)
+    // Parsed prompt = the rendered HTTP body containing substituted content
+    expect(result!.rawInput).toContain('INTENT: hello')
+    // The two must not be the same string
+    expect(result!.promptTemplate).not.toBe(result!.rawInput)
+  })
 })
 
 describe('describeToolResultOp', () => {

--- a/ui/src/components/ark-ui/ObservabilityPanel.tsx
+++ b/ui/src/components/ark-ui/ObservabilityPanel.tsx
@@ -9,6 +9,7 @@
 
 import { For, Show, createSignal, createMemo, Switch, Match } from 'solid-js'
 import { Tooltip } from '@ark-ui/solid/tooltip'
+import { Accordion } from '@ark-ui/solid/accordion'
 import type {
   ContextEvent,
   EventType,
@@ -976,7 +977,7 @@ const ParsedPromptView = (props: { rawInput: string }) => {
 // LLM Call Tabs Component
 // ============================================================================
 
-type LLMTab = 'rawPrompt' | 'parsedPrompt' | 'rawOutput' | 'parsedOutput'
+type LLMTab = 'prompt' | 'output'
 
 const TabButton = (props: { active: boolean; label: string; onClick: () => void }) => (
   <button
@@ -1056,8 +1057,117 @@ const UsageStats = (props: { llmCall: LLMCallData }) => (
   </div>
 )
 
+/** One section inside the Prompt accordion. */
+const PromptAccordionItem = (props: {
+  value: string
+  label: string
+  hint?: string
+  children: import('solid-js').JSX.Element
+}) => (
+  <Accordion.Item
+    value={props.value}
+    border="1 dark-border-secondary/40"
+    rounded="md"
+    overflow="hidden"
+  >
+    <Accordion.ItemTrigger
+      w="full"
+      p="x-3 y-2"
+      flex="~"
+      items="center"
+      justify="between"
+      gap="3"
+      bg="dark-bg-tertiary hover:dark-bg-hover"
+      cursor="pointer"
+      text="left"
+      style={{ border: 'none' }}
+    >
+      <div flex="~" items="center" gap="2">
+        <span text="xs neon-cyan" font="mono medium">{props.label}</span>
+        <Show when={props.hint}>
+          <span text="xs dark-text-tertiary">{props.hint}</span>
+        </Show>
+      </div>
+      <Accordion.ItemIndicator
+        text="xs dark-text-secondary"
+        style={{ transition: 'transform 150ms', 'transform-origin': 'center' }}
+      >
+        ▼
+      </Accordion.ItemIndicator>
+    </Accordion.ItemTrigger>
+    <Accordion.ItemContent p="3" bg="dark-bg-secondary">
+      {props.children}
+    </Accordion.ItemContent>
+  </Accordion.Item>
+)
+
+const PromptAccordion = (props: { llmCall: LLMCallData }) => {
+  const hasTemplate = () => Boolean(props.llmCall.promptTemplate)
+  const hasMessages = () => Boolean(props.llmCall.rawInput)
+  const variableKeys = () => Object.keys(props.llmCall.variables ?? {})
+
+  // Default-open the most informative section that has data
+  const defaultValue = () => {
+    if (hasTemplate()) return ['template']
+    if (hasMessages()) return ['messages']
+    return ['variables']
+  }
+
+  return (
+    <Accordion.Root multiple defaultValue={defaultValue()} flex="~ col" gap="2">
+      <PromptAccordionItem
+        value="template"
+        label="Template"
+        hint={hasTemplate() ? 'Jinja source with {{ vars }} and conditionals' : 'not captured'}
+      >
+        <Show
+          when={hasTemplate()}
+          fallback={
+            <div text="xs dark-text-tertiary">
+              BAML prompt template not captured. Run <code>pnpm baml-generate</code> or verify
+              the function name <code>{props.llmCall.functionName}</code> exists in <code>baml_src/</code>.
+            </div>
+          }
+        >
+          <CodeBlock content={props.llmCall.promptTemplate} />
+        </Show>
+      </PromptAccordionItem>
+
+      <PromptAccordionItem
+        value="variables"
+        label="Variables"
+        hint={`${variableKeys().length} input${variableKeys().length === 1 ? '' : 's'}`}
+      >
+        <Show
+          when={variableKeys().length > 0}
+          fallback={<div text="xs dark-text-tertiary">No variables passed to this function.</div>}
+        >
+          <CodeBlock content={JSON.stringify(props.llmCall.variables, null, 2)} />
+        </Show>
+      </PromptAccordionItem>
+
+      <PromptAccordionItem
+        value="messages"
+        label="Rendered messages"
+        hint={hasMessages() ? 'what actually went to the LLM' : 'not captured'}
+      >
+        <Show
+          when={hasMessages()}
+          fallback={
+            <div text="xs dark-text-tertiary">
+              HTTP request body not captured by the BAML collector.
+            </div>
+          }
+        >
+          <ParsedPromptView rawInput={props.llmCall.rawInput!} />
+        </Show>
+      </PromptAccordionItem>
+    </Accordion.Root>
+  )
+}
+
 const LLMCallTabs = (props: { llmCall: LLMCallData }) => {
-  const [activeTab, setActiveTab] = createSignal<LLMTab>('rawPrompt')
+  const [activeTab, setActiveTab] = createSignal<LLMTab>('prompt')
 
   return (
     <div border="b dark-border-primary" m="b-4" p="b-4">
@@ -1067,54 +1177,23 @@ const LLMCallTabs = (props: { llmCall: LLMCallData }) => {
       {/* Tab buttons */}
       <div flex="~ wrap" gap="2" m="b-3">
         <TabButton
-          active={activeTab() === 'rawPrompt'}
-          label="Raw Prompt"
-          onClick={() => setActiveTab('rawPrompt')}
+          active={activeTab() === 'prompt'}
+          label="Prompt"
+          onClick={() => setActiveTab('prompt')}
         />
         <TabButton
-          active={activeTab() === 'parsedPrompt'}
-          label="Parsed Prompt"
-          onClick={() => setActiveTab('parsedPrompt')}
-        />
-        <TabButton
-          active={activeTab() === 'rawOutput'}
-          label="Raw Output"
-          onClick={() => setActiveTab('rawOutput')}
-        />
-        <TabButton
-          active={activeTab() === 'parsedOutput'}
-          label="Parsed Output"
-          onClick={() => setActiveTab('parsedOutput')}
+          active={activeTab() === 'output'}
+          label="Output"
+          onClick={() => setActiveTab('output')}
         />
       </div>
 
       {/* Tab content */}
       <Switch>
-        <Match when={activeTab() === 'rawPrompt'}>
-          <Show
-            when={props.llmCall.promptTemplate}
-            fallback={
-              <div flex="~ col" gap="2">
-                <div text="xs dark-text-tertiary" m="b-1">Variables</div>
-                <CodeBlock content={JSON.stringify(props.llmCall.variables, null, 2)} />
-              </div>
-            }
-          >
-            <CodeBlock content={props.llmCall.promptTemplate} placeholder="Template not captured" />
-          </Show>
+        <Match when={activeTab() === 'prompt'}>
+          <PromptAccordion llmCall={props.llmCall} />
         </Match>
-        <Match when={activeTab() === 'parsedPrompt'}>
-          <Show
-            when={props.llmCall.rawInput}
-            fallback={<CodeBlock content={undefined} placeholder="Parsed prompt not captured" />}
-          >
-            <ParsedPromptView rawInput={props.llmCall.rawInput!} />
-          </Show>
-        </Match>
-        <Match when={activeTab() === 'rawOutput'}>
-          <CodeBlock content={props.llmCall.rawOutput} placeholder="Raw output not captured" />
-        </Match>
-        <Match when={activeTab() === 'parsedOutput'}>
+        <Match when={activeTab() === 'output'}>
           <CodeBlock
             content={
               props.llmCall.parsedOutput != null
@@ -1123,7 +1202,7 @@ const LLMCallTabs = (props: { llmCall: LLMCallData }) => {
                     : JSON.stringify(props.llmCall.parsedOutput, null, 2))
                 : undefined
             }
-            placeholder="Parsed output not captured"
+            placeholder="Output not captured"
           />
         </Match>
       </Switch>

--- a/ui/src/components/ark-ui/SupportPanel.tsx
+++ b/ui/src/components/ark-ui/SupportPanel.tsx
@@ -2,7 +2,7 @@
  * Support Panel Component
  *
  * Tabbed interface for knowledge graph visualization and observability tools
- * Tabs: Neo4j Graph | Memory Graph | All (Turn Explorer) | Observability | Data | Actions | Documents | Tools
+ * Tabs: Neo4j Graph | Memory Graph | All (Turn Explorer) | Context manager | Data | Actions | Documents | Tools
  */
 
 import { Tabs } from '@ark-ui/solid/tabs';
@@ -164,7 +164,7 @@ export const SupportPanel = (props: SupportPanelProps) => {
               "color": selectedTab() === 'stats' ? '#f59e0b' : '#a1a1aa'
             }}
           >
-            Observability
+            Context manager
           </Tabs.Trigger>
 
           <Tabs.Trigger
@@ -263,7 +263,7 @@ export const SupportPanel = (props: SupportPanelProps) => {
             />
           </Tabs.Content>
 
-          {/* Observability Tab - ContextEvents based */}
+          {/* Context manager Tab - ContextEvents based */}
           <Tabs.Content value="stats" h="full">
             <ObservabilityPanel
               events={props.contextEvents ?? []}

--- a/ui/src/lib/harness-patterns/baml-adapters.server.ts
+++ b/ui/src/lib/harness-patterns/baml-adapters.server.ts
@@ -22,6 +22,7 @@ import type { ControllerFn, CriticFn, CodeModeControllerFn, ControllerAction, Cr
 import type { ToolDescription, LoopTurn, Attempt, PriorResult, FewShot } from '../../../baml_client/types'
 import { listTools as mcpListTools } from './mcp-client.server'
 import { Collector, BamlValidationError } from '@boundaryml/baml'
+import { getBamlFiles } from '../../../baml_client/inlinedbaml'
 
 assertServerOnImport()
 
@@ -71,17 +72,37 @@ export function extractLLMCallData(
   const last = collector.last
   if (!last) return undefined
 
-  // Extract raw input from HTTP request body
+  // Prefer the call BAML actually selected (handles fallbacks); fall back to the last attempted call
+  const calls = (last.calls ?? []) as Array<{
+    selected?: boolean
+    provider?: string
+    clientName?: string
+    httpRequest?: { body?: unknown }
+  }>
+  const selectedCall = calls.find((c) => c.selected) ?? calls[calls.length - 1]
+
+  // BAML's httpRequest.body is an HttpBody class instance with .text()/.json()/.raw() methods.
+  // JSON.stringify on the class returns "{}" because it has no enumerable own properties.
   let rawInput: string | undefined
-  const lastCall = last.calls?.[last.calls.length - 1]
-  if (lastCall?.httpRequest?.body) {
-    const body = lastCall.httpRequest.body
-    rawInput = typeof body === 'string' ? body : JSON.stringify(body, null, 2)
+  const body = selectedCall?.httpRequest?.body as
+    | { text?: () => string }
+    | string
+    | Record<string, unknown>
+    | undefined
+  if (typeof body === 'string') {
+    rawInput = body
+  } else if (body && typeof (body as { text?: () => string }).text === 'function') {
+    try {
+      rawInput = (body as { text: () => string }).text()
+    } catch {
+      // body.text() may throw on malformed bodies — leave undefined
+    }
+  } else if (body && typeof body === 'object') {
+    rawInput = JSON.stringify(body, null, 2)
   }
 
-  // Extract provider and client info from the selected call
-  const provider = lastCall && 'provider' in lastCall ? (lastCall as { provider: string }).provider : undefined
-  const clientName = lastCall && 'clientName' in lastCall ? (lastCall as { clientName: string }).clientName : undefined
+  const provider = selectedCall?.provider
+  const clientName = selectedCall?.clientName
 
   return {
     functionName,
@@ -109,22 +130,47 @@ export function extractLLMCallData(
 /** Cache for extracted prompt templates keyed by function name */
 let promptTemplateCache: Record<string, string> | null = null
 
-/** Extract prompt template for a BAML function from inlined source */
+/** Extract prompt template for a BAML function. Reads from inlinedbaml when
+ * available (production builds), and falls back to the on-disk baml_src/
+ * directory (dev environments without a generated baml_client). */
 function getPromptTemplate(functionName: string): string | undefined {
   if (!promptTemplateCache) {
     promptTemplateCache = {}
-    try {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const { getBamlFiles } = require('../../../baml_client/inlinedbaml')
-      const files = getBamlFiles() as Record<string, string>
-      for (const source of Object.values(files)) {
-        extractPromptTemplates(source, promptTemplateCache)
-      }
-    } catch {
-      // If inlined BAML not available, return undefined
+    loadTemplatesFromInlinedBaml(promptTemplateCache)
+    if (Object.keys(promptTemplateCache).length === 0) {
+      loadTemplatesFromDisk(promptTemplateCache)
     }
   }
   return promptTemplateCache[functionName]
+}
+
+function loadTemplatesFromInlinedBaml(cache: Record<string, string>): void {
+  try {
+    const files = getBamlFiles() as Record<string, string>
+    for (const source of Object.values(files)) {
+      extractPromptTemplates(source, cache)
+    }
+  } catch {
+    // baml_client not generated — caller falls back to disk
+  }
+}
+
+function loadTemplatesFromDisk(cache: Record<string, string>): void {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const fs = require('node:fs') as typeof import('node:fs')
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const path = require('node:path') as typeof import('node:path')
+    const bamlSrc = path.resolve(process.cwd(), 'baml_src')
+    if (!fs.existsSync(bamlSrc)) return
+    for (const entry of fs.readdirSync(bamlSrc)) {
+      if (!entry.endsWith('.baml')) continue
+      const source = fs.readFileSync(path.join(bamlSrc, entry), 'utf8')
+      extractPromptTemplates(source, cache)
+    }
+  } catch {
+    // filesystem unavailable — templates remain unset
+  }
 }
 
 /** Parse BAML source to extract function prompt blocks */

--- a/ui/src/lib/harness-patterns/patterns/synthesizer.server.ts
+++ b/ui/src/lib/harness-patterns/patterns/synthesizer.server.ts
@@ -108,11 +108,25 @@ async function defaultSynthesize(input: SynthesizerInput, collector?: Collector)
   let llmCall: LLMCallData | undefined
   if (collector?.last) {
     const last = collector.last
+    const calls = (last.calls ?? []) as Array<{
+      selected?: boolean
+      httpRequest?: { body?: unknown }
+    }>
+    const selectedCall = calls.find((c) => c.selected) ?? calls[calls.length - 1]
     let rawInput: string | undefined
-    const lastCall = last.calls?.[last.calls.length - 1]
-    if (lastCall?.httpRequest?.body) {
-      const body = lastCall.httpRequest.body
-      rawInput = typeof body === 'string' ? body : JSON.stringify(body, null, 2)
+    const body = selectedCall?.httpRequest?.body as
+      | { text?: () => string }
+      | string
+      | Record<string, unknown>
+      | undefined
+    if (typeof body === 'string') {
+      rawInput = body
+    } else if (body && typeof (body as { text?: () => string }).text === 'function') {
+      try {
+        rawInput = (body as { text: () => string }).text()
+      } catch { /* body.text() may throw — leave undefined */ }
+    } else if (body && typeof body === 'object') {
+      rawInput = JSON.stringify(body, null, 2)
     }
 
     // Extract prompt template from inlined BAML source
@@ -130,8 +144,8 @@ async function defaultSynthesize(input: SynthesizerInput, collector?: Collector)
     } catch { /* inlined BAML not available */ }
 
     // Extract provider and client info from the selected call
-    const provider = lastCall && 'provider' in lastCall ? (lastCall as { provider: string }).provider : undefined
-    const clientName = lastCall && 'clientName' in lastCall ? (lastCall as { clientName: string }).clientName : undefined
+    const provider = selectedCall && 'provider' in selectedCall ? (selectedCall as { provider: string }).provider : undefined
+    const clientName = selectedCall && 'clientName' in selectedCall ? (selectedCall as { clientName: string }).clientName : undefined
 
     llmCall = {
       functionName: 'Synthesize',


### PR DESCRIPTION
## Summary

Three connected fixes to the LLM-call detail in the (formerly Observability) sub-tab of the support panel:

- Rename **Observability** → **Context manager** sub-tab.
- Collapse 4 LLM-call sub-tabs into 2 (**Prompt** + **Output**). The Prompt tab uses an Accordion with three sections: BAML Jinja template, function variables, and rendered messages.
- Fix `httpRequest.body` extraction in `baml-adapters.server.ts` + `synthesizer.server.ts`: BAML returns an `HttpBody` class instance, so `JSON.stringify(body)` was producing `"{}"`. Call `body.text()` and prefer the `selected` call (so fallback retries don't leak a failed attempt's body).
- Switch the prompt-template loader from `require('inlinedbaml')` (silently fails under vinxi) to a static ESM import, with on-disk `baml_src/` fallback.

## Tests

- New `baml-adapters.test.ts` coverage: `HttpBody.text()` case, `selected`-call preference under fallback, `promptTemplate` actually contains Jinja placeholders.
- Full suite: 566/566 passing.

## Docs

- `docs/UI_ARCHITECTURE.md` + `ui/README.md` updated to reference "Context manager" and the new Prompt/Output detail structure.

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)