### PR TITLE
feat(observability): capture failed LLM call prompt + vars in error events (closes #31)

### DIFF
--- a/ui/src/__tests__/lib/harness-patterns/baml-adapters.test.ts
+++ b/ui/src/__tests__/lib/harness-patterns/baml-adapters.test.ts
@@ -774,3 +774,245 @@ describe('annotateExpansions', () => {
     expect('expanded_in_turn' in out[0]).toBe(true)
   })
 })
+
+// ============================================================================
+// Failed LLM call capture (#31): adapters must wrap final-propagating
+// failures in LLMCallError carrying promptTemplate, variables, and the
+// best-effort HTTP body so the panel can render the same Prompt drill-down
+// for failures as for successes.
+// ============================================================================
+
+describe('LLMCallError — failed LLM call capture', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('throws LLMCallError carrying promptTemplate and variables when LoopController fails', async () => {
+    const { createLoopControllerAdapter, LLMCallError } = await import('../../../lib/harness-patterns/baml-adapters.server')
+
+    // Non-BamlValidationError fails on first attempt (no adapter retry):
+    // adapter must wrap in LLMCallError with the captured context. The
+    // mock receives a fake collector — we simulate BAML populating it
+    // before throwing (typical of parse failures arriving after the HTTP
+    // response). httpRequest body mirrors the HttpBody class shape.
+    // Note: the real `Collector.last` is a getter, so the test uses a
+    // plain object that satisfies the structural shape.
+    const bodyText = '{"messages":[{"role":"user","content":"INTENT: do thing"}]}'
+    const httpBody = Object.create({ text: () => bodyText })
+    const fakeCollector = {
+      last: undefined as unknown as Record<string, unknown> | undefined
+    }
+    mockLoopController.mockImplementation(async (..._args: unknown[]) => {
+      const options = _args[_args.length - 1] as { collector?: typeof fakeCollector } | undefined
+      if (options?.collector) {
+        options.collector.last = {
+          rawLlmResponse: 'malformed-json-from-llm',
+          calls: [{
+            httpRequest: { body: httpBody },
+            provider: 'groq',
+            clientName: 'GroqGPT120B'
+          }]
+        }
+      }
+      throw new Error('Network down')
+    })
+
+    const controller = createLoopControllerAdapter(['Return'])
+
+    let caught: unknown
+    try {
+      await controller('do thing', 'do thing', '[]', 0, undefined, fakeCollector as never)
+    } catch (e) {
+      caught = e
+    }
+
+    expect(caught).toBeInstanceOf(LLMCallError)
+    const err = caught as InstanceType<typeof LLMCallError>
+    expect(err.message).toBe('Network down')
+    expect(err.llmCall).toBeDefined()
+    expect(err.llmCall.functionName).toBe('LoopController')
+    expect(err.llmCall.variables).toEqual(expect.objectContaining({
+      user_message: 'do thing',
+      intent: 'do thing'
+    }))
+    // promptTemplate must be populated from inlined BAML
+    expect(err.llmCall.promptTemplate).toBeDefined()
+    expect(err.llmCall.promptTemplate).toMatch(/\{\{\s*intent\s*\}\}/)
+    // HTTP body captured before the failure
+    expect(err.llmCall.rawInput).toBe('{"messages":[{"role":"user","content":"INTENT: do thing"}]}')
+    // rawOutput captured (the malformed response) — equivalent to httpResponse
+    expect(err.llmCall.rawOutput).toBe('malformed-json-from-llm')
+    expect(err.llmCall.provider).toBe('groq')
+    expect(err.llmCall.clientName).toBe('GroqGPT120B')
+    // The original error is preserved as cause
+    expect(err.cause).toBeInstanceOf(Error)
+  })
+
+  it('LLMCallError omits rawInput when the failure is pre-call (collector never recorded a call)', async () => {
+    const { createLoopControllerAdapter, LLMCallError } = await import('../../../lib/harness-patterns/baml-adapters.server')
+
+    // Pre-call failure: collector stays empty (no last entry). Adapter
+    // should still throw LLMCallError with promptTemplate + variables;
+    // rawInput / rawOutput are undefined.
+    mockLoopController.mockRejectedValue(new Error('DNS lookup failed'))
+
+    const controller = createLoopControllerAdapter(['Return'])
+    const { Collector } = await import('@boundaryml/baml')
+    const collector = new Collector('test')
+
+    let caught: unknown
+    try {
+      await controller('msg', 'intent', '[]', 0, undefined, collector)
+    } catch (e) {
+      caught = e
+    }
+
+    expect(caught).toBeInstanceOf(LLMCallError)
+    const err = caught as InstanceType<typeof LLMCallError>
+    expect(err.message).toBe('DNS lookup failed')
+    expect(err.llmCall.functionName).toBe('LoopController')
+    expect(err.llmCall.variables).toEqual(expect.objectContaining({ intent: 'intent' }))
+    expect(err.llmCall.promptTemplate).toBeDefined()
+    expect(err.llmCall.rawInput).toBeUndefined()
+    expect(err.llmCall.rawOutput).toBeUndefined()
+  })
+
+  it('does NOT throw LLMCallError when a recovered fallback attempt succeeds', async () => {
+    // The fallback chain only emits a propagating error on the final
+    // failure. When attempt 1 fails with BamlValidationError but attempt
+    // 2 (GroqGPT120B) succeeds, the adapter returns the success — no
+    // LLMCallError is thrown and the recovered attempts don't surface
+    // as red error events in the panel.
+    const { createLoopControllerAdapter, LLMCallError } = await import('../../../lib/harness-patterns/baml-adapters.server')
+    const { BamlValidationError } = await import('@boundaryml/baml')
+
+    mockLoopController
+      .mockRejectedValueOnce(new BamlValidationError('Invalid JSON', 'raw', 'msg', 'detailed'))
+      .mockResolvedValueOnce(mockFinalAction('Recovered on attempt 2'))
+
+    const controller = createLoopControllerAdapter(['Return'])
+
+    // Should NOT throw: the recovered attempt produces a normal return.
+    const result = await controller('user message', 'intent', '[]', 0)
+    expect(result.action).toBeDefined()
+    expect(result.action.is_final).toBe(true)
+    // And just to assert the type: an LLMCallError did not slip through
+    expect(result instanceof LLMCallError).toBe(false)
+  })
+
+  it('throws LLMCallError when ALL fallbacks (primary + GroqGPT120B + GroqFast) fail', async () => {
+    // Only the final, propagating failure should produce an LLMCallError.
+    // Here every fallback throws BamlValidationError, so the adapter
+    // exhausts the chain and the propagating error from the last attempt
+    // is wrapped.
+    const { createLoopControllerAdapter, LLMCallError } = await import('../../../lib/harness-patterns/baml-adapters.server')
+    const { BamlValidationError } = await import('@boundaryml/baml')
+
+    mockLoopController
+      .mockRejectedValueOnce(new BamlValidationError('attempt 1 invalid', 'r1', 'm1', 'd1'))
+      .mockRejectedValueOnce(new BamlValidationError('attempt 2 invalid', 'r2', 'm2', 'd2'))
+      .mockRejectedValueOnce(new BamlValidationError('attempt 3 invalid', 'r3', 'm3', 'd3'))
+
+    const controller = createLoopControllerAdapter(['Return'])
+
+    let caught: unknown
+    try {
+      await controller('msg', 'intent', '[]', 0)
+    } catch (e) { caught = e }
+
+    expect(caught).toBeInstanceOf(LLMCallError)
+    // BamlValidationError's .message is empty (constructor stashes args on
+    // .prompt / .raw_output instead), so we just assert the wrapper class
+    // and the call count rather than asserting on message content.
+    expect((caught as InstanceType<typeof LLMCallError>).cause).toBeDefined()
+    // All three attempts ran
+    expect(mockLoopController).toHaveBeenCalledTimes(3)
+  })
+
+  it('throws LLMCallError from ActorController on BAML failure', async () => {
+    const { createActorControllerAdapter, LLMCallError } = await import('../../../lib/harness-patterns/baml-adapters.server')
+
+    mockActorController.mockRejectedValue(new Error('Provider 5xx'))
+
+    const actor = createActorControllerAdapter(['code-mode'])
+    const { Collector } = await import('@boundaryml/baml')
+
+    let caught: unknown
+    try {
+      await actor('msg', 'intent', ['code-mode'], [], new Collector('test'))
+    } catch (e) { caught = e }
+
+    expect(caught).toBeInstanceOf(LLMCallError)
+    const err = caught as InstanceType<typeof LLMCallError>
+    expect(err.llmCall.functionName).toBe('ActorController')
+    expect(err.llmCall.promptTemplate).toBeDefined()
+  })
+
+  it('throws LLMCallError from Critic on BAML failure', async () => {
+    const { createCriticAdapter, LLMCallError } = await import('../../../lib/harness-patterns/baml-adapters.server')
+
+    mockCritic.mockRejectedValue(new Error('Critic timed out'))
+
+    const critic = createCriticAdapter()
+    const { Collector } = await import('@boundaryml/baml')
+
+    let caught: unknown
+    try {
+      await critic('intent', [], new Collector('test'))
+    } catch (e) { caught = e }
+
+    expect(caught).toBeInstanceOf(LLMCallError)
+    const err = caught as InstanceType<typeof LLMCallError>
+    expect(err.llmCall.functionName).toBe('Critic')
+    expect(err.llmCall.variables).toEqual(expect.objectContaining({ intent: 'intent' }))
+  })
+})
+
+describe('extractFailureLLMCallData', () => {
+  it('returns LLMCallData with promptTemplate and variables when collector is empty', async () => {
+    const { extractFailureLLMCallData } = await import('../../../lib/harness-patterns/baml-adapters.server')
+
+    const result = extractFailureLLMCallData(
+      undefined,
+      'LoopController',
+      { user_message: 'hi', intent: 'hi' },
+      Date.now() - 50
+    )
+
+    expect(result).toBeDefined()
+    expect(result.functionName).toBe('LoopController')
+    expect(result.variables).toEqual({ user_message: 'hi', intent: 'hi' })
+    expect(result.promptTemplate).toBeDefined()
+    expect(result.rawInput).toBeUndefined()
+    expect(result.rawOutput).toBeUndefined()
+    expect(result.durationMs).toBeGreaterThanOrEqual(0)
+  })
+
+  it('returns the same shape as success when collector has captured a call', async () => {
+    const { extractFailureLLMCallData } = await import('../../../lib/harness-patterns/baml-adapters.server')
+
+    const bodyText = '{"messages":[{"role":"user","content":"hello"}]}'
+    const httpBody = Object.create({ text: () => bodyText })
+    const collector = {
+      last: {
+        rawLlmResponse: 'partial-or-malformed',
+        calls: [{ httpRequest: { body: httpBody }, provider: 'openai', clientName: 'OpenAIGPT5' }]
+      }
+    }
+
+    const result = extractFailureLLMCallData(
+      collector as never,
+      'Synthesize',
+      { userMessage: 'hello' },
+      Date.now() - 100
+    )
+
+    expect(result.functionName).toBe('Synthesize')
+    expect(result.rawInput).toBe(bodyText)
+    expect(result.rawOutput).toBe('partial-or-malformed')
+    expect(result.provider).toBe('openai')
+    expect(result.clientName).toBe('OpenAIGPT5')
+    // parsedOutput is intentionally omitted on failures
+    expect(result.parsedOutput).toBeUndefined()
+  })
+})

