### PR TITLE
fix(ui): use crypto.randomUUID() for session ids

### DIFF
--- a/ui/ROADMAP.md
+++ b/ui/ROADMAP.md
@@ -26,6 +26,12 @@
 - [x] Graph renders correctly when tab is inactive during a query (ResizeObserver-based deferred rendering)
 - [x] "Conversation Sync" toggle button (⏸/▶) next to "Clear Graph" — pauses live graph updates, freezing the current snapshot
 
+### Session ID — UUIDs + composer auto-focus (closes #52) ✅
+- [x] `routes/index.tsx` no longer mints session ids with Solid's `createUniqueId()`. The helper produced `cl-${counter++}` that reset to `0` on every page load, so once any conversations existed in Postgres a fresh load or `+ New Chat` click could collide with an already-persisted row and silently hydrate the old chat.
+- [x] New `ui/src/lib/session-id.ts` exports `newSessionId()`. It calls `crypto.randomUUID()` when available and falls back to a manual RFC 4122 v4 build from `crypto.getRandomValues` (with a `Math.random` last-resort) so dev access over a non-secure context — LAN IP, `host.docker.internal` — still works.
+- [x] `+ New Chat` now lands focus in the composer textarea: a monotonic `focusInputToken` signal in `routes/index.tsx` increments on `handleNewChat`, threads through `ChatInterface` → `ChatInput`, and a `createEffect(on(... , { defer: true }))` calls `.focus()` on the textarea ref. `defer: true` skips the initial mount so navigating to an existing thread doesn't steal focus.
+- [x] Tests: `__tests__/lib/session-id.test.ts` (1000-call uniqueness, no collision with `cl-{0..100}`, RFC-4122-v4 shape, and a regression that strips `crypto.randomUUID` to exercise the fallback). `ChatSidebar.test.ts` extended with a UUID-placeholder-vs-`cl-*`-threads invariant for `mergeThreadsWithPlaceholder`.
+
 ## Deferred
 
 ### Graph-to-Chat Linking (reverse direction)

--- a/ui/src/__tests__/components/ark-ui/ChatSidebar.test.ts
+++ b/ui/src/__tests__/components/ark-ui/ChatSidebar.test.ts
@@ -66,4 +66,28 @@ describe('mergeThreadsWithPlaceholder', () => {
     const ids = merged.map((t) => t.id)
     expect(new Set(ids).size).toBe(ids.length)
   })
+
+  // Regression for #52: when the placeholder is a UUID (post-fix) and the
+  // persisted list contains legacy `cl-{n}` ids, the placeholder must be kept
+  // — under the old `createUniqueId()` scheme the counter could mint a value
+  // that collided with one of these rows and the placeholder would silently
+  // vanish.
+  it('keeps a UUID placeholder when threads contain legacy cl-{n} ids', () => {
+    const legacy: ChatThreadSummary[] = Array.from({ length: 20 }, (_, i) => ({
+      id: `cl-${i}`,
+      title: `Conversation ${i}`,
+      updatedAt: '2026-05-10T00:00:00Z',
+    }))
+    const uuid = '550e8400-e29b-41d4-a716-446655440000'
+    const merged = mergeThreadsWithPlaceholder(
+      legacy,
+      uuid,
+      () => '2026-05-10T12:00:00Z',
+    )
+    expect(merged).toHaveLength(legacy.length + 1)
+    expect(merged[0].id).toBe(uuid)
+    expect(merged[0].isPlaceholder).toBe(true)
+    // Legacy rows still flow through unchanged, in order.
+    expect(merged.slice(1).map((t) => t.id)).toEqual(legacy.map((t) => t.id))
+  })
 })

