### PR TITLE
fix(ui): defer ResizeObserver on GraphVisualization unmount

### DIFF
--- a/docs/UI_ARCHITECTURE.md
+++ b/docs/UI_ARCHITECTURE.md
@@ -347,7 +347,7 @@ The All tab does not use the accumulated `graphElements` signal. Instead, it der
 #### 7. GraphVisualization.tsx
 Cytoscape.js graph component with dark futuristic theme.
 
-**Rendering lifecycle:** With `unmountOnExit` on `Tabs.Root`, Cytoscape instances are fully created/destroyed when switching tabs. A `ResizeObserver` on `containerRef` drives a `visible()` signal to defer layout until the container has non-zero dimensions.
+**Rendering lifecycle:** With `unmountOnExit` on `Tabs.Root`, Cytoscape instances are fully created/destroyed when switching tabs. A `ResizeObserver` on `containerRef` drives a `visible()` signal to defer layout until the container has non-zero dimensions. The observer callback guards against a detached `containerRef` and defers `setVisible` + `cy.resize()` to `requestAnimationFrame` so that a notify-during-layout firing after the tab unmounts doesn't surface as the `ResizeObserver loop completed with undelivered notifications` warning (issue #38). The component-scoped `resizeObserver` and `resizeRafId` are torn down explicitly in `onCleanup` alongside `cy.destroy()`.
 
 **Base styles** are extracted to a module-level `BASE_STYLES` constant. The `extraStyles` prop appends additional stylesheets (e.g. per-turn color rules) — a reactive `createEffect` re-applies `cy.style([...BASE_STYLES, ...extraStyles])` when they change.
 

--- a/ui/src/components/ark-ui/GraphVisualization.tsx
+++ b/ui/src/components/ark-ui/GraphVisualization.tsx
@@ -146,6 +146,8 @@ type LayoutName = 'cose' | 'cola' | 'dagre' | 'circle' | 'grid' | 'breadthfirst'
 export const GraphVisualization = (props: GraphVisualizationProps) => {
   let containerRef: HTMLDivElement | undefined;
   let cy: Core | null = null;
+  let resizeObserver: ResizeObserver | undefined;
+  let resizeRafId: number | undefined;
 
   // eslint-disable-next-line solid/reactivity
   const [selectedLayout, setSelectedLayout] = createSignal<LayoutName>(props.layout ?? 'cose');
@@ -294,13 +296,24 @@ export const GraphVisualization = (props: GraphVisualizationProps) => {
       });
     });
 
-    // Track container visibility via ResizeObserver (for deferred rendering)
-    const observer = new ResizeObserver((entries) => {
-      const { width, height } = entries[0].contentRect;
-      setVisible(width > 0 && height > 0);
+    // Track container visibility via ResizeObserver (for deferred rendering).
+    // Guard against detached container + defer to rAF so a notify-during-layout
+    // doesn't surface as "ResizeObserver loop completed with undelivered notifications"
+    // when the tab unmounts mid-layout. See issue #38.
+    resizeObserver = new ResizeObserver((entries) => {
+      if (!containerRef?.isConnected) return;
+      const entry = entries[0];
+      if (!entry) return;
+      const { width, height } = entry.contentRect;
+      if (resizeRafId !== undefined) cancelAnimationFrame(resizeRafId);
+      resizeRafId = requestAnimationFrame(() => {
+        resizeRafId = undefined;
+        if (!containerRef?.isConnected) return;
+        setVisible(width > 0 && height > 0);
+        cy?.resize();
+      });
     });
-    observer.observe(containerRef);
-    onCleanup(() => observer.disconnect());
+    resizeObserver.observe(containerRef);
 
     setIsLoading(false);
   });
@@ -542,7 +555,14 @@ export const GraphVisualization = (props: GraphVisualizationProps) => {
   // ========================================
 
   onCleanup(() => {
+    if (resizeRafId !== undefined) {
+      cancelAnimationFrame(resizeRafId);
+      resizeRafId = undefined;
+    }
+    resizeObserver?.disconnect();
+    resizeObserver = undefined;
     cy?.destroy();
+    cy = null;
   });
 
   // ========================================


### PR DESCRIPTION
## Summary

Switching between Observability and Neo4j tabs while a graph was settling surfaced "ResizeObserver loop completed with undelivered notifications" as a Vite error overlay. With `unmountOnExit` on `Tabs.Root`, the Cytoscape container is destroyed mid-layout, so the observer fired against a detached node and its callback's reactive updates couldn't complete in the same frame.

**GraphVisualization.tsx**:
- Hoist `resizeObserver` and `resizeRafId` to component scope.
- Guard the observer callback against a detached `containerRef`.
- Defer `setVisible` + `cy.resize()` to `requestAnimationFrame`, cancelling any pending frame first; re-check `isConnected` inside rAF.
- Consolidate cleanup: cancel pending rAF, disconnect observer, then destroy `cy` (order matters — a fired rAF must not touch a destroyed Cytoscape instance).

**docs/UI_ARCHITECTURE.md**:
- Document the detached-container guard, rAF deferral, and cleanup wiring in the GraphVisualization rendering-lifecycle paragraph.

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)