--- a/ui/src/components/ark-ui/ObservabilityPanel.tsx
+++ b/ui/src/components/ark-ui/ObservabilityPanel.tsx
@@ -783,6 +783,53 @@ const ActionDetail = (props: { data: ControllerActionEventData }) => (
   </div>
 )
 
+const ErrorDetail = (props: { data: ErrorEventData }) => (
+  <div flex="~ col" gap="3">
+    <div>
+      <div text="xs dark-text-tertiary" m="b-1">Error</div>
+      <div
+        text="sm red-400"
+        bg="red-500/5"
+        border="1 red-500/20"
+        p="3"
+        rounded="md"
+        font="mono"
+        style={{ 'white-space': 'pre-wrap', 'word-break': 'break-word' }}
+      >
+        {props.data.error}
+      </div>
+    </div>
+    <div flex="~ wrap" gap="4">
+      <Show when={props.data.severity}>
+        <div>
+          <div text="xs dark-text-tertiary" m="b-1">Severity</div>
+          <div text={`sm ${props.data.severity === 'irrecoverable' ? 'red-400' : 'amber-400'}`} font="mono">
+            {props.data.severity}
+          </div>
+        </div>
+      </Show>
+      <Show when={props.data.turn !== undefined}>
+        <div>
+          <div text="xs dark-text-tertiary" m="b-1">Turn</div>
+          <div text="sm dark-text-primary" font="mono">{props.data.turn}</div>
+        </div>
+      </Show>
+      <Show when={props.data.iteration !== undefined}>
+        <div>
+          <div text="xs dark-text-tertiary" m="b-1">Iteration</div>
+          <div text="sm dark-text-primary" font="mono">{props.data.iteration}</div>
+        </div>
+      </Show>
+    </div>
+    <Show when={props.data.hint}>
+      <div>
+        <div text="xs dark-text-tertiary" m="b-1">Hint</div>
+        <div text="sm dark-text-secondary" style={{ 'white-space': 'pre-wrap' }}>{props.data.hint}</div>
+      </div>
+    </Show>
+  </div>
+)
+
 const MessageDetail = (props: { data: { content: string }, role: 'user' | 'assistant' }) => (
   <div flex="~ col" gap="3">
     <div>
@@ -1297,6 +1344,9 @@ const EventDetailPanel = (props: { event: ContextEvent, onClose: () => void }) =
             </Match>
             <Match when={type === 'assistant_message'}>
               <MessageDetail data={data as AssistantMessageEventData} role="assistant" />
+            </Match>
+            <Match when={type === 'error'}>
+              <ErrorDetail data={data as ErrorEventData} />
             </Match>
           </Switch>
         </Show>

--- a/ui/src/lib/harness-patterns/baml-adapters.server.ts
+++ b/ui/src/lib/harness-patterns/baml-adapters.server.ts
@@ -71,8 +71,22 @@ export function extractLLMCallData(
 ): LLMCallData | undefined {
   const last = collector.last
   if (!last) return undefined
+  return buildLLMCallDataFromLog(last, functionName, variables, startTime, parsedOutput)
+}
 
-  // Prefer the call BAML actually selected (handles fallbacks); fall back to the last attempted call
+/** Build LLMCallData from a collector log entry. Used for both success and
+ *  failure paths — on failure `parsedOutput` is omitted, `rawOutput` may be
+ *  empty, and `usage` may be absent, but `promptTemplate`/`variables` are
+ *  always populated so the failed-call drill-down has something to render. */
+function buildLLMCallDataFromLog(
+  last: NonNullable<Collector['last']>,
+  functionName: string,
+  variables: Record<string, unknown>,
+  startTime: number,
+  parsedOutput?: unknown
+): LLMCallData {
+  // Prefer the call BAML actually selected (handles fallbacks); fall back to the last attempted call.
+  // For failures, `selected` is rarely set — we want the last attempt that actually went out.
   const calls = (last.calls ?? []) as Array<{
     selected?: boolean
     provider?: string
@@ -121,6 +135,61 @@ export function extractLLMCallData(
     provider,
     clientName
   }
+}
+
+/** Extract LLM call data after a BAML call threw. Always returns a record
+ *  carrying at least `functionName`, `variables`, and `promptTemplate` so the
+ *  panel can render the Template/Variables sections even when the collector
+ *  never saw a response (e.g. pre-call network failure). HTTP body /
+ *  rawOutput / usage are best-effort and may be absent. */
+export function extractFailureLLMCallData(
+  collector: Collector | undefined,
+  functionName: string,
+  variables: Record<string, unknown>,
+  startTime: number
+): LLMCallData {
+  const last = collector?.last
+  if (last) {
+    return buildLLMCallDataFromLog(last, functionName, variables, startTime)
+  }
+  return {
+    functionName,
+    variables,
+    promptTemplate: getPromptTemplate(functionName),
+    durationMs: Date.now() - startTime
+  }
+}
+
+/** Error thrown by BAML adapters when an LLM call fails after all in-adapter
+ *  fallbacks have been exhausted. Carries the captured prompt/variables/HTTP
+ *  bodies so the catching pattern can attach them to the emitted `error`
+ *  event. Recovered fallback attempts never produce this — only the final
+ *  propagating failure does. */
+export class LLMCallError extends Error {
+  readonly llmCall: LLMCallData
+  readonly cause?: unknown
+  constructor(message: string, llmCall: LLMCallData, cause?: unknown) {
+    super(message)
+    this.name = 'LLMCallError'
+    this.llmCall = llmCall
+    if (cause !== undefined) this.cause = cause
+  }
+}
+
+/** Re-throw a BAML failure as an `LLMCallError` enriched with collector data.
+ *  Preserves the original error's message and stack via `cause`. Used by all
+ *  adapter catch paths so failures arriving at the calling pattern carry the
+ *  same prompt/variables/HTTP shape that successful calls already attach. */
+function wrapAsLLMCallError(
+  err: unknown,
+  functionName: string,
+  variables: Record<string, unknown>,
+  startTime: number,
+  collector: Collector | undefined
+): LLMCallError {
+  const message = err instanceof Error ? err.message : String(err)
+  const llmCall = extractFailureLLMCallData(collector, functionName, variables, startTime)
+  return new LLMCallError(message, llmCall, err)
 }
 
 // ============================================================================
@@ -263,12 +332,20 @@ export function createLoopControllerAdapter(
         ? await b.LoopController(user_message, intent, tools, turns, context, priorResults, fewShots, { collector })
         : await b.LoopController(user_message, intent, tools, turns, context, priorResults, fewShots)
     } catch (e) {
-      if (!(e instanceof BamlValidationError)) throw e
+      if (!(e instanceof BamlValidationError)) {
+        throw wrapAsLLMCallError(e, 'LoopController', variables, startTime, collector)
+      }
       try {
-        action = await b.LoopController(user_message, intent, tools, turns, context, priorResults, fewShots, { client: 'GroqGPT120B' })
+        action = await b.LoopController(user_message, intent, tools, turns, context, priorResults, fewShots, collector ? { collector, client: 'GroqGPT120B' } : { client: 'GroqGPT120B' })
       } catch (e2) {
-        if (!(e2 instanceof BamlValidationError)) throw e2
-        action = await b.LoopController(user_message, intent, tools, turns, context, priorResults, fewShots, { client: 'GroqFast' })
+        if (!(e2 instanceof BamlValidationError)) {
+          throw wrapAsLLMCallError(e2, 'LoopController', variables, startTime, collector)
+        }
+        try {
+          action = await b.LoopController(user_message, intent, tools, turns, context, priorResults, fewShots, collector ? { collector, client: 'GroqFast' } : { client: 'GroqFast' })
+        } catch (e3) {
+          throw wrapAsLLMCallError(e3, 'LoopController', variables, startTime, collector)
+        }
       }
     }
 
@@ -388,9 +465,14 @@ export function createActorControllerAdapter(toolNames: string[]): CodeModeContr
     const variables = { user_message, intent, tools, attempts }
 
     // Call with or without collector
-    const action = collector
-      ? await b.ActorController(user_message, intent, tools, attempts, { collector })
-      : await b.ActorController(user_message, intent, tools, attempts)
+    let action: ControllerAction
+    try {
+      action = collector
+        ? await b.ActorController(user_message, intent, tools, attempts, { collector })
+        : await b.ActorController(user_message, intent, tools, attempts)
+    } catch (e) {
+      throw wrapAsLLMCallError(e, 'ActorController', variables, startTime, collector)
+    }
 
     // Extract LLM call data if collector present
     const llmCall = collector
@@ -433,9 +515,14 @@ export function createCriticAdapter(): CriticFnWithLLMData {
     const variables = { intent, attempts }
 
     // Call with or without collector
-    const result = collector
-      ? await b.Critic(intent, attempts, { collector })
-      : await b.Critic(intent, attempts)
+    let result: CriticResult
+    try {
+      result = collector
+        ? await b.Critic(intent, attempts, { collector })
+        : await b.Critic(intent, attempts)
+    } catch (e) {
+      throw wrapAsLLMCallError(e, 'Critic', variables, startTime, collector)
+    }
 
     // Extract LLM call data if collector present
     const llmCall = collector

--- a/ui/src/lib/harness-patterns/patterns/actorCritic.server.ts
+++ b/ui/src/lib/harness-patterns/patterns/actorCritic.server.ts
@@ -27,6 +27,7 @@ import { getErrorHint } from '../error-hints'
 import { trackEvent, resolveConfig, generateId } from '../context.server'
 import { getRequestSettings } from '../../settings-context.server'
 import type { CodeModeControllerFnWithLLMData, CriticFnWithLLMData } from '../baml-adapters.server'
+import { LLMCallError } from '../baml-adapters.server'
 
 assertServerOnImport()
 
@@ -248,11 +249,15 @@ export function actorCritic<T extends ActorCriticData>(
       return scope
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error)
+      // Preserve LLM call data through to the error event so the panel can
+      // show the prompt drill-down for failed BAML calls (actor or critic).
+      const llmCall = error instanceof LLMCallError ? error.llmCall : undefined
       trackEvent(scope, 'error', {
         error: msg,
         severity: resolved.errorSeverity,
         hint: getErrorHint(msg),
-      } as ErrorEventData, true)
+        ...(llmCall ? { kind: 'llm_call' as const } : {}),
+      } as ErrorEventData, true, llmCall)
       return scope
     }
   }

