### PR TITLE
feat(ui): optimistic new-chat row + per-session progress + LLM titles

### DIFF
--- a/docs/UI_ARCHITECTURE.md
+++ b/docs/UI_ARCHITECTURE.md
@@ -308,7 +308,7 @@ Main container combining sidebar and chat area:
 - **Keyboard shortcuts:**
   - Enter → Send message
   - Shift+Enter → New line
-- **States:** Disabled during AI processing
+- **Submit guard (#47):** When `disabled` is true, the textarea **stays editable** so the user's draft survives, but Enter no-ops. If `blockedMessage` is provided, an inline banner ("Waiting for `<tool>` to complete. Try later.") renders above the input — driven by the currently-running tool from the active session's `controller_action` events.
 - **Styling:** Neon cyan border on focus
 
 #### 5. AgentSelector.tsx
@@ -520,6 +520,48 @@ The first 60 chars of the first `user_message` becomes the conversation title. O
 ### Auth
 
 Every public action and the `/api/events` / `/api/stash` routes authenticate via Stack Auth and scope session ops by `user.id`. When `VITE_DEV_BYPASS_AUTH=true`, the user id falls back to `dev-bypass-user`.
+
+---
+
+## 6a. Per-Session Progress & Submit Guard (#47)
+
+The live progress bar and "Waiting for `<tool>`…" composer guard are scoped to a conversation, not to the `ChatInterface` instance. Switching threads while a chain is running leaves the streamed loop running on the server — progress keeps accumulating in the originating session's controller, and the bar restores on return.
+
+### State location
+
+`routes/index.tsx` owns two parallel per-session registries:
+
+| Registry | Shape | Purpose |
+|----------|-------|---------|
+| `progressBySession` | `Map<sessionId, ChainProgressController>` | One progress controller per session. Lazily created on first read. |
+| `runStates` signal | `Record<sessionId, SessionRunState>` | Reactive `{ isProcessing, runningTool }` per session — drives the composer guard banner and the bar's `visible` flag. |
+| `abortControllers` | `Map<sessionId, AbortController>` | One in-flight SSE stream per session. Aborted only on page unload (not on chat switch). |
+
+`ChatInterface` receives `getProgress`, `getRunState`, `updateRunState`, `registerAbortController`, `unregisterAbortController` as props. Inside `handleSendMessage` the active `props.sessionId` is captured as `runSessionId` at submit time — all subsequent state mutations are keyed on that captured id, not the live prop, so events that arrive after a chat switch don't pollute the wrong view.
+
+### Event routing
+
+- **Progress is always routed** into `getProgress(runSessionId)` regardless of which chat the user is viewing.
+- **Tool name** is extracted from `controller_action.action.tool_name` and pushed via `updateRunState(runSessionId, { runningTool })`. When `is_final` is true the field clears.
+- **Graph, events, messages, context** are dropped when `runSessionId !== props.sessionId` — the active view owns those signals, and the persisted row will surface anything missed on the next hydration.
+
+### SSE envelope
+
+`api/events.ts` now spreads `sessionId` into every emitted JSON object (the `event: done` payload too). It's not part of the typed `ContextEvent` shape — it's an envelope-only field consumed by the client.
+
+### Submit guard
+
+`ChatInput` now keeps the textarea editable while `disabled` is true. The Enter handler still no-ops, but the user's draft survives. A `blockedMessage` prop renders an inline banner above the input; it's set by `ChatInterface` to `` `Waiting for \`<tool>\` to complete. Try later.` `` whenever the active session has both `isProcessing` and a `runningTool`.
+
+### Lifecycle
+
+| Event | Behavior |
+|-------|----------|
+| Submit on a non-running chat | `getProgress(sid).reset()`; `updateRunState(sid, { isProcessing: true })`; SSE opens; per-session `AbortController` registered. |
+| Switch chats mid-stream | Nothing aborts. `selectedSessionId` swaps; `ChatInterface`'s reactive memos pick up the new session's controller (idle → bar hides). |
+| Switch back to the running chat | The original controller's snapshot signal is still live; the bar re-renders with the current `currentTurn` and `status`. |
+| Stream completes | `progress.finish()`; `updateRunState(sid, { isProcessing: false, runningTool: null })`; `AbortController` unregistered. |
+| Tab close / `beforeunload` | Route iterates `abortControllers.values()` and aborts each → no zombie fetches in DevTools. |
 
 ---
 

--- a/docs/UI_ARCHITECTURE.md
+++ b/docs/UI_ARCHITECTURE.md
@@ -515,7 +515,11 @@ Conversations are persisted to Postgres so they survive process restarts and lis
 
 ### Sticky titles
 
-The first 60 chars of the first `user_message` becomes the conversation title. Once set, it never changes via `saveConversation()` — `COALESCE(conversations.title, EXCLUDED.title)` on update. (A dedicated rename action can override this when shipped.)
+The first 60 chars of the first `user_message` becomes the conversation title. Once set, it never changes via `saveConversation()` — `COALESCE(conversations.title, EXCLUDED.title)` on update. A dedicated `updateConversationTitle(id, userId, title)` action bypasses the COALESCE rule and is used by the LLM title generator (see §6b below) to replace the heuristic title once the model resolves. A future user-rename UI can use the same action.
+
+### LLM-generated titles (§6b)
+
+Once the first turn completes, a minimal one-pattern harness agent in `lib/harness-client/examples/title-generator.server.ts` calls a single BAML function (`GenerateConversationTitle`, using the `DescribeFallback` chain) and writes the result via `updateConversationTitle()`. The result is pushed to the client over the existing `/api/events` SSE stream as an `event: title_updated` frame before the stream closes (capped at 3s so a slow LLM never wedges the response). The client patches the threads cache in-place — no refetch. See §6b for the full architecture.
 
 ### Auth
 
@@ -562,6 +566,110 @@ The live progress bar and "Waiting for `<tool>`…" composer guard are scoped to
 | Switch back to the running chat | The original controller's snapshot signal is still live; the bar re-renders with the current `currentTurn` and `status`. |
 | Stream completes | `progress.finish()`; `updateRunState(sid, { isProcessing: false, runningTool: null })`; `AbortController` unregistered. |
 | Tab close / `beforeunload` | Route iterates `abortControllers.values()` and aborts each → no zombie fetches in DevTools. |
+
+---
+
+## 6b. LLM-Generated Conversation Titles
+
+Once the first user turn completes, a minimal harness agent generates a 3–5 word title and replaces the heuristic placeholder. The result is pushed to the client on the same SSE channel the turn was streamed over.
+
+### Why a harness agent for one BAML call?
+
+The `harness-patterns/` library is the testbed for an eventual standalone npm package. Its current example catalog (`harness-client/examples/`) ranges from `simpleLoop` through `actorCritic`, `parallel`, `guardrail`, and a full ontology-builder pipeline — but had no *minimum-rung* example showing the library handles one-shot LLM jobs too. The title generator fills that gap with what is genuinely the smallest legal composition:
+
+```ts
+// ui/src/lib/harness-client/examples/title-generator.server.ts
+export const titleAgent = harness<TitleAgentData>(
+  synthesizer<TitleAgentData>({
+    patternId: 'title-gen',
+    mode: 'message',
+    synthesize: async ({ userMessage }) => sanitizeTitle(await b.GenerateConversationTitle(userMessage)) ?? '',
+  }),
+)
+```
+
+One pattern (`synthesizer`), one BAML call, no tools, no router. `mode: 'message'` makes the synthesizer a thin shell around the custom `synthesize` fn: it pulls the latest `user_message` from the view and feeds it as the function's input.
+
+### The BAML function
+
+`ui/baml_src/title.baml` — `GenerateConversationTitle(user_message: string) -> string`, wired to `DescribeFallback` (`[GroqFast, OpenRouterGemma4, OpenAIGPT5, AnthropicHaiku45]`). Reuses the same lightweight client chain the background tool-result summarizer uses; both are "tiny async post-process" jobs.
+
+### When it runs
+
+| Trigger | Path |
+|---------|------|
+| **First turn of a conversation** | `api/events.ts` calls `runFirstTurnTitleGen(ctx, sessionId, userId)` after the SSE `done` frame, before close. Hard 3s timeout. |
+| **On-demand from the sidebar** | Hover-reveal `↻` icon on each row → calls the `regenerateConversationTitle(sessionId)` server action → loads context → calls `runRegenerateTitle()` (no first-turn gate, uses the latest user message). |
+
+`runFirstTurnTitleGen` is the one with the gate: it skips when `ctx.events.filter(e => e.type === 'user_message').length !== 1`. Titles stay stable across turns; users learn to recognize them.
+
+### How the title reaches the sidebar
+
+The integrated SSE event approach — no new endpoint, no long-lived connection, no polling.
+
+```
+POST /api/events
+  ◀── event: <ContextEvent>      (user_message)
+  ◀── event: <ContextEvent>      (…)
+  ◀── event: done {response, …}  ← user already sees the response
+  ░░░ runFirstTurnTitleGen() runs (≤ 3s) ░░░
+  ◀── event: title_updated {sessionId, title}    ← server pushes
+                                                    stream closes
+```
+
+Server-side (`api/events.ts:78-95`):
+
+```ts
+controller.enqueue(`event: done\ndata: ${doneData}\n\n`)
+await Promise.race([
+  runFirstTurnTitleGen(result.context, sessionId, userId).then(title => {
+    if (!title) return
+    controller.enqueue(`event: title_updated\ndata: ${JSON.stringify({ sessionId, title })}\n\n`)
+  }),
+  new Promise(resolve => setTimeout(resolve, 3000)),
+]).catch(err => console.error('[title-gen] failed:', err))
+controller.close()
+```
+
+Client-side: the typed SSE parser yields `{ event: 'title_updated', data: { sessionId, title } }` and `ChatInterface` invokes `props.onTitleUpdated?.(sessionId, title)`. `routes/index.tsx` patches the threads cache via `mutateThreads()` — no `listConversations()` round-trip.
+
+### Bypassing the COALESCE-sticky upsert
+
+`saveConversation()`'s `COALESCE(conversations.title, EXCLUDED.title)` keeps a once-set title forever. For the LLM title we need authoritative replacement, so `lib/db/conversations.server.ts` exposes a dedicated `updateConversationTitle(id, userId, title)` that does a direct `UPDATE … SET title = $1` scoped by `user_id`. The upsert path retains its sticky semantics for everything else.
+
+### Failure handling
+
+All failures (LLM throws, returns empty, sanitizer rejects, 3s timeout fires) are caught silently. The heuristic title (`deriveTitle()`) remains in place. No retry, no error event to the user.
+
+### Sidebar regenerate (`↻` button)
+
+`ChatSidebar.tsx` renders a hover-reveal `↻` icon on each non-placeholder row. Click → calls `regenerateConversationTitle(threadId)` server action → forwards the returned title to `onTitleRegenerated`, which routes through the same `handleTitleUpdated` patcher used by the SSE event. Inline spinner while in flight. Pending state is tracked per row in a `Set<sessionId>`.
+
+### Replay correctness — `final?` discriminator
+
+Restoring a conversation no longer surfaces residual router status messages ("Let me look into that…") as if they were assistant responses. `AssistantMessageEventData.final?: boolean` distinguishes the synthesizer's user-facing emit (and the router's direct-response branch) from intermediate routing status. `replayMessages` in `lib/harness-client/replay.ts` filters on it. The live stream is unaffected — the live UI only paints `finalResult.response` anyway.
+
+---
+
+## 6c. Typed SSE Parser
+
+`ui/src/lib/sse-client.ts` exposes a single function:
+
+```ts
+parseChatStream(response: Response): AsyncGenerator<ChatStreamEvent>
+```
+
+Wraps the `/api/events` response body and yields a discriminated union over event kinds:
+
+```ts
+type ChatStreamEvent =
+  | { event: 'message';       data: ContextEvent & { sessionId?: string } }
+  | { event: 'done';          data: DoneEventData }
+  | { event: 'error';         data: { sessionId?: string; error: string } }
+  | { event: 'title_updated'; data: TitleUpdatedEventData }
+```
+
+`ChatInterface.handleSendMessage` consumes it with `for await … switch (evt.event)`. Adding a new event type is a one-line union extension; TS surfaces every consumer that doesn't handle it. Frame buffering, partial reads, malformed JSON, multi-line `data:` payloads, and comment lines (`: keepalive`) are all handled inside the parser. Unknown event names still come through at runtime (so a future server-side addition doesn't crash an older client) but aren't part of the static type — consumers should treat them as no-ops via `default` branch.
 
 ---
 