--- a/ui/src/__tests__/lib/session-id.test.ts
+++ b/ui/src/__tests__/lib/session-id.test.ts
@@ -1,0 +1,57 @@
+/**
+ * newSessionId — collision regression for #52.
+ *
+ * Solid's `createUniqueId()` minted `cl-${counter++}` on the client and reset
+ * the counter on every page load, so fresh ids collided with previously-
+ * persisted `cl-*` rows in Postgres. We replaced it with `crypto.randomUUID()`.
+ * These tests guard the two properties that matter:
+ *   1. Fresh ids never collide with one another within a session.
+ *   2. Fresh ids never collide with the legacy `cl-{n}` id space that may
+ *      still exist as opaque strings in the DB.
+ */
+
+import { afterEach, describe, it, expect, vi } from 'vitest'
+import { newSessionId } from '../../lib/session-id'
+
+const UUID_V4_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+describe('newSessionId', () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  it('produces no duplicates across 1000 calls', () => {
+    const ids = new Set<string>()
+    for (let i = 0; i < 1000; i++) ids.add(newSessionId())
+    expect(ids.size).toBe(1000)
+  })
+
+  it('never collides with legacy cl-{0..100} ids', () => {
+    const legacy = new Set<string>()
+    for (let i = 0; i <= 100; i++) legacy.add(`cl-${i}`)
+    for (let i = 0; i < 1000; i++) {
+      expect(legacy.has(newSessionId())).toBe(false)
+    }
+  })
+
+  it('returns RFC 4122 v4-shaped strings (not cl-{n})', () => {
+    const id = newSessionId()
+    expect(id).toMatch(UUID_V4_REGEX)
+    expect(id.startsWith('cl-')).toBe(false)
+  })
+
+  // Regression: in non-secure browser contexts (e.g. http://<lan-ip>:3444)
+  // `crypto.randomUUID` is undefined and we must fall back to a manual
+  // RFC 4122 v4 build from `crypto.getRandomValues`.
+  it('falls back to getRandomValues when randomUUID is unavailable', () => {
+    vi.spyOn(crypto, 'randomUUID').mockImplementation(
+      () => { throw new TypeError('crypto.randomUUID is not a function') },
+    )
+    // Re-shape the spy so the `typeof === 'function'` guard rejects it.
+    Object.defineProperty(crypto, 'randomUUID', { value: undefined, configurable: true })
+
+    const ids = new Set<string>()
+    for (let i = 0; i < 100; i++) ids.add(newSessionId())
+    expect(ids.size).toBe(100)
+    for (const id of ids) expect(id).toMatch(UUID_V4_REGEX)
+  })
+})

--- a/ui/src/components/ark-ui/ChatInput.tsx
+++ b/ui/src/components/ark-ui/ChatInput.tsx
@@ -1,5 +1,5 @@
 import { Field } from '@ark-ui/solid/field'