--- a/ui/src/lib/harness-patterns/patterns/simpleLoop.server.ts
+++ b/ui/src/lib/harness-patterns/patterns/simpleLoop.server.ts
@@ -27,7 +27,8 @@ import { trackEvent, resolveConfig, generateId } from '../context.server'
 import { getRequestSettings } from '../../settings-context.server'
 import { trimToFit, getContextWindow } from '../token-budget.server'
 import type { ControllerFnWithLLMData } from '../baml-adapters.server'
-import { dedupByRefId, annotateExpansions } from '../baml-adapters.server'
+import { dedupByRefId, annotateExpansions, LLMCallError } from '../baml-adapters.server'
+import type { LLMCallData } from '../types'
 
 assertServerOnImport()
 
@@ -155,6 +156,7 @@ export function simpleLoop<T extends SimpleLoopData>(
     let hasError = false
     let errorMessage: string | undefined
     let errorTurn: number | undefined
+    let errorLlmCall: LLMCallData | undefined
     let exitedViaReturn = false
 
     // Build structured references to tool results from previous tasks.
@@ -245,6 +247,13 @@ export function simpleLoop<T extends SimpleLoopData>(
           hasError = true
           errorMessage = msg
           errorTurn = turn
+          // Carry LLM call data from the failed BAML call through to the
+          // error event so the panel can render the same Prompt/Output
+          // drill-down as a successful call. Adapters wrap final propagating
+          // failures in LLMCallError specifically for this purpose.
+          if (controllerError instanceof LLMCallError) {
+            errorLlmCall = controllerError.llmCall
+          }
           break
         }
 
@@ -474,13 +483,17 @@ export function simpleLoop<T extends SimpleLoopData>(
       }
 
       if (hasError) {
-        // Track error event — downstream patterns read errors via view.errors()
+        // Track error event — downstream patterns read errors via view.errors().
+        // When the error originated from a failed BAML call, attach the captured
+        // LLM call data so the Observability panel can render the same
+        // Prompt/Output drill-down as a successful call.
         trackEvent(scope, 'error', {
           error: errorMessage,
           severity: resolved.errorSeverity,
           hint: getErrorHint(errorMessage ?? ''),
           turn: errorTurn,
-        } as ErrorEventData, true)
+          ...(errorLlmCall ? { kind: 'llm_call' as const } : {}),
+        } as ErrorEventData, true, errorLlmCall)
       } else if (!exitedViaReturn && turns.length > 0) {
         // Loop exhausted maxTurns without controller signaling completion.
         // Surface as a recoverable error so the synthesizer can warn the user;

--- a/ui/src/lib/harness-patterns/patterns/synthesizer.server.ts
+++ b/ui/src/lib/harness-patterns/patterns/synthesizer.server.ts
@@ -23,6 +23,7 @@ import { getErrorHint } from '../error-hints'
 import { trackEvent, resolveConfig } from '../context.server'
 import { Collector } from '@boundaryml/baml'
 import { trimToFit, getContextWindow } from '../token-budget.server'
+import { extractFailureLLMCallData } from '../baml-adapters.server'
 
 assertServerOnImport()
 
@@ -279,6 +280,11 @@ export function synthesizer<T extends SynthesizerData>(
     scope: PatternScope<T>,
     view: EventView
   ): Promise<PatternScope<T>> => {
+    // Collector + start time hoisted so the outer catch can recover LLM call
+    // data (prompt template, variables, HTTP body) on a failed BAML call.
+    let collector: Collector | undefined
+    let startTime: number | undefined
+    let synthesizeVariables: Record<string, unknown> | undefined
     try {
       // Skip if already has synthesized response
       if (skipIfHasResponse && scope.data.synthesizedResponse) {
@@ -307,7 +313,14 @@ export function synthesizer<T extends SynthesizerData>(
         synthesizedResponse = await synthesize(input)
       } else {
         // Use default with collector for LLM observability
-        const collector = new Collector('synthesizer')
+        collector = new Collector('synthesizer')
+        startTime = Date.now()
+        synthesizeVariables = {
+          userMessage: input.userMessage,
+          intent: input.intent,
+          hasError: input.hasError ?? false,
+          errorMessage: input.errorMessage
+        }
         const result = await defaultSynthesize(input, collector)
         synthesizedResponse = result.content
         llmCall = result.llmCall
@@ -334,11 +347,19 @@ export function synthesizer<T extends SynthesizerData>(
       return scope
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error)
+      // Best-effort: if the BAML Synthesize call threw, surface the prompt
+      // template / variables / HTTP body alongside the error so the panel
+      // can render the same drill-down as a successful call.
+      const failedLlmCall =
+        collector !== undefined && synthesizeVariables !== undefined && startTime !== undefined
+          ? extractFailureLLMCallData(collector, 'Synthesize', synthesizeVariables, startTime)
+          : undefined
       trackEvent(scope, 'error', {
         error: msg,
         severity: resolved.errorSeverity,
         hint: getErrorHint(msg),
-      } as ErrorEventData, true)
+        ...(failedLlmCall ? { kind: 'llm_call' as const } : {}),
+      } as ErrorEventData, true, failedLlmCall)
       return scope
     }
   }

--- a/ui/src/lib/harness-patterns/types.ts
+++ b/ui/src/lib/harness-patterns/types.ts
@@ -550,6 +550,11 @@ export interface ErrorEventData {
   turn?: number
   /** Retry iteration (for actorCritic, 0-indexed) */
   iteration?: number
+  /** Origin of the error. `llm_call` means a BAML call failed (parse error,
+   *  fallback exhausted, network) and the event carries LLM observability
+   *  data on `ContextEvent.llmCall` for the failed call. Absent for non-LLM
+   *  errors (MCP failures, tool errors, etc.). */
+  kind?: 'llm_call'
 }
 
 /** Data payload for reference_attached event — emitted by `withReferences` on pattern entry */


### PR DESCRIPTION
## Summary

When a BAML call fails (parse error, fallback exhausted, network failure), the emitted `error` event now carries the same `LLMCallData` shape that successful calls already attach — prompt template, function variables, HTTP request/response body, provider, client. The Observability panel renders the same **Template / Variables / Rendered messages / Output** drill-down for failed calls as for successful ones; only the event chip color differs (error red vs neutral). Makes failed LLM calls debuggable from the panel without needing server logs. Closes #31.

## Mechanism

- **`baml-adapters.server.ts`** — new `LLMCallError` class + `wrapAsLLMCallError` / `extractFailureLLMCallData` helpers. Each adapter (`createLoopControllerAdapter`, `createActorControllerAdapter`, `createCriticAdapter`) wraps its terminal propagating failure in `LLMCallError` carrying the collector-derived `LLMCallData`. Recovered fallback attempts return success — no error event is emitted for them. The existing `extractLLMCallData` was refactored to share its log-building logic with the failure path.
- **`simpleLoop.server.ts` / `actorCritic.server.ts`** — catch `LLMCallError`, carry its `llmCall` through to the `error` event via `trackEvent`'s 5th-arg channel and stamp `kind: 'llm_call'` on the data.
- **`synthesizer.server.ts`** — hoisted the `Collector` / `startTime` / `synthesizeVariables` out of the synthesize branch so the outer catch can call `extractFailureLLMCallData` and attach the result to the error event.
- **`types.ts`** — added optional `kind?: 'llm_call'` discriminator on `ErrorEventData`. LLM call data rides on the existing `ContextEvent.llmCall` channel, so the panel renders failures with the same shape as successes without a separate code path.
- **`ObservabilityPanel.tsx`** — added an `ErrorDetail` component (error message + severity / turn / iteration / hint) and a `Match` case for `type === 'error'`. The existing `LLMCallTabs` already renders above the event-specific detail for any event with `event.llmCall`, so the Template/Variables/Rendered/Output accordion now appears on failed-call error events automatically.

## Test plan

- [x] `pnpm test:run` — 612/612 pass (added 8 new cases in `baml-adapters.test.ts` covering: HTTP body captured before failure; pre-call failure where rawInput is absent; recovered fallback attempts not propagating; all-three-fallbacks-fail propagating; Actor/Critic adapter coverage; `extractFailureLLMCallData` shape).
- [x] `pnpm exec tsc --noEmit --project tsconfig.json` — no new errors versus base branch.
- [ ] **Manual repro**: force a fallback exhaustion (or use Groq `gpt-oss-120b` structured-output failure on turn 2+). Open the Context manager panel, click the error event, confirm the Prompt accordion shows Template / Variables / Rendered messages and the Output section is populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)