--- a/docs/UI_ARCHITECTURE.md
+++ b/docs/UI_ARCHITECTURE.md
@@ -281,12 +281,13 @@ Main container combining sidebar and chat area:
 ```
 
 #### 2. ChatSidebar.tsx
-**Props:** `collapsed: boolean`, `onToggle: () => void`
+**Props:** `collapsed: boolean`, `onToggle: () => void`, `threads`, `selectedId`, `onSelectThread`, `onNewChat`
 - Width: `3rem` (collapsed) → `16rem` (expanded)
 - Smooth inline style transition
 - Thread history with relative timestamps
 - Settings gear icon (opens `SettingsPanel` FloatingPanel) + New Chat button in footer
 - Content hidden when collapsed (toggle button only)
+- **Optimistic "+ New Chat" placeholder (#44):** Clicking *+ New Chat* immediately prepends a placeholder row keyed by the new `selectedSessionId` (`title: null`, `isPlaceholder: true`, muted italic *"description will appear here"*). Once the first user message persists and the `threadsResource` refetch returns the real row, the merger (`mergeThreadsWithPlaceholder` in `ChatSidebar.tsx`) drops the placeholder by id. No DB writes for the placeholder — purely client-side. Switching to an existing thread clears it.
 
 #### 3. ChatMessages.tsx
 - **ScrollArea.Root** - Custom scrollable message container

--- a/ui/baml_src/title.baml
+++ b/ui/baml_src/title.baml
@@ -1,0 +1,27 @@
+// GenerateConversationTitle — ultra-short conversation titles for the sidebar.
+// Reuses the DescribeFallback client chain (Groq → Gemma → OpenAI → Haiku)
+// — same lightweight chain used by the background tool-result summarizer
+// since both are "tiny async post-process" jobs with identical cost shapes.
+//
+// Invoked as the body of a minimal one-pattern harness agent
+// (lib/harness-client/examples/title-generator.server.ts) on the first
+// turn of a conversation, and on-demand via the sidebar's regenerate
+// button. Output is sanitized client-side (quote stripping, length cap)
+// so the prompt rules are best-effort, not load-bearing.
+
+function GenerateConversationTitle(user_message: string) -> string {
+  client DescribeFallback
+  prompt #"
+    {{ _.role("system") }}
+    Generate a 3-to-5-word title summarizing what this conversation is
+    about, based on the user's first message. Title case. No quotes. No
+    trailing punctuation. No emojis. Return only the title text — no
+    preamble, no explanation.
+
+    {{ _.role("user") }}
+    First message:
+    {{ user_message }}
+
+    {{ ctx.output_format }}
+  "#
+}

--- a/ui/src/__tests__/components/ark-ui/ChatSidebar.test.ts
+++ b/ui/src/__tests__/components/ark-ui/ChatSidebar.test.ts
@@ -1,0 +1,59 @@
+/**
+ * ChatSidebar — placeholder merge logic.
+ *
+ * Covers the optimistic "+ New Chat" placeholder rules from #44:
+ *  - placeholder is prepended when its id is not in the persisted list
+ *  - placeholder is dropped once the persisted row arrives (the real row
+ *    replaces the optimistic one in-place at the top of the list)
+ *  - no placeholder when `placeholderId` is null
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  mergeThreadsWithPlaceholder,
+  type ChatThreadSummary,
+} from '../../../components/ark-ui/ChatSidebar'
+
+const persisted: ChatThreadSummary[] = [
+  { id: 'a', title: 'Alpha', updatedAt: '2026-05-10T00:00:00Z' },
+  { id: 'b', title: 'Beta', updatedAt: '2026-05-09T00:00:00Z' },
+]
+
+describe('mergeThreadsWithPlaceholder', () => {
+  it('returns persisted list unchanged when no placeholder is set', () => {
+    expect(mergeThreadsWithPlaceholder(persisted, null)).toBe(persisted)
+  })
+
+  it('prepends an optimistic placeholder when its id is not yet persisted', () => {
+    const merged = mergeThreadsWithPlaceholder(
+      persisted,
+      'new-id',
+      () => '2026-05-10T12:00:00Z',
+    )
+    expect(merged).toHaveLength(3)
+    expect(merged[0]).toEqual({
+      id: 'new-id',
+      title: null,
+      updatedAt: '2026-05-10T12:00:00Z',
+      isPlaceholder: true,
+    })
+    expect(merged[1].id).toBe('a')
+    expect(merged[2].id).toBe('b')
+  })
+
+  it('drops the placeholder once a persisted row with the same id arrives', () => {
+    const withRow: ChatThreadSummary[] = [
+      { id: 'new-id', title: 'First message…', updatedAt: '2026-05-10T12:00:00Z' },
+      ...persisted,
+    ]
+    const merged = mergeThreadsWithPlaceholder(withRow, 'new-id')
+    expect(merged).toBe(withRow)
+    expect(merged.some((t) => t.isPlaceholder)).toBe(false)
+  })
+
+  it('never produces duplicate ids', () => {
+    const merged = mergeThreadsWithPlaceholder(persisted, 'new-id')
+    const ids = merged.map((t) => t.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+})

--- a/ui/src/__tests__/components/ark-ui/ChatSidebar.test.ts
+++ b/ui/src/__tests__/components/ark-ui/ChatSidebar.test.ts
@@ -8,11 +8,21 @@
  *  - no placeholder when `placeholderId` is null
  */
 
-import { describe, it, expect } from 'vitest'
-import {
-  mergeThreadsWithPlaceholder,
-  type ChatThreadSummary,
-} from '../../../components/ark-ui/ChatSidebar'
+import { describe, it, expect, vi } from 'vitest'
+
+// ChatSidebar.tsx now imports `regenerateConversationTitle` from the
+// server-only `harness-client` module. The transitive import chain
+// (`harness-patterns` → `assert.server.ts`) self-asserts at import time
+// and throws under jsdom. Stub both before pulling in the SUT.
+vi.mock('../../../lib/harness-patterns/assert.server', () => ({
+  assertServerOnImport: vi.fn(),
+}))
+vi.mock('../../../lib/harness-client', () => ({
+  regenerateConversationTitle: vi.fn(async () => null),
+}))
+
+const { mergeThreadsWithPlaceholder } = await import('../../../components/ark-ui/ChatSidebar')
+type ChatThreadSummary = import('../../../components/ark-ui/ChatSidebar').ChatThreadSummary
 
 const persisted: ChatThreadSummary[] = [
   { id: 'a', title: 'Alpha', updatedAt: '2026-05-10T00:00:00Z' },

--- a/ui/src/__tests__/components/ark-ui/useChainProgress.test.ts
+++ b/ui/src/__tests__/components/ark-ui/useChainProgress.test.ts
@@ -147,6 +147,43 @@ describe('createChainProgress', () => {
     })
   })
 
+  describe('per-session isolation (#47)', () => {
+    it('two controllers ingest independently — switching active session does not bleed state', () => {
+      createRoot(() => {
+        // Models the route-level registry: one controller per sessionId.
+        // Streaming events for session A must not affect session B's bar.
+        const a = createChainProgress()
+        const b = createChainProgress()
+
+        a.ingest(ev('user_message', 'harness', { content: 'A', chainTurnEstimate: 5 }))
+        a.ingest(ev('pattern_enter', 'a-loop', { pattern: 'simpleLoop', maxTurns: 5 }))
+        a.ingest(ev('controller_action', 'a-loop', { action: { status: 'a step 1' }, turn: 0, maxTurns: 5 }))
+        a.ingest(ev('controller_action', 'a-loop', { action: { status: 'a step 2' }, turn: 1, maxTurns: 5 }))
+
+        // B receives nothing — it's idle.
+        expect(b.snapshot()).toEqual({
+          currentTurn: 0,
+          maxProjection: 0,
+          pathProjection: 0,
+          status: null,
+          done: false,
+        })
+
+        // A has advanced and carries its own status.
+        expect(a.snapshot().currentTurn).toBe(2)
+        expect(a.snapshot().maxProjection).toBe(5)
+        expect(a.snapshot().status).toBe('a step 2')
+
+        // Now B starts its own run — A's still-in-flight state is untouched.
+        b.ingest(ev('user_message', 'harness', { content: 'B', chainTurnEstimate: 2 }))
+        b.ingest(ev('controller_action', 'b-router', { action: { status: 'b step 1' }, turn: 0, maxTurns: 2 }))
+        expect(b.snapshot().status).toBe('b step 1')
+        expect(a.snapshot().status).toBe('a step 2')
+        expect(a.snapshot().currentTurn).toBe(2)
+      })
+    })
+  })
+
   describe('fallback (no seed)', () => {
     it('grows pathProjection from pattern_enter events', () => {
       createRoot(() => {

--- a/ui/src/__tests__/lib/harness-client/examples/title-generator.test.ts
+++ b/ui/src/__tests__/lib/harness-client/examples/title-generator.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Title Generator — sanitizer + first-turn gate tests.
+ *
+ * The agent itself (`titleAgent`) is exercised via the live SSE path in
+ * manual verification; here we cover the pure helpers that decide whether
+ * to write a title and how to clean up model output. The DB action and
+ * the harness invocation are heavy server modules; we test them indirectly
+ * by validating the pieces that decide whether they're called.
+ */
+import { describe, it, expect, vi } from 'vitest'
+
+// `examples/title-generator.server.ts` imports `harness-patterns` (which
+// asserts server-only on import) and `db/conversations.server` (which
+// needs a pg pool). Mock both before dynamic-importing the SUT.
+vi.mock('../../../../lib/harness-patterns/assert.server', () => ({
+  assertServerOnImport: vi.fn(),
+}))
+vi.mock('../../../../lib/db/conversations.server', () => ({
+  updateConversationTitle: vi.fn(async () => undefined),
+}))
+vi.mock('../../../../../baml_client', () => ({
+  b: {
+    GenerateConversationTitle: vi.fn(async (msg: string) => `Title For ${msg.slice(0, 8)}`),
+  },
+}))
+vi.mock('../../../../lib/harness-patterns', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>(
+    '../../../../lib/harness-patterns',
+  )
+  // Keep the real exports but stub out the `harness()` factory — the agent
+  // would otherwise pull in MCP tools, settings-context, etc.
+  return {
+    ...actual,
+    harness: () => async (_input: string, _sid?: string) => ({
+      response: 'Mocked Agent Response',
+      data: {},
+      status: 'done' as const,
+      duration_ms: 0,
+      context: { events: [], sessionId: 'mock', createdAt: 0, status: 'done', input: '', data: {} },
+      serialized: '{}',
+    }),
+  }
+})
+
+const sut = await import('../../../../lib/harness-client/examples/title-generator.server')
+const { updateConversationTitle } = await import('../../../../lib/db/conversations.server')
+
+describe('sanitizeTitle', () => {
+  it('returns the input verbatim when already clean', () => {
+    expect(sut.sanitizeTitle('Cytoscape Edge Styling')).toBe('Cytoscape Edge Styling')
+  })
+
+  it('strips surrounding quotes and backticks', () => {
+    expect(sut.sanitizeTitle('"Cytoscape Edge Styling"')).toBe('Cytoscape Edge Styling')
+    expect(sut.sanitizeTitle("'Foo Bar'")).toBe('Foo Bar')
+    expect(sut.sanitizeTitle('`A Title`')).toBe('A Title')
+    expect(sut.sanitizeTitle('""Mixed""')).toBe('Mixed')
+  })
+
+  it('strips trailing punctuation', () => {
+    expect(sut.sanitizeTitle('A Title.')).toBe('A Title')
+    expect(sut.sanitizeTitle('A Title!')).toBe('A Title')
+    expect(sut.sanitizeTitle('A Title???')).toBe('A Title')
+  })
+
+  it('takes only the first line of a multi-line response', () => {
+    expect(sut.sanitizeTitle('First Line\nSecond Line')).toBe('First Line')
+    expect(sut.sanitizeTitle('Preamble\n\nReal Title')).toBe('Preamble')
+  })
+
+  it('caps overlong output at 50 chars', () => {
+    const long = 'A '.repeat(60).trim()
+    const result = sut.sanitizeTitle(long)
+    expect(result).not.toBeNull()
+    expect(result!.length).toBeLessThanOrEqual(50)
+  })
+
+  it('returns null for empty or whitespace-only input', () => {
+    expect(sut.sanitizeTitle('')).toBeNull()
+    expect(sut.sanitizeTitle('   ')).toBeNull()
+    expect(sut.sanitizeTitle('""')).toBeNull()
+  })
+})
+
+describe('runFirstTurnTitleGen', () => {
+  it('skips when the context has zero user messages', async () => {
+    const ctx = {
+      sessionId: 's',
+      createdAt: 0,
+      events: [],
+      status: 'done' as const,
+      input: '',
+      data: {},
+    }
+    const result = await sut.runFirstTurnTitleGen(ctx, 's1', 'u1')
+    expect(result).toBeNull()
+    expect(updateConversationTitle).not.toHaveBeenCalled()
+  })
+
+  it('skips when there are already 2+ user messages (regen only via on-demand path)', async () => {
+    const ctx = {
+      sessionId: 's',
+      createdAt: 0,
+      events: [
+        { id: 'u1', type: 'user_message' as const, ts: 1, patternId: 'h', data: { content: 'first' } },
+        { id: 'u2', type: 'user_message' as const, ts: 2, patternId: 'h', data: { content: 'second' } },
+      ],
+      status: 'done' as const,
+      input: 'second',
+      data: {},
+    }
+    const result = await sut.runFirstTurnTitleGen(ctx, 's1', 'u1')
+    expect(result).toBeNull()
+  })
+
+  it('runs on first turn and persists the sanitized title', async () => {
+    vi.mocked(updateConversationTitle).mockClear()
+    const ctx = {
+      sessionId: 's',
+      createdAt: 0,
+      events: [
+        { id: 'u1', type: 'user_message' as const, ts: 1, patternId: 'h', data: { content: 'first message' } },
+      ],
+      status: 'done' as const,
+      input: 'first message',
+      data: {},
+    }
+    const result = await sut.runFirstTurnTitleGen(ctx, 'sess-1', 'user-1')
+    // The mocked harness returns 'Mocked Agent Response' which sanitizes to itself.
+    expect(result).toBe('Mocked Agent Response')
+    expect(updateConversationTitle).toHaveBeenCalledWith('sess-1', 'user-1', 'Mocked Agent Response')
+  })
+})
+
+describe('runRegenerateTitle', () => {
+  it('returns null when context has no user messages', async () => {
+    vi.mocked(updateConversationTitle).mockClear()
+    const ctx = {
+      sessionId: 's',
+      createdAt: 0,
+      events: [],
+      status: 'done' as const,
+      input: '',
+      data: {},
+    }
+    const result = await sut.runRegenerateTitle(ctx, 's1', 'u1')
+    expect(result).toBeNull()
+    expect(updateConversationTitle).not.toHaveBeenCalled()
+  })
+
+  it('runs regardless of message count (unlike runFirstTurnTitleGen)', async () => {
+    vi.mocked(updateConversationTitle).mockClear()
+    const ctx = {
+      sessionId: 's',
+      createdAt: 0,
+      events: [
+        { id: 'u1', type: 'user_message' as const, ts: 1, patternId: 'h', data: { content: 'first' } },
+        { id: 'u2', type: 'user_message' as const, ts: 2, patternId: 'h', data: { content: 'latest' } },
+        { id: 'u3', type: 'user_message' as const, ts: 3, patternId: 'h', data: { content: 'newest' } },
+      ],
+      status: 'done' as const,
+      input: 'newest',
+      data: {},
+    }
+    const result = await sut.runRegenerateTitle(ctx, 'sess-x', 'user-x')
+    expect(result).toBe('Mocked Agent Response')
+    expect(updateConversationTitle).toHaveBeenCalledWith('sess-x', 'user-x', 'Mocked Agent Response')
+  })
+})

--- a/ui/src/__tests__/lib/harness-client/replay-messages.test.ts
+++ b/ui/src/__tests__/lib/harness-client/replay-messages.test.ts
@@ -1,0 +1,114 @@
+/**
+ * replayMessages — chat-history hydration filter.
+ *
+ * Verifies that on conversation restore (sidebar selection), intermediate
+ * router status messages ("Let me look into that…") are excluded and only
+ * the synthesizer's (or direct-response router's) final emit surfaces as a
+ * chat bubble. Discriminator: `AssistantMessageEventData.final === true`.
+ */
+import { describe, it, expect } from 'vitest'
+import { replayMessages } from '../../../lib/harness-client/replay'
+import type { ContextEvent } from '../../../lib/harness-patterns'
+
+const userMsg = (content: string, ts: number, id: string): ContextEvent => ({
+  id,
+  type: 'user_message',
+  ts,
+  patternId: 'harness',
+  data: { content },
+})
+
+const assistantMsg = (content: string, ts: number, id: string, opts?: { final?: boolean; patternId?: string }): ContextEvent => ({
+  id,
+  type: 'assistant_message',
+  ts,
+  patternId: opts?.patternId ?? 'router',
+  data: { content, ...(opts?.final !== undefined ? { final: opts.final } : {}) },
+})
+
+const wrap = (events: ContextEvent[]) => JSON.stringify({ events })
+
+describe('replayMessages', () => {
+  it('returns [] for non-JSON input', () => {
+    expect(replayMessages('not json')).toEqual([])
+  })
+
+  it('returns [] when context has no events', () => {
+    expect(replayMessages(JSON.stringify({ events: [] }))).toEqual([])
+    expect(replayMessages(JSON.stringify({}))).toEqual([])
+  })
+
+  it('keeps all user messages', () => {
+    const out = replayMessages(wrap([
+      userMsg('first', 1, 'u1'),
+      userMsg('second', 2, 'u2'),
+    ]))
+    expect(out.map(m => m.content)).toEqual(['first', 'second'])
+    expect(out.every(m => m.role === 'user')).toBe(true)
+  })
+
+  it('skips assistant_message events without final: true (router status)', () => {
+    const out = replayMessages(wrap([
+      userMsg('hi', 1, 'u1'),
+      assistantMsg('Let me look into that…', 2, 'a1', { patternId: 'router' }),
+      assistantMsg('Looking into the graph…', 3, 'a2', { patternId: 'router' }),
+    ]))
+    expect(out).toHaveLength(1)
+    expect(out[0]).toMatchObject({ role: 'user', content: 'hi' })
+  })
+
+  it('keeps assistant_message events with final: true (synthesizer output)', () => {
+    const out = replayMessages(wrap([
+      userMsg('hi', 1, 'u1'),
+      assistantMsg('Looking…', 2, 'a1', { patternId: 'router' }),                          // intermediate, skipped
+      assistantMsg('Here is the answer.', 3, 'a2', { final: true, patternId: 'response-synth' }),  // final, kept
+    ]))
+    expect(out).toHaveLength(2)
+    expect(out[0]).toMatchObject({ role: 'user', content: 'hi' })
+    expect(out[1]).toMatchObject({ role: 'assistant', content: 'Here is the answer.' })
+  })
+
+  it('handles a multi-turn conversation with mixed router + synthesizer emits', () => {
+    const out = replayMessages(wrap([
+      userMsg('q1', 1, 'u1'),
+      assistantMsg('Routing…', 2, 'r1', { patternId: 'router' }),
+      assistantMsg('A1.', 3, 's1', { final: true, patternId: 'response-synth' }),
+      userMsg('q2', 4, 'u2'),
+      assistantMsg('Routing…', 5, 'r2', { patternId: 'router' }),
+      assistantMsg('A2.', 6, 's2', { final: true, patternId: 'response-synth' }),
+    ]))
+    expect(out.map(m => ({ role: m.role, content: m.content }))).toEqual([
+      { role: 'user', content: 'q1' },
+      { role: 'assistant', content: 'A1.' },
+      { role: 'user', content: 'q2' },
+      { role: 'assistant', content: 'A2.' },
+    ])
+  })
+
+  it('keeps the router-as-final emit on a conversational direct-response turn', () => {
+    // When the router decides no tool is needed, it emits the final response
+    // itself (final: true) and the synthesizer skips BAML for that route.
+    const out = replayMessages(wrap([
+      userMsg('what time is it?', 1, 'u1'),
+      assistantMsg("I don't have realtime access.", 2, 'r1', { final: true, patternId: 'router' }),
+    ]))
+    expect(out).toHaveLength(2)
+    expect(out[1]).toMatchObject({ role: 'assistant', content: "I don't have realtime access." })
+  })
+
+  it('preserves event ordering by array position', () => {
+    const out = replayMessages(wrap([
+      userMsg('q1', 1, 'u1'),
+      assistantMsg('A1.', 3, 's1', { final: true }),
+      userMsg('q2', 2, 'u2'), // intentionally out-of-order ts to confirm we keep array order
+    ]))
+    expect(out.map(m => m.timestamp)).toEqual([1, 3, 2])
+  })
+
+  it('falls back to a synthetic id when an event lacks one', () => {
+    const out = replayMessages(wrap([
+      { ...userMsg('hi', 1, ''), id: undefined } as ContextEvent,
+    ]))
+    expect(out[0].id).toMatch(/^replay-\d+$/)
+  })
+})

--- a/ui/src/__tests__/lib/sse-client.test.ts
+++ b/ui/src/__tests__/lib/sse-client.test.ts
@@ -1,0 +1,136 @@
+/**
+ * sse-client — typed AsyncIterable SSE parser tests.
+ *
+ * Covers the wire-format edge cases we actually emit from `/api/events`:
+ *  - default event name (no `event:` header → 'message')
+ *  - explicit event names (`done`, `error`, `title_updated`)
+ *  - frames split across chunks (partial frame in buffer between reads)
+ *  - malformed JSON in a single frame (skip, don't tear down the stream)
+ *  - unknown event names (yielded for forward-compat)
+ *  - trailing frame with no terminating blank line (flushed on close)
+ */
+import { describe, it, expect } from 'vitest'
+import { parseChatStream, type ChatStreamEvent } from '../../lib/sse-client'
+
+/** Build a minimal Response with a body that emits the given chunks in order. */
+function responseFrom(chunks: string[]): Response {
+  const encoder = new TextEncoder()
+  let i = 0
+  const stream = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (i < chunks.length) {
+        controller.enqueue(encoder.encode(chunks[i++]))
+      } else {
+        controller.close()
+      }
+    },
+  })
+  return new Response(stream)
+}
+
+async function collect(response: Response): Promise<ChatStreamEvent[]> {
+  const out: ChatStreamEvent[] = []
+  for await (const evt of parseChatStream(response)) out.push(evt)
+  return out
+}
+
+describe('parseChatStream', () => {
+  it('yields a single `message` frame with no event header', async () => {
+    const evts = await collect(
+      responseFrom([
+        `data: {"type":"user_message","ts":1,"patternId":"harness","data":{"content":"hi"}}\n\n`,
+      ]),
+    )
+    expect(evts).toHaveLength(1)
+    expect(evts[0].event).toBe('message')
+    expect(evts[0].data).toMatchObject({ type: 'user_message', patternId: 'harness' })
+  })
+
+  it('discriminates by `event:` header', async () => {
+    const evts = await collect(
+      responseFrom([
+        `event: done\ndata: {"sessionId":"s1","response":"ok","data":{},"status":"done","context":{"events":[]}}\n\n`,
+        `event: title_updated\ndata: {"sessionId":"s1","title":"My Title"}\n\n`,
+        `event: error\ndata: {"sessionId":"s1","error":"boom"}\n\n`,
+      ]),
+    )
+    expect(evts.map(e => e.event)).toEqual(['done', 'title_updated', 'error'])
+    if (evts[1].event === 'title_updated') {
+      expect(evts[1].data.title).toBe('My Title')
+    }
+  })
+
+  it('reassembles a frame split across chunks', async () => {
+    // Same frame, sliced mid-`data:` line and mid-JSON-string.
+    const evts = await collect(
+      responseFrom([
+        `event: title_updated\nda`,
+        `ta: {"sessionId":"abc","ti`,
+        `tle":"Split Frame"}\n\n`,
+      ]),
+    )
+    expect(evts).toHaveLength(1)
+    expect(evts[0].event).toBe('title_updated')
+    expect(evts[0].data).toMatchObject({ sessionId: 'abc', title: 'Split Frame' })
+  })
+
+  it('skips a frame with malformed JSON without dropping subsequent frames', async () => {
+    const evts = await collect(
+      responseFrom([
+        `event: done\ndata: {not json}\n\n`,
+        `event: title_updated\ndata: {"sessionId":"x","title":"After Bad"}\n\n`,
+      ]),
+    )
+    expect(evts).toHaveLength(1)
+    expect(evts[0].event).toBe('title_updated')
+  })
+
+  it('yields unknown event names for forward-compat', async () => {
+    const evts = await collect(
+      responseFrom([`event: future_event\ndata: {"hello":"world"}\n\n`]),
+    )
+    expect(evts).toHaveLength(1)
+    expect(evts[0].event).toBe('future_event')
+    expect(evts[0].data).toEqual({ hello: 'world' })
+  })
+
+  it('joins multi-line `data:` payloads per SSE spec', async () => {
+    const evts = await collect(
+      responseFrom([
+        `event: done\ndata: {"sessionId":"s","response":"line1`,
+        `","data":{},"status":"done","context":{"events":[]}}\n\n`,
+      ]),
+    )
+    expect(evts).toHaveLength(1)
+    expect(evts[0].event).toBe('done')
+  })
+
+  it('flushes a trailing frame even without a terminating blank line', async () => {
+    const evts = await collect(
+      responseFrom([`event: title_updated\ndata: {"sessionId":"s","title":"Last"}`]),
+    )
+    expect(evts).toHaveLength(1)
+    expect(evts[0].event).toBe('title_updated')
+  })
+
+  it('ignores comment lines starting with `:`', async () => {
+    const evts = await collect(
+      responseFrom([
+        `: keepalive\nevent: title_updated\ndata: {"sessionId":"s","title":"After Comment"}\n\n`,
+      ]),
+    )
+    expect(evts).toHaveLength(1)
+    expect(evts[0].event).toBe('title_updated')
+  })
+
+  it('skips a frame with no `data:` field', async () => {
+    const evts = await collect(
+      responseFrom([
+        `event: ping\n\n`,
+        `event: title_updated\ndata: {"sessionId":"s","title":"Real"}\n\n`,
+      ]),
+    )
+    expect(evts).toHaveLength(1)
+    expect(evts[0].event).toBe('title_updated')
+  })
+})