-import { Show, createSignal } from 'solid-js'
+import { Show, createEffect, createSignal, on } from 'solid-js'
 
 interface ChatInputProps {
   onSend: (message: string) => void
@@ -9,10 +9,24 @@ interface ChatInputProps {
   /** Inline guard message shown above the composer when submit is blocked,
    *  e.g. "Waiting for `web_search` to complete. Try later." */
   blockedMessage?: string
+  /** Monotonic token: every time it changes the textarea is focused. Used by
+   *  the route to drop the cursor into the composer after `+ New Chat`. */
+  focusToken?: number
 }
 
 export const ChatInput = (props: ChatInputProps) => {
   const [value, setValue] = createSignal('')
+  let textareaRef: HTMLTextAreaElement | undefined
+
+  // `defer: true` skips the initial fire — we only focus when the token
+  // *changes*, so initial mount of an existing chat doesn't steal focus.
+  createEffect(
+    on(
+      () => props.focusToken,
+      () => textareaRef?.focus(),
+      { defer: true },
+    ),
+  )
 
   const handleSend = () => {
     const message = value().trim()
@@ -47,6 +61,7 @@ export const ChatInput = (props: ChatInputProps) => {
         </div>
       </Show>
       <Field.Textarea
+        ref={textareaRef}
         value={value()}
         onInput={(e) => setValue(e.currentTarget.value)}
         onKeyDown={handleKeyDown}

--- a/ui/src/components/ark-ui/ChatInterface.tsx
+++ b/ui/src/components/ark-ui/ChatInterface.tsx
@@ -77,6 +77,9 @@ export interface ChatInterfaceProps {
    *  `title_updated` SSE event after the first-turn LLM title resolves.
    *  Route patches its threads cache in-place; no refetch required. */
   onTitleUpdated?: (sessionId: string, title: string) => void
+  /** Monotonic token forwarded to ChatInput — every change focuses the
+   *  composer textarea (used to land focus there after `+ New Chat`). */
+  focusInputToken?: number
 }
 
 const WELCOME_MESSAGE: Message = {
@@ -496,6 +499,7 @@ export const ChatInterface = (props: ChatInterfaceProps) => {
           onSend={handleSendMessage}
           disabled={isProcessing()}
           blockedMessage={blockedMessage()}
+          focusToken={props.focusInputToken}
         />
       </div>
     </div>

--- a/ui/src/lib/session-id.ts
+++ b/ui/src/lib/session-id.ts
@@ -1,0 +1,35 @@
+/**
+ * Mint a fresh, globally-unique session id for a new conversation.
+ *
+ * Replaces Solid's `createUniqueId()` for this specific purpose. The Solid
+ * helper produces `cl-${counter++}` on the client and resets the counter on
+ * every page load, which collides with previously-persisted rows once any
+ * conversations exist in Postgres (see #52). UUIDs avoid the collision and
+ * have no cross-load shared state.
+ *
+ * `crypto.randomUUID` is the preferred path but it's only defined in secure
+ * contexts (https, localhost, 127.0.0.1) — dev access over a LAN IP or
+ * `host.docker.internal` leaves it undefined and we hit `not a function`.
+ * `crypto.getRandomValues` is available in non-secure contexts too, so we
+ * use it to build an RFC 4122 v4 UUID by hand as a fallback.
+ */
+export const newSessionId = (): string => {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID()
+  }
+  return uuidV4Fallback()
+}
+
+const uuidV4Fallback = (): string => {
+  const bytes = new Uint8Array(16)
+  if (typeof crypto !== 'undefined' && typeof crypto.getRandomValues === 'function') {
+    crypto.getRandomValues(bytes)
+  } else {
+    for (let i = 0; i < 16; i++) bytes[i] = Math.floor(Math.random() * 256)
+  }
+  // RFC 4122 §4.4: set version (4) in byte 6 and variant (10xx) in byte 8.
+  bytes[6] = (bytes[6] & 0x0f) | 0x40
+  bytes[8] = (bytes[8] & 0x3f) | 0x80
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('')
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`
+}

--- a/ui/src/routes/index.tsx
+++ b/ui/src/routes/index.tsx
@@ -1,5 +1,5 @@
 import { Splitter } from '@ark-ui/solid/splitter'
-import { createSignal, createMemo, createResource, createEffect, createUniqueId, onCleanup, onMount } from 'solid-js'
+import { createSignal, createMemo, createResource, createEffect, onCleanup, onMount } from 'solid-js'
 import { ChatInterface, type SessionRunState } from '~/components/ark-ui/ChatInterface'
 import { ChatSidebar, mergeThreadsWithPlaceholder } from '~/components/ark-ui/ChatSidebar'
 import { SupportPanel, type GraphElement } from '~/components/ark-ui/SupportPanel'
@@ -7,6 +7,7 @@ import type { ContextEvent, UnifiedContext, ToolResultEventData } from '~/lib/ha
 import { executeCypherWrite } from '~/lib/neo4j/write-action'
 import { mergeGraphElements } from '~/lib/graph-merge'
 import { listConversations } from '~/lib/harness-client'
+import { newSessionId } from '~/lib/session-id'
 import type { StashAction } from '~/components/ark-ui/DataStashPanel'
 import { createChainProgress, type ChainProgressController } from '~/components/ark-ui/useChainProgress'
 
@@ -16,13 +17,17 @@ export default function Home() {
   // Conversation a user is currently viewing. Initial value is a fresh id so
   // the first message creates a new persisted row; switching threads via the
   // sidebar (or "+ New Chat") swaps this signal.
-  const [selectedSessionId, setSelectedSessionId] = createSignal(createUniqueId())
+  const [selectedSessionId, setSelectedSessionId] = createSignal(newSessionId())
   const [sidebarCollapsed, setSidebarCollapsed] = createSignal(false)
 
   // Optimistic placeholder for a freshly-minted "+ New Chat" id that hasn't
   // been persisted yet (see #44). Cleared once the real row arrives in the
   // threadsResource refetch, or when the user picks an existing thread.
   const [placeholderSessionId, setPlaceholderSessionId] = createSignal<string | null>(null)
+
+  // Monotonic token: each `+ New Chat` click bumps it, the ChatInput effect
+  // focuses the textarea so the user can start typing without an extra click.
+  const [focusInputToken, setFocusInputToken] = createSignal(0)
 
   const [graphElements, setGraphElements] = createSignal<GraphElement[]>([])
   const [highlightedIds, setHighlightedIds] = createSignal<string[]>([])
@@ -132,9 +137,10 @@ export default function Home() {
 
   const handleNewChat = () => {
     resetForNewSession()
-    const id = createUniqueId()
+    const id = newSessionId()
     setSelectedSessionId(id)
     setPlaceholderSessionId(id)
+    setFocusInputToken(t => t + 1)
   }
 
   const handleSelectThread = (threadId: string) => {
@@ -266,6 +272,7 @@ export default function Home() {
                 registerAbortController={registerAbortController}
                 unregisterAbortController={unregisterAbortController}
                 onTitleUpdated={handleTitleUpdated}
+                focusInputToken={focusInputToken()}
               />
             </div>
           </div>


### PR DESCRIPTION
## Summary

Solid's `createUniqueId()` mints `cl-${counter++}` on the client and resets to `0` on every page load, so once any conversations exist in Postgres a fresh load or `+ New Chat` click can collide with an already-persisted row and silently hydrate the old chat.

Mint session ids via `crypto.randomUUID()` with a `crypto.getRandomValues`-based RFC 4122 v4 fallback for non-secure contexts (LAN IP, `host.docker.internal`). `+ New Chat` also focuses the composer textarea via a monotonic `focusInputToken` signal so the user can start typing immediately.

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)