### PR TITLE
fix(harness): demote Neo4j error responses to success:false

### DIFF
--- a/ui/src/__tests__/lib/harness-patterns/mcp-client.test.ts
+++ b/ui/src/__tests__/lib/harness-patterns/mcp-client.test.ts
@@ -137,6 +137,79 @@ describe('mcp-client', () => {
       expect(result.data).toBeNull()
       expect(result.error).toBe('Connection failed')
     })
+
+    // Issue #50: mcp-neo4j-cypher's `write_neo4j_cypher` returns Neo4j errors
+    // as a plain text result instead of failing the call, so callTool's text
+    // path used to return `{ success: true, data: "Neo4j Error: ..." }` and
+    // downstream gating (view.hasErrors, enricher's success check, the
+    // synthesizer) couldn't tell a real failure from a real success.
+    it('demotes "Neo4j Error:" text results to success:false (issue #50)', async () => {
+      const neo4jErrorText =
+        'Neo4j Error: {neo4j_code: Neo.ClientError.Statement.ParameterMissing} ' +
+        '{message: Expected parameter(s): pulsarName, pulsarDesc, platformName, platformDesc} ' +
+        '{gql_status: 50N42}'
+      mockCallTool.mockResolvedValue({
+        content: [{ type: 'text', text: neo4jErrorText }]
+      })
+
+      const { callTool } = await import('../../../lib/harness-patterns/mcp-client.server')
+
+      const result = await callTool('write_neo4j_cypher', { query: 'MERGE ...' })
+
+      expect(result.success).toBe(false)
+      expect(result.data).toBeNull()
+      expect(result.error).toBe(neo4jErrorText)
+    })
+
+    it('demotes any "<ToolName> Error:" prefixed text result', async () => {
+      mockCallTool.mockResolvedValue({
+        content: [{ type: 'text', text: 'Redis Error: WRONGTYPE Operation against a key…' }]
+      })
+
+      const { callTool } = await import('../../../lib/harness-patterns/mcp-client.server')
+
+      const result = await callTool('some_redis_tool', {})
+
+      expect(result.success).toBe(false)
+      expect(result.error).toMatch(/^Redis Error:/)
+    })
+
+    it('preserves success:true for normal Neo4j write results (regression)', async () => {
+      // Real shape returned by a successful write_neo4j_cypher call.
+      mockCallTool.mockResolvedValue({
+        content: [{
+          type: 'text',
+          text: JSON.stringify({
+            _contains_updates: true,
+            nodes_created: 2,
+            relationships_created: 1,
+            properties_set: 4,
+            labels_added: 2
+          })
+        }]
+      })
+
+      const { callTool } = await import('../../../lib/harness-patterns/mcp-client.server')
+
+      const result = await callTool('write_neo4j_cypher', { query: 'MERGE ...' })
+
+      expect(result.success).toBe(true)
+      expect(result.data).toMatchObject({ nodes_created: 2, relationships_created: 1 })
+    })
+
+    it('does not demote unrelated text starting with a capital word', async () => {
+      // "Error: foo" alone (no preceding tool-name token) should not match.
+      mockCallTool.mockResolvedValue({
+        content: [{ type: 'text', text: 'Hello world — nothing wrong here.' }]
+      })
+
+      const { callTool } = await import('../../../lib/harness-patterns/mcp-client.server')
+
+      const result = await callTool('test_tool', {})
+
+      expect(result.success).toBe(true)
+      expect(result.data).toBe('Hello world — nothing wrong here.')
+    })
   })
 
   describe('listTools', () => {

--- a/ui/src/lib/harness-patterns/README.md
+++ b/ui/src/lib/harness-patterns/README.md
@@ -998,7 +998,7 @@ harness-patterns/
 ├── tools.server.ts         # Tools() — groups MCP tools by namespace
 ├── harness.server.ts       # harness(), resumeHarness(), continueSession() — all accept onEvent? callback
 ├── routing.server.ts       # BAML router integration (routeMessageOp)
-├── mcp-client.server.ts    # callTool(), listTools()
+├── mcp-client.server.ts    # callTool(), listTools(); demotes `"<ToolName> Error:"` text results to `success:false` (issue #50)
 ├── baml-adapters.server.ts # Adapter factories: createLoopControllerAdapter, createNeo4jController, createActorControllerAdapter, createCriticAdapter, describeToolResultOp, etc.
 ├── summarize.server.ts     # scheduleSummarization() — background tool result summarization via DescribeFallback
 ├── token-budget.server.ts  # trimToFit(), getContextWindow(), estimateTokens() — rolling context window

--- a/ui/src/lib/harness-patterns/mcp-client.server.ts
+++ b/ui/src/lib/harness-patterns/mcp-client.server.ts
@@ -57,6 +57,8 @@ export async function callTool(
     if (result.content && Array.isArray(result.content)) {
       const textContent = result.content.find((c) => c.type === 'text');
       if (textContent && 'text' in textContent) {
+        const demoted = demoteErrorString(textContent.text);
+        if (demoted) return demoted;
         try {
           return { success: true, data: JSON.parse(textContent.text) };
         } catch {
@@ -77,6 +79,24 @@ export async function callTool(
       error: error instanceof Error ? error.message : String(error)
     };
   }
+}
+
+/** Some MCP servers (notably `mcp-neo4j-cypher`'s `write_neo4j_cypher`) report
+ *  failures by returning the error message as a normal text result, leaving
+ *  the call's `success` indicator implicitly true. Detect that shape and
+ *  demote to `{ success: false, error }` so downstream gating
+ *  (`view.hasErrors()`, `iteration.success`, the enricher's success guard)
+ *  treats it as a real failure. Matches `"<ToolName> Error:"` prefixes
+ *  generically — the immediate offender is `"Neo4j Error:"`. */
+const ERROR_STRING_PREFIX = /^[A-Z][A-Za-z0-9]*\s+Error:/;
+
+function demoteErrorString(
+  text: string
+): { success: false; data: null; error: string } | null {
+  if (typeof text === 'string' && ERROR_STRING_PREFIX.test(text)) {
+    return { success: false, data: null, error: text };
+  }
+  return null;
 }
 
 export async function listTools(): Promise<MCPToolDescription[]> {


### PR DESCRIPTION
## Summary

`mcp-neo4j-cypher`'s `write_neo4j_cypher` returns Neo4j errors as a plain text result with the call still marked successful, so `callTool` was returning `{ success: true, data: "Neo4j Error: ..." }`. Downstream gating (`view.hasErrors`, the synthesizer's `iteration.success`, the enricher's `success` guard) could not tell a real failure from a real success.

Detect `"<ToolName> Error:"`-prefixed text results inside `callTool` and demote them to `{ success: false, data: null, error: text }`. The match generalises beyond Neo4j with no extra moving parts.

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)