--- a/ui/src/components/ark-ui/ChatInput.tsx
+++ b/ui/src/components/ark-ui/ChatInput.tsx
@@ -1,9 +1,14 @@
 import { Field } from '@ark-ui/solid/field'
-import { createSignal } from 'solid-js'
+import { Show, createSignal } from 'solid-js'
 
 interface ChatInputProps {
   onSend: (message: string) => void
+  /** Submit is blocked (e.g. a chain is in flight on this session). The
+   *  textarea stays editable so the user's draft survives — see #47. */
   disabled?: boolean
+  /** Inline guard message shown above the composer when submit is blocked,
+   *  e.g. "Waiting for `web_search` to complete. Try later." */
+  blockedMessage?: string
 }
 
 export const ChatInput = (props: ChatInputProps) => {
@@ -26,13 +31,28 @@ export const ChatInput = (props: ChatInputProps) => {
 
   return (
     <Field.Root w="full">
+      <Show when={props.disabled && props.blockedMessage}>
+        <div
+          data-role="composer-guard"
+          flex="~ items-center gap-2"
+          p="2"
+          m="b-2"
+          rounded="md"
+          border="1 neon-cyan/30"
+          bg="cyber-700/15"
+          text="xs dark-text-secondary"
+        >
+          <span w="1.5" h="1.5" rounded="full" bg="neon-cyan" class="animate-pulse" style={{ 'flex-shrink': 0 }} />
+          <span>{props.blockedMessage}</span>
+        </div>
+      </Show>
       <Field.Textarea
         value={value()}
         onInput={(e) => setValue(e.currentTarget.value)}
         onKeyDown={handleKeyDown}
         autoresize
         placeholder="Type your message... (Enter to send, Shift+Enter for new line)"
-        disabled={props.disabled}
+        aria-disabled={props.disabled ? 'true' : undefined}
         border="1 dark-border-secondary focus:neon-cyan"
         rounded="lg"
         p="3"
@@ -42,8 +62,6 @@ export const ChatInput = (props: ChatInputProps) => {
         w="full"
         text="sm dark-text-primary"
         bg="dark-bg-tertiary"
-        disabled:opacity="50"
-        disabled:cursor="not-allowed"
         outline="none"
         ring="2 transparent focus:neon-cyan/20"
         transition="all"

--- a/ui/src/components/ark-ui/ChatInterface.tsx
+++ b/ui/src/components/ark-ui/ChatInterface.tsx
@@ -31,6 +31,7 @@ import {
   extractGraphElements,
 } from '~/lib/harness-client'
 import { getSettings } from '~/lib/settings-store'
+import { parseChatStream, type DoneEventData } from '~/lib/sse-client'
 import type { GraphElement } from './SupportPanel'
 import type { ContextEvent, UnifiedContext, ControllerActionEventData } from '~/lib/harness-patterns'
 
@@ -205,109 +206,73 @@ export const ChatInterface = (props: ChatInterfaceProps) => {
         throw new Error(`Server error: ${response.status}`)
       }
 
-      const reader = response.body?.getReader()
-      if (!reader) throw new Error('No response stream')
+      let finalResult: DoneEventData | null = null
 
-      const decoder = new TextDecoder()
-      let buffer = ''
-      let finalResult: { response: string; data: Record<string, unknown>; status: string; context: UnifiedContext } | null = null
+      // Typed SSE iteration — the parser handles frame buffering, malformed
+      // JSON, partial reads, and yields discriminated `ChatStreamEvent`s.
+      for await (const sseEvt of parseChatStream(response)) {
+        if (sseEvt.event === 'done') {
+          finalResult = sseEvt.data as DoneEventData
+          continue
+        }
+        if (sseEvt.event === 'error') {
+          throw new Error((sseEvt.data as { error: string }).error)
+        }
+        if (sseEvt.event !== 'message') continue // Forward-compat: ignore unknown event names
 
-      while (true) {
-        const { done, value } = await reader.read()
-        if (done) break
+        const evt = sseEvt.data as ContextEvent
 
-        buffer += decoder.decode(value, { stream: true })
+        // Progress is always routed into the captured run session's
+        // controller, even if the user has navigated away.
+        progress.ingest(evt)
 
-        // SSE frames are delimited by double newlines
-        const frames = buffer.split('\n\n')
-        buffer = frames.pop() ?? '' // Keep incomplete frame in buffer
-
-        for (const frame of frames) {
-          if (!frame.trim()) continue
-
-          let eventType = 'message'
-          let dataStr = ''
-
-          for (const line of frame.split('\n')) {
-            if (line.startsWith('event: ')) {
-              eventType = line.slice(7).trim()
-            } else if (line.startsWith('data: ')) {
-              dataStr += line.slice(6)
-            }
+        // Surface the currently-running tool for the composer guard.
+        if (evt.type === 'controller_action') {
+          const data = evt.data as ControllerActionEventData
+          const toolName = data.action?.tool_name
+          if (toolName && toolName !== 'Return') {
+            props.updateRunState(runSessionId, { runningTool: toolName })
+          } else if (data.action?.is_final) {
+            props.updateRunState(runSessionId, { runningTool: null })
           }
+        }
 
-          if (!dataStr) continue
+        // The remaining route-level state (events, graph, messages) is
+        // only owned by the actively-displayed session — drop events
+        // from a backgrounded stream rather than corrupt the view. The
+        // server-side persistence catches everything up on rehydrate.
+        if (runSessionId !== props.sessionId) continue
 
-          try {
-            const parsed = JSON.parse(dataStr)
+        if (props.onEventsUpdate) {
+          props.onEventsUpdate([evt])
+        }
 
-            if (eventType === 'done') {
-              finalResult = parsed
-            } else if (eventType === 'error') {
-              throw new Error(parsed.error)
-            } else if (parsed.type) {
-              // Regular event — stream to UI. The SSE envelope carries
-              // sessionId (#47); ignore it before treating the body as a
-              // ContextEvent.
-              const evt = parsed as ContextEvent
-
-              // Progress is always routed into the captured run session's
-              // controller, even if the user has navigated away.
-              progress.ingest(evt)
-
-              // Surface the currently-running tool for the composer guard.
-              if (evt.type === 'controller_action') {
-                const data = evt.data as ControllerActionEventData
-                const toolName = data.action?.tool_name
-                if (toolName && toolName !== 'Return') {
-                  props.updateRunState(runSessionId, { runningTool: toolName })
-                } else if (data.action?.is_final) {
-                  props.updateRunState(runSessionId, { runningTool: null })
-                }
-              }
-
-              // The remaining route-level state (events, graph, messages) is
-              // only owned by the actively-displayed session — drop events
-              // from a backgrounded stream rather than corrupt the view. The
-              // server-side persistence catches everything up on rehydrate.
-              if (runSessionId !== props.sessionId) continue
-
-              if (props.onEventsUpdate) {
-                props.onEventsUpdate([evt])
-              }
-
-              // Reactive graph update on tool_result events
-              if (evt.type === 'tool_result' && props.onGraphUpdate) {
-                const graphElements = extractGraphElements([evt])
-                if (graphElements.length > 0) {
-                  props.onGraphUpdate(graphElements)
-                }
-              }
-
-              // Convert error events to inline chat messages
-              if (evt.type === 'error') {
-                const errorData = evt.data as { error: string; severity?: string; hint?: string; turn?: number; iteration?: number }
-                // Build context string (e.g., "(turn 3, attempt 2)")
-                const parts: string[] = []
-                if (errorData.turn !== undefined) parts.push(`turn ${errorData.turn + 1}`)
-                if (errorData.iteration !== undefined) parts.push(`attempt ${errorData.iteration + 1}`)
-                const turnInfo = parts.length > 0 ? `(${parts.join(', ')})` : undefined
-                const errorMsg: Message = {
-                  id: `err-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
-                  role: errorData.severity === 'recoverable' ? 'warning' : 'error',
-                  content: errorData.error,
-                  timestamp: new Date(),
-                  hint: errorData.hint,
-                  patternId: evt.patternId,
-                  turnInfo,
-                }
-                setMessages([...messages(), errorMsg])
-              }
-            }
-          } catch (e) {
-            if (e instanceof SyntaxError) continue // Skip malformed JSON
-            throw e
+        // Reactive graph update on tool_result events
+        if (evt.type === 'tool_result' && props.onGraphUpdate) {
+          const graphElements = extractGraphElements([evt])
+          if (graphElements.length > 0) {
+            props.onGraphUpdate(graphElements)
           }
+        }
+
+        // Convert error events to inline chat messages
+        if (evt.type === 'error') {
+          const errorData = evt.data as { error: string; severity?: string; hint?: string; turn?: number; iteration?: number }
+          // Build context string (e.g., "(turn 3, attempt 2)")
+          const parts: string[] = []
+          if (errorData.turn !== undefined) parts.push(`turn ${errorData.turn + 1}`)
+          if (errorData.iteration !== undefined) parts.push(`attempt ${errorData.iteration + 1}`)
+          const turnInfo = parts.length > 0 ? `(${parts.join(', ')})` : undefined
+          const errorMsg: Message = {
+            id: `err-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+            role: errorData.severity === 'recoverable' ? 'warning' : 'error',
+            content: errorData.error,
+            timestamp: new Date(),
+            hint: errorData.hint,
+            patternId: evt.patternId,
+            turnInfo,
+          }
+          setMessages([...messages(), errorMsg])
         }
       }
 

--- a/ui/src/components/ark-ui/ChatInterface.tsx
+++ b/ui/src/components/ark-ui/ChatInterface.tsx
@@ -12,15 +12,17 @@
  * Architecture:
  * - Uses harness-client server actions
  * - ContextEvents streamed to parent for observability
- * - Session ID per component instance
+ * - Per-session progress + run state lives in the parent route — see #47.
+ *   The fetch loop captures `runSessionId` at submit time and routes ingest
+ *   calls into the correct controller even after the user switches threads.
  */
 
-import { createSignal, createEffect, onMount } from 'solid-js'
+import { createSignal, createEffect, createMemo, onMount } from 'solid-js'
 import { ChatMessages, type Message } from './ChatMessages'
 import { ChatInput } from './ChatInput'
 import { AgentSelector } from './AgentSelector'
 import { LiveProgressBar } from './LiveProgressBar'
-import { createChainProgress } from './useChainProgress'
+import type { ChainProgressController } from './useChainProgress'
 import {
   approveAction,
   rejectAction,
@@ -30,11 +32,23 @@ import {
 } from '~/lib/harness-client'
 import { getSettings } from '~/lib/settings-store'
 import type { GraphElement } from './SupportPanel'
-import type { ContextEvent, UnifiedContext } from '~/lib/harness-patterns'
+import type { ContextEvent, UnifiedContext, ControllerActionEventData } from '~/lib/harness-patterns'
 
 // ============================================================================
 // Types
 // ============================================================================
+
+/**
+ * Per-session UI run state. Lives at the route so progress and the submit
+ * guard survive sidebar switches — see #47.
+ */
+export interface SessionRunState {
+  /** A submit for this session is in flight (SSE stream open). */
+  isProcessing: boolean
+  /** Tool name from the latest `controller_action` event of the active loop.
+   *  Drives the composer guard banner ("Waiting for `<tool>`…"). */
+  runningTool: string | null
+}
 
 export interface ChatInterfaceProps {
   /** Session ID for server-side state (shared with SupportPanel for stash actions).
@@ -52,6 +66,12 @@ export interface ChatInterfaceProps {
   graphEntityNames?: Map<string, string[]>
   /** Callback to highlight specific graph element IDs */
   onHighlightEntities?: (ids: string[]) => void
+  // ---- Per-session progress + run state (lives in the route, see #47) ----
+  getProgress: (sessionId: string) => ChainProgressController
+  getRunState: (sessionId: string) => SessionRunState
+  updateRunState: (sessionId: string, patch: Partial<SessionRunState>) => void
+  registerAbortController: (sessionId: string, ac: AbortController) => void
+  unregisterAbortController: (sessionId: string) => void
 }
 
 const WELCOME_MESSAGE: Message = {
@@ -67,12 +87,19 @@ const WELCOME_MESSAGE: Message = {
 
 export const ChatInterface = (props: ChatInterfaceProps) => {
   const [messages, setMessages] = createSignal<Message[]>([])
-  const [isProcessing, setIsProcessing] = createSignal(false)
   const [selectedAgent, setSelectedAgent] = createSignal('default')
-  const progress = createChainProgress()
   // Cursor into ctx.events — tracks how many events were sent last turn so we
   // emit only the delta (new events) rather than the full accumulated history
   let prevEventCount = 0
+
+  // Reactive accessors into the per-session registries owned by the route.
+  // Re-reading `props.sessionId` inside the memo means snapshot/run-state
+  // tracking automatically swaps when the user picks a different thread.
+  const currentProgress = createMemo(() => props.getProgress(props.sessionId))
+  const currentSnapshot = () => currentProgress().snapshot()
+  const currentRunState = () => props.getRunState(props.sessionId)
+  const isProcessing = () => currentRunState().isProcessing
+  const runningTool = () => currentRunState().runningTool
 
   onMount(() => {
     setMessages([WELCOME_MESSAGE])
@@ -133,16 +160,32 @@ export const ChatInterface = (props: ChatInterfaceProps) => {
   }
 
   const handleSendMessage = async (content: string) => {
-    // Add user message
-    const userMessage: Message = {
-      id: Date.now().toString(),
-      role: 'user',
-      content,
-      timestamp: new Date()
-    }
-    setMessages([...messages(), userMessage])
-    setIsProcessing(true)
+    // Snapshot the active sessionId at submit time. The user may switch
+    // threads mid-stream; without this, late-arriving events would corrupt
+    // whichever thread happens to be in view (#47).
+    const runSessionId = props.sessionId
+
+    // Per-session progress controller — owned by the route registry so it
+    // survives the user navigating away to a different chat.
+    const progress = props.getProgress(runSessionId)
     progress.reset()
+    props.updateRunState(runSessionId, { isProcessing: true, runningTool: null })
+
+    // Add user message — only if we're still on this thread. (If the user
+    // submits, then immediately switches, the local view belongs to the new
+    // thread and we should not pollute it with the old message.)
+    if (runSessionId === props.sessionId) {
+      const userMessage: Message = {
+        id: Date.now().toString(),
+        role: 'user',
+        content,
+        timestamp: new Date()
+      }
+      setMessages([...messages(), userMessage])
+    }
+
+    const abortController = new AbortController()
+    props.registerAbortController(runSessionId, abortController)
 
     try {
       // Stream events via SSE endpoint for real-time updates
@@ -150,11 +193,12 @@ export const ChatInterface = (props: ChatInterfaceProps) => {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          sessionId: props.sessionId,
+          sessionId: runSessionId,
           message: content,
           agentId: selectedAgent(),
           settings: getSettings()
-        })
+        }),
+        signal: abortController.signal,
       })
 
       if (!response.ok) {
@@ -202,8 +246,32 @@ export const ChatInterface = (props: ChatInterfaceProps) => {
             } else if (eventType === 'error') {
               throw new Error(parsed.error)
             } else if (parsed.type) {
-              // Regular event — stream to UI
+              // Regular event — stream to UI. The SSE envelope carries
+              // sessionId (#47); ignore it before treating the body as a
+              // ContextEvent.
               const evt = parsed as ContextEvent
+
+              // Progress is always routed into the captured run session's
+              // controller, even if the user has navigated away.
+              progress.ingest(evt)
+
+              // Surface the currently-running tool for the composer guard.
+              if (evt.type === 'controller_action') {
+                const data = evt.data as ControllerActionEventData
+                const toolName = data.action?.tool_name
+                if (toolName && toolName !== 'Return') {
+                  props.updateRunState(runSessionId, { runningTool: toolName })
+                } else if (data.action?.is_final) {
+                  props.updateRunState(runSessionId, { runningTool: null })
+                }
+              }
+
+              // The remaining route-level state (events, graph, messages) is
+              // only owned by the actively-displayed session — drop events
+              // from a backgrounded stream rather than corrupt the view. The
+              // server-side persistence catches everything up on rehydrate.
+              if (runSessionId !== props.sessionId) continue
+
               if (props.onEventsUpdate) {
                 props.onEventsUpdate([evt])
               }
@@ -215,10 +283,6 @@ export const ChatInterface = (props: ChatInterfaceProps) => {
                   props.onGraphUpdate(graphElements)
                 }
               }
-
-              // Feed every event into the chain-progress hook — it derives
-              // running current/total/status across the whole chain.
-              progress.ingest(evt)
 
               // Convert error events to inline chat messages
               if (evt.type === 'error') {
@@ -250,18 +314,20 @@ export const ChatInterface = (props: ChatInterfaceProps) => {
       // Mark progress complete — bar fills, fades, and unmounts.
       progress.finish()
 
-      // Update event count cursor and emit final context
+      // Update event count cursor and emit final context — but only if the
+      // user is still looking at this thread.
       if (finalResult?.context) {
         prevEventCount = finalResult.context.events?.length ?? 0
-        if (props.onContextUpdate) {
+        if (runSessionId === props.sessionId && props.onContextUpdate) {
           props.onContextUpdate(finalResult.context as UnifiedContext)
         }
       }
 
       // Build assistant message from final result — only if there's a real response
-      // (not an error status with empty/stale response)
+      // (not an error status with empty/stale response). Drop it silently if the
+      // user has switched away; the persisted row will surface it on reload.
       const finalResponse = finalResult?.response ?? ''
-      if (finalResponse && finalResult?.status !== 'error') {
+      if (runSessionId === props.sessionId && finalResponse && finalResult?.status !== 'error') {
         const assistantMessage: Message = {
           id: Date.now().toString(),
           role: 'assistant',
@@ -278,23 +344,29 @@ export const ChatInterface = (props: ChatInterfaceProps) => {
         setMessages([...messages(), assistantMessage])
       }
     } catch (error) {
-      console.error('Error processing message:', error)
-
-      const errorMessage: Message = {
-        id: Date.now().toString(),
-        role: 'error',
-        content: error instanceof Error ? error.message : 'Unknown error',
-        timestamp: new Date()
+      // Suppress the noisy AbortError that fires on page-unload teardown.
+      const aborted = error instanceof DOMException && error.name === 'AbortError'
+      if (!aborted) {
+        console.error('Error processing message:', error)
+        if (runSessionId === props.sessionId) {
+          const errorMessage: Message = {
+            id: Date.now().toString(),
+            role: 'error',
+            content: error instanceof Error ? error.message : 'Unknown error',
+            timestamp: new Date()
+          }
+          setMessages([...messages(), errorMessage])
+        }
       }
       progress.finish()
-      setMessages([...messages(), errorMessage])
     } finally {
-      setIsProcessing(false)
+      props.updateRunState(runSessionId, { isProcessing: false, runningTool: null })
+      props.unregisterAbortController(runSessionId)
     }
   }
 
   const handleApproveWrite = async (messageId: string) => {
-    setIsProcessing(true)
+    props.updateRunState(props.sessionId, { isProcessing: true })
 
     try {
       // Execute the approved operation
@@ -357,7 +429,7 @@ export const ChatInterface = (props: ChatInterfaceProps) => {
       }
       setMessages([...messages(), errorMessage])
     } finally {
-      setIsProcessing(false)
+      props.updateRunState(props.sessionId, { isProcessing: false })
     }
   }
 
@@ -388,6 +460,13 @@ export const ChatInterface = (props: ChatInterfaceProps) => {
     } catch (error) {
       console.error('Error rejecting write:', error)
     }
+  }
+
+  // Composer guard banner — set when the active session has a tool in flight.
+  const blockedMessage = () => {
+    const tool = runningTool()
+    if (!isProcessing() || !tool) return undefined
+    return `Waiting for \`${tool}\` to complete. Try later.`
   }
 
   return (
@@ -421,14 +500,14 @@ export const ChatInterface = (props: ChatInterfaceProps) => {
           onHighlightEntities={props.onHighlightEntities}
           trailing={() => (
             <LiveProgressBar
-              status={progress.snapshot().status}
-              current={progress.snapshot().currentTurn}
-              pathProjection={progress.snapshot().pathProjection}
-              maxProjection={progress.snapshot().maxProjection}
+              status={currentSnapshot().status}
+              current={currentSnapshot().currentTurn}
+              pathProjection={currentSnapshot().pathProjection}
+              maxProjection={currentSnapshot().maxProjection}
               visible={
                 isProcessing() &&
-                !progress.snapshot().done &&
-                progress.snapshot().maxProjection > 0
+                !currentSnapshot().done &&
+                currentSnapshot().maxProjection > 0
               }
             />
           )}
@@ -436,7 +515,11 @@ export const ChatInterface = (props: ChatInterfaceProps) => {
 
       {/* Input */}
       <div border="t dark-border-primary" p="4" bg="dark-bg-secondary/80" backdrop-blur="sm">
-        <ChatInput onSend={handleSendMessage} disabled={isProcessing()} />
+        <ChatInput
+          onSend={handleSendMessage}
+          disabled={isProcessing()}
+          blockedMessage={blockedMessage()}
+        />
       </div>
     </div>
   )

--- a/ui/src/components/ark-ui/ChatInterface.tsx
+++ b/ui/src/components/ark-ui/ChatInterface.tsx
@@ -73,6 +73,10 @@ export interface ChatInterfaceProps {
   updateRunState: (sessionId: string, patch: Partial<SessionRunState>) => void
   registerAbortController: (sessionId: string, ac: AbortController) => void
   unregisterAbortController: (sessionId: string) => void
+  /** Push-driven sidebar title update — fired when the server emits a
+   *  `title_updated` SSE event after the first-turn LLM title resolves.
+   *  Route patches its threads cache in-place; no refetch required. */
+  onTitleUpdated?: (sessionId: string, title: string) => void
 }
 
 const WELCOME_MESSAGE: Message = {
@@ -217,6 +221,14 @@ export const ChatInterface = (props: ChatInterfaceProps) => {
         }
         if (sseEvt.event === 'error') {
           throw new Error((sseEvt.data as { error: string }).error)
+        }
+        if (sseEvt.event === 'title_updated') {
+          // Server pushed the LLM-generated title for this conversation —
+          // patch the sidebar's threads cache in place. Lands regardless of
+          // which thread the user is currently viewing.
+          const { sessionId: sid, title } = sseEvt.data
+          props.onTitleUpdated?.(sid, title)
+          continue
         }
         if (sseEvt.event !== 'message') continue // Forward-compat: ignore unknown event names
 

--- a/ui/src/components/ark-ui/ChatSidebar.tsx
+++ b/ui/src/components/ark-ui/ChatSidebar.tsx
@@ -12,7 +12,7 @@ export interface ChatThreadSummary {
   isPlaceholder?: boolean
 }
 
-const PLACEHOLDER_TITLE = 'description will appear here'
+const PLACEHOLDER_TITLE = 'new chat'
 
 /**
  * Merge the optimistic "+ New Chat" placeholder with the persisted thread

--- a/ui/src/components/ark-ui/ChatSidebar.tsx
+++ b/ui/src/components/ark-ui/ChatSidebar.tsx
@@ -1,5 +1,6 @@
-import { For, Show } from 'solid-js'
+import { For, Show, createSignal } from 'solid-js'
 import { SettingsPanel } from './SettingsPanel'
+import { regenerateConversationTitle } from '../../lib/harness-client'
 
 export interface ChatThreadSummary {
   id: string
@@ -62,9 +63,36 @@ interface ChatSidebarProps {
   selectedId: string | null
   onSelectThread: (threadId: string) => void
   onNewChat: () => void
+  /** Called when the user clicks the per-row ↻ button to regenerate the
+   *  LLM title. The sidebar handles the server action itself, then forwards
+   *  the new title so the parent can patch its threads cache in-place. */
+  onTitleRegenerated?: (sessionId: string, title: string) => void
 }
 
 export const ChatSidebar = (props: ChatSidebarProps) => {
+  // Per-thread pending state for the ↻ button — keyed by sessionId.
+  const [pendingRegen, setPendingRegen] = createSignal<ReadonlySet<string>>(new Set())
+
+  const handleRegenerate = async (e: MouseEvent, threadId: string) => {
+    // Stop the click from also selecting the thread.
+    e.stopPropagation()
+    e.preventDefault()
+    if (pendingRegen().has(threadId)) return
+    setPendingRegen(prev => new Set(prev).add(threadId))
+    try {
+      const title = await regenerateConversationTitle(threadId)
+      if (title) props.onTitleRegenerated?.(threadId, title)
+    } catch (err) {
+      console.error('[sidebar] regenerate title failed:', err)
+    } finally {
+      setPendingRegen(prev => {
+        const next = new Set(prev)
+        next.delete(threadId)
+        return next
+      })
+    }
+  }
+
   return (
     <div
       flex="~ col"
@@ -122,6 +150,7 @@ export const ChatSidebar = (props: ChatSidebarProps) => {
                 <For each={props.threads}>
                   {(thread) => {
                     const isSelected = () => thread.id === props.selectedId
+                    const isRegenerating = () => pendingRegen().has(thread.id)
                     return (
                       <button
                         onClick={() => props.onSelectThread(thread.id)}
@@ -135,11 +164,14 @@ export const ChatSidebar = (props: ChatSidebarProps) => {
                         border={isSelected() ? '1 neon-cyan/40' : '1 transparent hover:neon-cyan/30'}
                         cursor="pointer"
                         data-placeholder={thread.isPlaceholder ? '' : undefined}
+                        relative=""
+                        class="group"
                       >
                         <div
                           text={thread.isPlaceholder ? 'sm dark-text-tertiary' : 'sm dark-text-primary'}
                           font={thread.isPlaceholder ? 'normal italic' : 'medium'}
                           truncate
+                          pr="6"
                         >
                           {thread.isPlaceholder
                             ? PLACEHOLDER_TITLE
@@ -148,6 +180,47 @@ export const ChatSidebar = (props: ChatSidebarProps) => {
                         <div text="xs dark-text-tertiary" m="t-1">
                           {formatTimestamp(thread.updatedAt)}
                         </div>
+                        {/* Hover-reveal regenerate-title button. Hidden for
+                            placeholder rows (nothing persisted yet). Spinning
+                            while the LLM call is in flight. Sits in a span
+                            outside the outer <button> hit area so nested-
+                            interactive semantics stay valid. */}
+                        <Show when={!thread.isPlaceholder}>
+                          <span
+                            aria-hidden="true"
+                            onClick={(e) => handleRegenerate(e, thread.id)}
+                            title="Regenerate title"
+                            style={{
+                              position: 'absolute',
+                              top: '0.5rem',
+                              right: '0.5rem',
+                              padding: '0.25rem',
+                              'border-radius': '0.375rem',
+                              cursor: 'pointer',
+                              opacity: isRegenerating() ? 1 : undefined,
+                              'pointer-events': isRegenerating() ? 'none' : 'auto',
+                            }}
+                            text="xs dark-text-tertiary hover:neon-cyan"
+                            transition="opacity"
+                            class={isRegenerating() ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'}
+                          >
+                            <svg
+                              width="14"
+                              height="14"
+                              fill="none"
+                              stroke="currentColor"
+                              viewBox="0 0 24 24"
+                              class={isRegenerating() ? 'animate-spin' : ''}
+                            >
+                              <path
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                                stroke-width="2"
+                                d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+                              />
+                            </svg>
+                          </span>
+                        </Show>
                       </button>
                     )
                   }}

--- a/ui/src/components/ark-ui/ChatSidebar.tsx
+++ b/ui/src/components/ark-ui/ChatSidebar.tsx
@@ -6,6 +6,37 @@ export interface ChatThreadSummary {
   title: string | null
   /** ISO 8601 timestamp from the server. */
   updatedAt: string
+  /** Optimistic client-side row for a brand-new chat that hasn't been
+   *  persisted yet. Replaced in place once the real row appears in the
+   *  threadsResource refetch. */
+  isPlaceholder?: boolean
+}
+
+const PLACEHOLDER_TITLE = 'description will appear here'
+
+/**
+ * Merge the optimistic "+ New Chat" placeholder with the persisted thread
+ * list. When the persisted list already contains a row with the placeholder's
+ * id (the conversation has been saved), the placeholder is dropped — the real
+ * row takes over with its sticky title and timestamp. See #44.
+ *
+ * Pure: no Solid signals, no DOM — straightforward to unit test.
+ */
+export function mergeThreadsWithPlaceholder(
+  threads: ChatThreadSummary[],
+  placeholderId: string | null,
+  /** Defaults to `Date.now()` — overrideable for deterministic tests. */
+  nowIso: () => string = () => new Date().toISOString(),
+): ChatThreadSummary[] {
+  if (!placeholderId) return threads
+  if (threads.some(t => t.id === placeholderId)) return threads
+  const placeholder: ChatThreadSummary = {
+    id: placeholderId,
+    title: null,
+    updatedAt: nowIso(),
+    isPlaceholder: true,
+  }
+  return [placeholder, ...threads]
 }
 
 const formatTimestamp = (iso: string): string => {
@@ -103,9 +134,16 @@ export const ChatSidebar = (props: ChatSidebarProps) => {
                         transition="all"
                         border={isSelected() ? '1 neon-cyan/40' : '1 transparent hover:neon-cyan/30'}
                         cursor="pointer"
+                        data-placeholder={thread.isPlaceholder ? '' : undefined}
                       >
-                        <div text="sm dark-text-primary" font="medium" truncate>
-                          {thread.title ?? '(untitled)'}
+                        <div
+                          text={thread.isPlaceholder ? 'sm dark-text-tertiary' : 'sm dark-text-primary'}
+                          font={thread.isPlaceholder ? 'normal italic' : 'medium'}
+                          truncate
+                        >
+                          {thread.isPlaceholder
+                            ? PLACEHOLDER_TITLE
+                            : thread.title ?? '(untitled)'}
                         </div>
                         <div text="xs dark-text-tertiary" m="t-1">
                           {formatTimestamp(thread.updatedAt)}

--- a/ui/src/lib/db/conversations.server.ts
+++ b/ui/src/lib/db/conversations.server.ts
@@ -141,6 +141,27 @@ export async function deleteConversation(
 }
 
 /**
+ * Authoritative title override. Bypasses the COALESCE-sticky rule that
+ * `saveConversation` applies on upsert — used by the LLM title generator
+ * to replace the heuristic title with a model-authored one once it lands.
+ *
+ * Safe by construction: the WHERE clause includes `user_id`, so a wrong
+ * userId silently no-ops (zero rows affected) rather than overwriting
+ * another user's title.
+ */
+export async function updateConversationTitle(
+  id: string,
+  userId: string,
+  title: string,
+): Promise<void> {
+  await query(
+    `UPDATE conversations SET title = $1, updated_at = NOW()
+     WHERE id = $2 AND user_id = $3`,
+    [title, id, userId],
+  )
+}
+
+/**
  * Derive a sticky title from the first user message: trimmed, single-line,
  * capped at 60 chars. Returns null if the input is empty.
  */

--- a/ui/src/lib/harness-client/actions.server.ts
+++ b/ui/src/lib/harness-client/actions.server.ts
@@ -256,3 +256,28 @@ export async function loadConversation(
   };
 }
 
+/**
+ * Regenerate the LLM-authored title for an existing conversation. Bound
+ * to the sidebar's hover-reveal ↻ button. Loads the session's stored
+ * context, runs the minimal title-generator harness agent against the
+ * most recent user message, and persists the result via
+ * `updateConversationTitle()` (bypasses the COALESCE-sticky upsert).
+ *
+ * Returns the new title on success, or null when the conversation has
+ * no user messages, isn't found, or the LLM call fails — silent failure
+ * leaves the existing title in place.
+ */
+export async function regenerateConversationTitle(
+  sessionId: string,
+): Promise<string | null> {
+  const user = await requireUser();
+  const loaded = await loadSession(sessionId, user.id);
+  if (!loaded) return null;
+  const { deserializeContext } = await import("../harness-patterns");
+  const { runRegenerateTitle } = await import(
+    "./examples/title-generator.server"
+  );
+  const ctx = deserializeContext(loaded.serializedContext);
+  return runRegenerateTitle(ctx, sessionId, user.id);
+}
+

--- a/ui/src/lib/harness-client/actions.server.ts
+++ b/ui/src/lib/harness-client/actions.server.ts
@@ -17,8 +17,6 @@ import {
   continueSession,
   type HarnessResultScoped,
   type ContextEvent,
-  type UserMessageEventData,
-  type AssistantMessageEventData,
 } from "../harness-patterns";
 import {
   getOrBuildPatterns,
@@ -222,13 +220,10 @@ export async function listConversations(): Promise<ConversationSummary[]> {
   }));
 }
 
-export interface ReplayedMessage {
-  id: string;
-  role: "user" | "assistant";
-  content: string;
-  /** Epoch ms — convert to Date on the client. */
-  timestamp: number;
-}
+// Replay helper extracted to a dependency-free module so it can be unit-tested
+// without dragging in the auth/DB import graph. Re-export the type for callers.
+import { replayMessages, type ReplayedMessage } from "./replay";
+export type { ReplayedMessage };
 
 export interface LoadedConversation {
   id: string;
@@ -261,33 +256,3 @@ export async function loadConversation(
   };
 }
 
-function replayMessages(serializedContext: string): ReplayedMessage[] {
-  let parsed: { events?: ContextEvent[] };
-  try {
-    parsed = JSON.parse(serializedContext) as { events?: ContextEvent[] };
-  } catch {
-    return [];
-  }
-  const events = parsed.events ?? [];
-  const out: ReplayedMessage[] = [];
-  for (const ev of events) {
-    if (ev.type === "user_message") {
-      const data = ev.data as UserMessageEventData;
-      out.push({
-        id: ev.id ?? `replay-${out.length}`,
-        role: "user",
-        content: data.content ?? "",
-        timestamp: ev.ts,
-      });
-    } else if (ev.type === "assistant_message") {
-      const data = ev.data as AssistantMessageEventData;
-      out.push({
-        id: ev.id ?? `replay-${out.length}`,
-        role: "assistant",
-        content: data.content ?? "",
-        timestamp: ev.ts,
-      });
-    }
-  }
-  return out;
-}

--- a/ui/src/lib/harness-client/examples/README.md
+++ b/ui/src/lib/harness-client/examples/README.md
@@ -42,6 +42,32 @@ compositions across all available MCP servers.
 
 ## Examples
 
+### 0. Title Generator — minimum-rung example
+
+**Servers**: none (no MCP)
+**Patterns**: `synthesizer({ mode: 'message', synthesize })`
+**Use case**: Generate a 3-5 word conversation title from the user's first message.
+
+The smallest legal harness composition — one pattern, one BAML call, ~20 LoC. Demonstrates that the library is appropriate for one-shot LLM jobs, not just multi-pattern agentic workflows. Used in production by `/api/events` post-stream to title new conversations as soon as the first response lands.
+
+```typescript
+// ui/src/lib/harness-client/examples/title-generator.server.ts
+export const titleAgent = harness<TitleAgentData>(
+  synthesizer<TitleAgentData>({
+    patternId: 'title-gen',
+    mode: 'message',
+    synthesize: async ({ userMessage }) => {
+      const raw = await b.GenerateConversationTitle(userMessage)
+      return sanitizeTitle(raw) ?? ''
+    },
+  }),
+)
+```
+
+`mode: 'message'` makes the synthesizer a thin shell around the custom `synthesize` fn — it pulls the latest `user_message` from the view and hands it to the function as `input.userMessage`. No router, no tools, no loop.
+
+---
+
 ### 1. Documentation Assistant
 
 **Servers**: context7, memory

--- a/ui/src/lib/harness-client/examples/title-generator.server.ts
+++ b/ui/src/lib/harness-client/examples/title-generator.server.ts
@@ -1,0 +1,169 @@
+/**
+ * Title Generator — minimal one-pattern harness example.
+ *
+ * The smallest legal harness-patterns composition: a single `synthesizer`
+ * pattern wired through `harness()`, with a custom `synthesize` fn that
+ * calls a single BAML function (`GenerateConversationTitle`).
+ *
+ * Demonstrates that the harness is appropriate for one-shot LLM jobs, not
+ * just multi-pattern agentic workflows. Used both in production (by
+ * `/api/events` post-stream to generate the conversation title after the
+ * first turn) and as a reference example for the harness-patterns library
+ * extraction (this file is what consumers see when looking for the
+ * "absolute minimum viable agent").
+ *
+ * Why `synthesizer({ mode: 'message' })`?
+ *   In `mode: 'message'`, the synthesizer's input carries the latest user
+ *   message and expects a string back from the optional `synthesize` fn.
+ *   That's exactly the shape of "give the LLM the user's first message,
+ *   get a title string." No loops, no tools, no router.
+ *
+ * Library boundary: imports only from `~/lib/harness-patterns` and
+ * `~/baml_client`. No imports from `~/components` or other consumers —
+ * keeps the agent extractable as a standalone npm package example.
+ */
+"use server";
+
+import { harness, synthesizer } from "../../harness-patterns";
+import type {
+  HarnessData,
+  UnifiedContext,
+  UserMessageEventData,
+} from "../../harness-patterns";
+import { b } from "../../../../baml_client";
+import { updateConversationTitle } from "../../db/conversations.server";
+
+/**
+ * Data shape carried through the title agent's harness context. Has to
+ * satisfy both `harness()`'s `HarnessData & Record<string, unknown>` and
+ * `synthesizer()`'s `SynthesizerData` (which expects optional `response`,
+ * `synthesizedResponse`, `intent`, `loopHistory`). The empty index
+ * signature wires up the structural subtype.
+ */
+interface TitleAgentData extends HarnessData {
+  response?: string;
+  synthesizedResponse?: string;
+  [key: string]: unknown;
+}
+
+// ============================================================================
+// Validation & sanitization
+// ============================================================================
+
+const MAX_TITLE_CHARS = 50;
+
+/**
+ * Best-effort cleanup of model output. The prompt asks for a bare title,
+ * but small/fast models occasionally wrap in quotes, add a trailing
+ * period, or echo a multiline preamble — strip all of those defensively.
+ * Empty / unreasonably long → returns null so the caller skips the DB write.
+ */
+export function sanitizeTitle(raw: string): string | null {
+  const stripped = raw
+    .trim()
+    .replace(/^["'`]+|["'`]+$/g, "") // surrounding quotes / backticks
+    .replace(/[.!?]+$/, "")           // trailing punctuation
+    .split("\n")[0]                    // first line only
+    .trim();
+  if (!stripped) return null;
+  return stripped.slice(0, MAX_TITLE_CHARS);
+}
+
+// ============================================================================
+// The agent
+// ============================================================================
+
+/**
+ * The whole agent is one pattern. `mode: 'message'` makes the synthesizer
+ * a thin shell around our custom `synthesize` fn — no default BAML call,
+ * no event tracking beyond `assistant_message`.
+ */
+export const titleAgent = harness<TitleAgentData>(
+  synthesizer<TitleAgentData>({
+    patternId: "title-gen",
+    mode: "message",
+    synthesize: async ({ userMessage }) => {
+      const raw = await b.GenerateConversationTitle(userMessage);
+      return sanitizeTitle(raw) ?? "";
+    },
+  }),
+);
+
+// ============================================================================
+// Production entry points
+// ============================================================================
+
+/** Extract the user_message events from a UnifiedContext, oldest first.
+ *  Untyped data parameter so callers can pass `deserializeContext()` output
+ *  (UnifiedContext<unknown>) without first widening it. */
+function userMessages(ctx: UnifiedContext<unknown>): string[] {
+  return (ctx.events ?? [])
+    .filter((e) => e.type === "user_message")
+    .map((e) => (e.data as UserMessageEventData).content ?? "");
+}
+
+/** Returns true iff this turn was the first user_message of the conversation. */
+function isFirstTurn(ctx: UnifiedContext<unknown>): boolean {
+  return userMessages(ctx).length === 1;
+}
+
+/**
+ * First-turn entry point. Called from `/api/events` after the SSE `done`
+ * frame, before the stream closes. Skips (returns null) when this isn't
+ * the first turn — titles are only auto-generated once per conversation.
+ *
+ * Failure modes (LLM throws, returns empty, sanitizer rejects) all return
+ * null, leaving the heuristic title (set by `deriveTitle` in
+ * `saveConversation`) in place. No retry, no error event.
+ */
+export async function runFirstTurnTitleGen(
+  ctx: UnifiedContext<unknown>,
+  sessionId: string,
+  userId: string,
+): Promise<string | null> {
+  if (!isFirstTurn(ctx)) return null;
+  const firstUserMessage = userMessages(ctx)[0];
+  if (!firstUserMessage) return null;
+  return runTitleAgent(firstUserMessage, sessionId, userId);
+}
+
+/**
+ * On-demand entry point. No first-turn gate. Called from the sidebar's
+ * regenerate-title button via `regenerateConversationTitle` server action
+ * — re-runs the agent with the most recent user message in context (so
+ * a chat that has drifted topic gets a refreshed title).
+ *
+ * Could be evolved to summarize across all messages, but keeps the same
+ * one-pattern shape for now — first iteration: take the latest user message.
+ */
+export async function runRegenerateTitle(
+  ctx: UnifiedContext<unknown>,
+  sessionId: string,
+  userId: string,
+): Promise<string | null> {
+  const messages = userMessages(ctx);
+  const seed = messages[messages.length - 1] ?? messages[0];
+  if (!seed) return null;
+  return runTitleAgent(seed, sessionId, userId);
+}
+
+/** Shared helper — runs the agent, persists on success, swallows failures. */
+async function runTitleAgent(
+  userMessage: string,
+  sessionId: string,
+  userId: string,
+): Promise<string | null> {
+  try {
+    // The agent generates its own throwaway sessionId for the harness
+    // context; we pass a deterministic one for traceability in logs.
+    const result = await titleAgent(userMessage, `title-gen-${sessionId}`);
+    const title = sanitizeTitle(result.response);
+    if (!title) return null;
+    await updateConversationTitle(sessionId, userId, title);
+    return title;
+  } catch (err) {
+    // Silent fallthrough — heuristic title remains in the DB row.
+    console.error("[title-gen] failed:", err);
+    return null;
+  }
+}

--- a/ui/src/lib/harness-client/index.ts
+++ b/ui/src/lib/harness-client/index.ts
@@ -15,6 +15,7 @@ export {
   getAgentList,
   listConversations,
   loadConversation,
+  regenerateConversationTitle,
   type ConversationSummary,
   type LoadedConversation,
   type ReplayedMessage

--- a/ui/src/lib/harness-client/replay.ts
+++ b/ui/src/lib/harness-client/replay.ts
@@ -1,0 +1,65 @@
+/**
+ * Chat-history replay — convert a serialized `UnifiedContext` back into the
+ * minimal `{ id, role, content, timestamp }[]` list the UI paints when a
+ * conversation is restored from the sidebar.
+ *
+ * Pure data transformation — no server-only dependencies, no DB, no auth.
+ * Lives outside `actions.server.ts` so it can be unit-tested directly
+ * without dragging in the auth/DB import graph.
+ *
+ * Key rule (issue: residual "Let me look into that…" on hydration):
+ * router emits `assistant_message` events for intermediate routing status
+ * AND the synthesizer (or direct-response router) emits one for the
+ * user-facing final response. We discriminate via
+ * `AssistantMessageEventData.final === true` — only `final` emits become
+ * chat bubbles on replay.
+ */
+import type {
+  ContextEvent,
+  AssistantMessageEventData,
+  UserMessageEventData,
+} from '../harness-patterns'
+
+export interface ReplayedMessage {
+  id: string
+  role: 'user' | 'assistant'
+  content: string
+  /** Epoch ms — convert to Date on the client. */
+  timestamp: number
+}
+
+export function replayMessages(serializedContext: string): ReplayedMessage[] {
+  let parsed: { events?: ContextEvent[] }
+  try {
+    parsed = JSON.parse(serializedContext) as { events?: ContextEvent[] }
+  } catch {
+    return []
+  }
+  const events = parsed.events ?? []
+  const out: ReplayedMessage[] = []
+  for (const ev of events) {
+    if (ev.type === 'user_message') {
+      const data = ev.data as UserMessageEventData
+      out.push({
+        id: ev.id ?? `replay-${out.length}`,
+        role: 'user',
+        content: data.content ?? '',
+        timestamp: ev.ts,
+      })
+    } else if (ev.type === 'assistant_message') {
+      const data = ev.data as AssistantMessageEventData
+      // Skip intermediate router status messages ("Let me look into that…").
+      // Only the synthesizer's (or direct-response router's) final emit
+      // carries `final: true` and should surface as a chat bubble on replay.
+      // The live UI handles this implicitly by only painting `finalResult.response`.
+      if (!data.final) continue
+      out.push({
+        id: ev.id ?? `replay-${out.length}`,
+        role: 'assistant',
+        content: data.content ?? '',
+        timestamp: ev.ts,
+      })
+    }
+  }
+  return out
+}

--- a/ui/src/lib/harness-patterns/patterns/router.server.ts
+++ b/ui/src/lib/harness-patterns/patterns/router.server.ts
@@ -134,11 +134,13 @@ export function router<T extends RouterData>(
           response: responseText
         }
 
-        // Track assistant message with LLM call data
+        // Track assistant message with LLM call data. `final: true` because
+        // on the conversational route the router IS the final responder —
+        // the downstream synthesizer skips BAML in this case.
         trackEvent(
           scope,
           'assistant_message',
-          { content: responseText } as AssistantMessageEventData,
+          { content: responseText, final: true } as AssistantMessageEventData,
           resolved.trackHistory,
           result.llmCall
         )
@@ -153,7 +155,10 @@ export function router<T extends RouterData>(
         return scope
       }
 
-      // Track the routing decision as an assistant message with LLM data
+      // Track the routing decision as an assistant message with LLM data.
+      // No `final` flag — this is an intermediate "Looking into that…"
+      // status that the synthesizer will later supersede with the real
+      // response. Chat-history replay filters these out.
       const statusText = result.response_text || ''
       if (statusText) {
         trackEvent(

--- a/ui/src/lib/harness-patterns/patterns/synthesizer.server.ts
+++ b/ui/src/lib/harness-patterns/patterns/synthesizer.server.ts
@@ -299,11 +299,14 @@ export function synthesizer<T extends SynthesizerData>(
         llmCall = result.llmCall
       }
 
-      // Track assistant message event with LLM call data
+      // Track assistant message event with LLM call data. `final: true`
+      // distinguishes the synthesizer's user-facing response from router
+      // status messages that share the same event type — chat-history
+      // replay reads this flag to skip intermediate emits.
       trackEvent(
         scope,
         'assistant_message',
-        { content: synthesizedResponse } as AssistantMessageEventData,
+        { content: synthesizedResponse, final: true } as AssistantMessageEventData,
         resolved.trackHistory,
         llmCall
       )

--- a/ui/src/lib/harness-patterns/types.ts
+++ b/ui/src/lib/harness-patterns/types.ts
@@ -465,6 +465,11 @@ export interface UserMessageEventData {
 /** Data payload for assistant_message event */
 export interface AssistantMessageEventData {
   content: string
+  /** Set to true on the synthesizer's user-facing final response. Used by
+   *  chat-history replay to filter out intermediate router status messages
+   *  (e.g. "Let me look into that…") that share the same event type.
+   *  Absent / false on router/intermediate emits. */
+  final?: boolean
 }
 
 /** Data payload for tool_call event */

--- a/ui/src/lib/sse-client.ts
+++ b/ui/src/lib/sse-client.ts
@@ -1,0 +1,157 @@
+/**
+ * Typed SSE parser for the `/api/events` chat stream.
+ *
+ * Wraps a `Response.body` ReadableStream and yields a discriminated union of
+ * event types. Replaces the hand-rolled byte-stream → frame-split → field-scan
+ * logic that used to live inline in `ChatInterface.handleSendMessage`.
+ *
+ * Adding a new SSE event type is a one-line extension to `ChatStreamEvent`;
+ * TypeScript then surfaces any consumer `switch` that doesn't handle it.
+ *
+ * Wire format (per the W3C SSE spec, subset we emit):
+ *
+ *   event: <name>\n      (optional; default 'message')
+ *   data: <json>\n        (one or more `data:` lines, joined)
+ *   \n                    (blank line = end of frame)
+ *
+ * Frames whose `data:` payload isn't valid JSON are skipped, not thrown —
+ * defensive against partial truncation or stray comment lines (`: keepalive`).
+ */
+import type { ContextEvent, UnifiedContext } from './harness-patterns'
+
+// ============================================================================
+// Event union
+// ============================================================================
+
+/** Final-result payload emitted as `event: done`. */
+export interface DoneEventData {
+  sessionId: string
+  response: string
+  data: Record<string, unknown>
+  status: string
+  duration_ms?: number
+  context: UnifiedContext
+  serialized?: string
+}
+
+/** Notification that the conversation's title was just regenerated server-side.
+ *  Emitted on the same stream after `done`, before the stream closes. The
+ *  client should patch its local thread list — no refetch needed. */
+export interface TitleUpdatedEventData {
+  sessionId: string
+  title: string
+}
+
+/** A standard harness event with the sessionId envelope added in #47.
+ *  Carries no `event:` header on the wire (default `message`). */
+export type MessageEventData = ContextEvent & { sessionId?: string }
+
+/**
+ * Discriminated union of all event kinds the chat stream can emit.
+ *
+ * `event` here is *not* the harness `EventType` — it's the SSE-protocol
+ * event name (the value of the `event:` header line). The two are unrelated
+ * namespaces; only `message` frames carry a harness `ContextEvent`.
+ *
+ * Forward-compat: unknown event names still come through at runtime
+ * (see `parseChatStream`) but are not part of the static union; consumers
+ * should handle them in a `default` branch and treat `data` as `unknown`.
+ * Including a `{ event: string; data: unknown }` arm here would defeat
+ * literal-name narrowing on the known variants.
+ */
+export type ChatStreamEvent =
+  | { event: 'message'; data: MessageEventData }
+  | { event: 'done'; data: DoneEventData }
+  | { event: 'error'; data: { sessionId?: string; error: string } }
+  | { event: 'title_updated'; data: TitleUpdatedEventData }
+
+// ============================================================================
+// Parser
+// ============================================================================
+
+/** Parse a single SSE frame's lines into `(eventName, dataString)`. */
+function parseFrame(frame: string): { eventName: string; dataStr: string } | null {
+  let eventName = 'message'
+  let dataStr = ''
+  for (const line of frame.split('\n')) {
+    if (line.startsWith('event: ')) {
+      eventName = line.slice(7).trim()
+    } else if (line.startsWith('data: ')) {
+      // Multiple `data:` lines are concatenated per the SSE spec.
+      dataStr += line.slice(6)
+    }
+    // Lines starting with `:` are comments; lines without a recognized field
+    // prefix are ignored. Both fall through silently.
+  }
+  if (!dataStr) return null
+  return { eventName, dataStr }
+}
+
+/**
+ * Yield typed events from a `fetch()` response carrying an SSE body.
+ *
+ * Usage:
+ * ```ts
+ * for await (const evt of parseChatStream(response)) {
+ *   switch (evt.event) {
+ *     case 'message':       progress.ingest(evt.data); break
+ *     case 'done':          finalResult = evt.data; break
+ *     case 'error':         throw new Error(evt.data.error)
+ *     case 'title_updated': onTitleUpdated(evt.data.sessionId, evt.data.title); break
+ *   }
+ * }
+ * ```
+ */
+export async function* parseChatStream(
+  response: Response,
+): AsyncGenerator<ChatStreamEvent, void, void> {
+  const reader = response.body?.getReader()
+  if (!reader) throw new Error('No response stream')
+
+  const decoder = new TextDecoder()
+  let buffer = ''
+
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+
+    buffer += decoder.decode(value, { stream: true })
+
+    // Frames are delimited by blank lines (\n\n). The last segment may be
+    // an incomplete frame; hold it in the buffer for the next read.
+    const frames = buffer.split('\n\n')
+    buffer = frames.pop() ?? ''
+
+    for (const frame of frames) {
+      if (!frame.trim()) continue
+      const parsed = parseFrame(frame)
+      if (!parsed) continue
+
+      let data: unknown
+      try {
+        data = JSON.parse(parsed.dataStr)
+      } catch {
+        // Skip malformed JSON rather than aborting the whole stream.
+        continue
+      }
+
+      // The `as` casts are safe here: consumers narrow via `evt.event`, and
+      // unknown event names fall through to the `{ event: string; data: unknown }`
+      // arm. We trust the server to emit well-shaped payloads per type.
+      yield { event: parsed.eventName, data } as ChatStreamEvent
+    }
+  }
+
+  // Flush any final trailing frame if the stream closed without a blank line.
+  if (buffer.trim()) {
+    const parsed = parseFrame(buffer)
+    if (parsed) {
+      try {
+        const data = JSON.parse(parsed.dataStr)
+        yield { event: parsed.eventName, data } as ChatStreamEvent
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+}

--- a/ui/src/routes/api/events.ts
+++ b/ui/src/routes/api/events.ts
@@ -55,7 +55,11 @@ export async function POST(event: APIEvent) {
           message,
           resolvedAgentId,
           (evt) => {
-            const data = JSON.stringify(evt);
+            // `sessionId` rides on every envelope so the client can route the
+            // event to the right per-session progress controller (#47). Events
+            // themselves don't carry sessionId in their typed shape — it's an
+            // envelope-only field.
+            const data = JSON.stringify({ ...evt, sessionId });
             controller.enqueue(encoder.encode(`data: ${data}\n\n`));
           },
           settings,
@@ -63,6 +67,7 @@ export async function POST(event: APIEvent) {
 
         // Send final result as a named event
         const doneData = JSON.stringify({
+          sessionId,
           response: result.response,
           data: result.data,
           status: result.status,
@@ -90,7 +95,7 @@ export async function POST(event: APIEvent) {
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
         controller.enqueue(
-          encoder.encode(`event: error\ndata: ${JSON.stringify({ error: msg })}\n\n`),
+          encoder.encode(`event: error\ndata: ${JSON.stringify({ sessionId, error: msg })}\n\n`),
         );
         controller.close();
       }

--- a/ui/src/routes/api/events.ts
+++ b/ui/src/routes/api/events.ts
@@ -8,8 +8,14 @@ import type { APIEvent } from "@solidjs/start/server";
 import { processMessageStreaming } from "../../lib/harness-client/actions.server";
 import { saveSession } from "../../lib/harness-client/session.server";
 import { scheduleSummarization, serializeContext } from "../../lib/harness-patterns";
+import { runFirstTurnTitleGen } from "../../lib/harness-client/examples/title-generator.server";
 import { getAuthenticatedUser } from "../../lib/auth/server";
 import type { HarnessSettings } from "../../lib/settings";
+
+/** Hard cap on how long the SSE stream stays open after `done` waiting for
+ *  the title agent to resolve. If the LLM exceeds this, we close the stream
+ *  without a `title_updated` event — the heuristic title persists. */
+const TITLE_GEN_TIMEOUT_MS = 3000;
 
 async function requireUserId(): Promise<string> {
   if (import.meta.env.VITE_DEV_BYPASS_AUTH === "true") return "dev-bypass-user";
@@ -76,6 +82,21 @@ export async function POST(event: APIEvent) {
           serialized: result.serialized,
         });
         controller.enqueue(encoder.encode(`event: done\ndata: ${doneData}\n\n`));
+
+        // First-turn title generation — synchronous w.r.t. the stream so the
+        // result can ride out as a `title_updated` event before close. Hard
+        // 3s cap so a slow LLM never wedges the stream. Heuristic title
+        // (from `deriveTitle` / `saveConversation` COALESCE) persists if this
+        // path fails or times out — the next `listConversations()` returns it.
+        await Promise.race([
+          runFirstTurnTitleGen(result.context, sessionId, userId).then((title) => {
+            if (!title) return;
+            const payload = JSON.stringify({ sessionId, title });
+            controller.enqueue(encoder.encode(`event: title_updated\ndata: ${payload}\n\n`));
+          }),
+          new Promise<void>((resolve) => setTimeout(resolve, TITLE_GEN_TIMEOUT_MS)),
+        ]).catch((err) => console.error("[title-gen] failed:", err));
+
         controller.close();
 
         // Fire-and-forget: summarize this turn's tool results in the background.

--- a/ui/src/routes/index.tsx
+++ b/ui/src/routes/index.tsx
@@ -1,6 +1,6 @@
 import { Splitter } from '@ark-ui/solid/splitter'
-import { createSignal, createMemo, createResource, createEffect, createUniqueId } from 'solid-js'
-import { ChatInterface } from '~/components/ark-ui/ChatInterface'
+import { createSignal, createMemo, createResource, createEffect, createUniqueId, onCleanup, onMount } from 'solid-js'
+import { ChatInterface, type SessionRunState } from '~/components/ark-ui/ChatInterface'
 import { ChatSidebar, mergeThreadsWithPlaceholder } from '~/components/ark-ui/ChatSidebar'
 import { SupportPanel, type GraphElement } from '~/components/ark-ui/SupportPanel'
 import type { ContextEvent, UnifiedContext, ToolResultEventData } from '~/lib/harness-patterns'
@@ -8,6 +8,9 @@ import { executeCypherWrite } from '~/lib/neo4j/write-action'
 import { mergeGraphElements } from '~/lib/graph-merge'
 import { listConversations } from '~/lib/harness-client'
 import type { StashAction } from '~/components/ark-ui/DataStashPanel'
+import { createChainProgress, type ChainProgressController } from '~/components/ark-ui/useChainProgress'
+
+const DEFAULT_RUN_STATE: SessionRunState = { isProcessing: false, runningTool: null }
 
 export default function Home() {
   // Conversation a user is currently viewing. Initial value is a fresh id so
@@ -28,6 +31,58 @@ export default function Home() {
 
   // Sidebar threads — refetched after each turn completes (see onContextUpdate).
   const [threads, { refetch: refetchThreads }] = createResource(() => listConversations())
+
+  // ===========================================================================
+  // Per-session progress + run state (#47)
+  // ===========================================================================
+  // ChainProgressController instances are owned by the route so the live bar
+  // and submit guard persist across sidebar switches. ChatInterface reads its
+  // session's controller via `getProgress(sid)` and routes ingest calls into
+  // the controller for the captured run sessionId — events arriving for the
+  // unfocused chat keep flowing into its own bar.
+
+  const progressBySession = new Map<string, ChainProgressController>()
+  const getProgress = (sid: string): ChainProgressController => {
+    let p = progressBySession.get(sid)
+    if (!p) {
+      p = createChainProgress()
+      progressBySession.set(sid, p)
+    }
+    return p
+  }
+
+  // Reactive run-state map (`isProcessing`, `runningTool`). Kept as a plain
+  // object so Solid can diff equality on the whole record without Map identity.
+  const [runStates, setRunStates] = createSignal<Record<string, SessionRunState>>({})
+  const getRunState = (sid: string): SessionRunState => runStates()[sid] ?? DEFAULT_RUN_STATE
+  const updateRunState = (sid: string, patch: Partial<SessionRunState>) => {
+    setRunStates(prev => ({
+      ...prev,
+      [sid]: { ...DEFAULT_RUN_STATE, ...prev[sid], ...patch },
+    }))
+  }
+
+  // AbortControllers for in-flight SSE streams. Switching sessions does NOT
+  // abort — only an explicit cancel or page unload does (acceptance: "Streams
+  // survive chat switches").
+  const abortControllers = new Map<string, AbortController>()
+  const registerAbortController = (sid: string, ac: AbortController) => {
+    abortControllers.set(sid, ac)
+  }
+  const unregisterAbortController = (sid: string) => {
+    abortControllers.delete(sid)
+  }
+
+  onMount(() => {
+    const onUnload = () => {
+      for (const ac of abortControllers.values()) {
+        try { ac.abort() } catch { /* ignore */ }
+      }
+      abortControllers.clear()
+    }
+    window.addEventListener('beforeunload', onUnload)
+    onCleanup(() => window.removeEventListener('beforeunload', onUnload))
+  })
 
   // Accumulate graph elements across calls. Dedup + touched-flag refresh logic
   // lives in `mergeGraphElements` so it can be unit-tested in isolation.
@@ -57,7 +112,9 @@ export default function Home() {
 
   // Wipe per-conversation state. Called by ChatInterface before it hydrates a
   // newly selected sessionId so the graph + observability tabs don't keep
-  // showing stale data from the previous thread.
+  // showing stale data from the previous thread. Progress state is NOT cleared
+  // here — it belongs to the per-session registry, so a still-running stream
+  // for the previous thread keeps populating its own controller.
   const resetForNewSession = () => {
     clearGraph()
     clearEvents()
@@ -192,6 +249,11 @@ export default function Home() {
                 onAgentChangeRequestsNewSession={handleNewChat}
                 graphEntityNames={graphEntityNames()}
                 onHighlightEntities={setHighlightedIds}
+                getProgress={getProgress}
+                getRunState={getRunState}
+                updateRunState={updateRunState}
+                registerAbortController={registerAbortController}
+                unregisterAbortController={unregisterAbortController}
               />
             </div>
           </div>

--- a/ui/src/routes/index.tsx
+++ b/ui/src/routes/index.tsx
@@ -30,7 +30,17 @@ export default function Home() {
   const [unifiedContext, setUnifiedContext] = createSignal<UnifiedContext | undefined>(undefined)
 
   // Sidebar threads — refetched after each turn completes (see onContextUpdate).
-  const [threads, { refetch: refetchThreads }] = createResource(() => listConversations())
+  // `mutate` is exposed so the `title_updated` SSE event can patch a single
+  // row's title in-place without re-querying the full list (the server already
+  // gave us the new title in the event payload).
+  const [threads, { refetch: refetchThreads, mutate: mutateThreads }] = createResource(() => listConversations())
+
+  // Push-driven title update from the SSE stream — the server emits a
+  // `title_updated` event after the LLM title generator resolves. We splice
+  // the new title into the threads cache; no refetch needed.
+  const handleTitleUpdated = (sid: string, title: string) => {
+    mutateThreads(list => (list ?? []).map(t => (t.id === sid ? { ...t, title } : t)))
+  }
 
   // ===========================================================================
   // Per-session progress + run state (#47)
@@ -238,6 +248,7 @@ export default function Home() {
               selectedId={selectedSessionId()}
               onSelectThread={handleSelectThread}
               onNewChat={handleNewChat}
+              onTitleRegenerated={handleTitleUpdated}
             />
             <div flex="1" overflow="hidden">
               <ChatInterface
@@ -254,6 +265,7 @@ export default function Home() {
                 updateRunState={updateRunState}
                 registerAbortController={registerAbortController}
                 unregisterAbortController={unregisterAbortController}
+                onTitleUpdated={handleTitleUpdated}
               />
             </div>
           </div>

--- a/ui/src/routes/index.tsx
+++ b/ui/src/routes/index.tsx
@@ -1,7 +1,7 @@
 import { Splitter } from '@ark-ui/solid/splitter'
-import { createSignal, createMemo, createResource, createUniqueId } from 'solid-js'
+import { createSignal, createMemo, createResource, createEffect, createUniqueId } from 'solid-js'
 import { ChatInterface } from '~/components/ark-ui/ChatInterface'
-import { ChatSidebar } from '~/components/ark-ui/ChatSidebar'
+import { ChatSidebar, mergeThreadsWithPlaceholder } from '~/components/ark-ui/ChatSidebar'
 import { SupportPanel, type GraphElement } from '~/components/ark-ui/SupportPanel'
 import type { ContextEvent, UnifiedContext, ToolResultEventData } from '~/lib/harness-patterns'
 import { executeCypherWrite } from '~/lib/neo4j/write-action'
@@ -15,6 +15,11 @@ export default function Home() {
   // sidebar (or "+ New Chat") swaps this signal.
   const [selectedSessionId, setSelectedSessionId] = createSignal(createUniqueId())
   const [sidebarCollapsed, setSidebarCollapsed] = createSignal(false)
+
+  // Optimistic placeholder for a freshly-minted "+ New Chat" id that hasn't
+  // been persisted yet (see #44). Cleared once the real row arrives in the
+  // threadsResource refetch, or when the user picks an existing thread.
+  const [placeholderSessionId, setPlaceholderSessionId] = createSignal<string | null>(null)
 
   const [graphElements, setGraphElements] = createSignal<GraphElement[]>([])
   const [highlightedIds, setHighlightedIds] = createSignal<string[]>([])
@@ -60,14 +65,35 @@ export default function Home() {
 
   const handleNewChat = () => {
     resetForNewSession()
-    setSelectedSessionId(createUniqueId())
+    const id = createUniqueId()
+    setSelectedSessionId(id)
+    setPlaceholderSessionId(id)
   }
 
   const handleSelectThread = (threadId: string) => {
     if (threadId === selectedSessionId()) return
     resetForNewSession()
     setSelectedSessionId(threadId)
+    // User picked an existing thread — drop the optimistic row.
+    setPlaceholderSessionId(null)
   }
+
+  // Once the persisted row for the placeholder lands in the threadsResource,
+  // drop the optimistic row so the real one (with its sticky title) takes over.
+  createEffect(() => {
+    const ph = placeholderSessionId()
+    if (!ph) return
+    const list = threads() ?? []
+    if (list.some(t => t.id === ph)) {
+      setPlaceholderSessionId(null)
+    }
+  })
+
+  // Display threads = optimistic placeholder (if any) on top, then persisted
+  // rows, deduped by id. See `mergeThreadsWithPlaceholder` for the rule.
+  const displayThreads = createMemo(() =>
+    mergeThreadsWithPlaceholder(threads() ?? [], placeholderSessionId())
+  )
 
   // Wrap the supplied unified-context setter so each save also refreshes the
   // sidebar list (titles update once the first user_message lands).
@@ -151,7 +177,7 @@ export default function Home() {
             <ChatSidebar
               collapsed={sidebarCollapsed()}
               onToggle={() => setSidebarCollapsed(!sidebarCollapsed())}
-              threads={threads() ?? []}
+              threads={displayThreads()}
               selectedId={selectedSessionId()}
               onSelectThread={handleSelectThread}
               onNewChat={handleNewChat}


### PR DESCRIPTION
## Summary

Sidebar + chat-stream improvements. Two scoped issues (#44, #47) plus follow-on work on the same surface.

### Issue commits

- **`560abeb` `feat(ui): optimistic new-chat row in sidebar`** — clicking **+ New Chat** prepends a placeholder thread at the top of the sidebar immediately, highlighted as active, so the user sees their fresh chat without waiting 10–60s for the first response. Client-only `placeholderSessionId` signal + a pure `mergeThreadsWithPlaceholder` helper; dropped in place once the persisted row arrives. **Closes #44**.
- **`66c7a35` `feat(ui): per-session progress lock + submit guard`** — live progress bar + composer guard are now scoped to a conversation rather than the `ChatInterface` instance. Route owns parallel per-session registries (`progressBySession`, `runStates`, `abortControllers`); flipping threads mid-stream leaves the server loop running and progress accumulating in the originating session. `controller_action.action.tool_name` drives the "Waiting for `<tool>` to complete. Try later." banner. `api/events.ts` adds `sessionId` to every SSE envelope. `beforeunload` aborts in-flight fetches. **Closes #47**.

### Follow-on work on the same surface

- **`8e96abd` `chore(ui): use 'new chat' as placeholder title label`** — tighter copy than "description will appear here".
- **`501e942` `refactor(ui): typed SSE parser for chat stream`** — extract the hand-rolled byte→frame parser from `ChatInterface` into a typed AsyncIterable (`lib/sse-client.ts`). No behavior change; 9 new parser tests. Sets up the next commit.
- **`104a167` `fix(ui): exclude router status from replayed chat history`** — restoring a conversation surfaced residual router status messages ("Looking into the graph…") as assistant responses. Added `final?: boolean` to `AssistantMessageEventData`; `replayMessages` filters non-final. Extracted into `lib/harness-client/replay.ts` for unit testability.
- **`8ad4afd` `feat(ui): LLM-generated conversation titles via minimal harness agent`** — once the first user turn completes, a one-pattern harness agent generates a 3–5 word title and replaces the heuristic placeholder. Rides back over the existing `/api/events` SSE stream as `title_updated`, patched into the threads cache in-place. Hover-reveal ↻ icon on each sidebar row triggers regeneration. New `title-generator.server.ts` (smallest legal harness composition, ~20 LoC) fills the "minimum-rung" gap in the examples catalog. Backed by `DescribeFallback` (Groq Fast p50 sub-second).

### Notes

- #52 (createUniqueId collision) remains open — separate root cause not addressed in this PR.
- Full suite green (597 tests).
- Docs updated: `UI_ARCHITECTURE.md` §6b, `harness-client/examples/README.md` §0.

Closes #44
Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)