### PR TITLE
feat(code-mode): dedicated agent + framework fixes (closes #12)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,18 @@ Run a single test file:
 cd ui && pnpm vitest run src/__tests__/lib/harness-patterns/simpleLoop.test.ts
 ```
 
+### Client routing: Anthropic-default, mixed-chains opt-in
+
+Every BAML call (Router / LoopController / ActorController / Critic / Synthesize / ResultDescribe) routes through the Anthropic-only fallback chains in `baml_src/anthropic-only.baml` by default. Cross-provider rate limits (Groq + OpenRouter + OpenAI) interfered too much during dev iteration, so Anthropic-only is the dev default.
+
+To use the **mixed-provider production chains** (RouterFallback / ControllerFallback / etc. in `baml_src/clients.baml`):
+
+```bash
+USE_MIXED_CHAINS=1 pnpm dev:exposed
+```
+
+This unsets the override and lets each BAML function fall back to its declared chain. Production deployments and occasional mixed-chain testing both use this. See `ui/src/lib/harness-patterns/clients.server.ts` for the toggle.
+
 Docker services (Neo4j, MCP Gateway, Redis):
 ```bash
 docker compose up -d
@@ -98,19 +110,31 @@ view.fromPatterns(['neo4j-query']).serialize()        // → XML for LLM
 
 ## BAML Clients
 
+**Default (Anthropic-only)** — declared in `baml_src/anthropic-only.baml`:
+
 | Client | Role | Chain |
 |--------|------|-------|
-| `RouterFallback` | Intent classification | OpenRouterGemma4 → GroqFast → GroqGPT120B |
-| `ControllerFallback` | Tool loop controllers | OpenRouterNemotron120B → OpenAIGPT5 → OpenRouterMiniMax2_5 → GroqGPT120B |
-| `CriticFallback` | Evaluation/critique | GroqQwen3_32b → GroqGPT120B → OpenRouterMiniMax2_5 |
-| `SynthesizerFallback` | Response synthesis | OpenRouterGemma4 → GroqQwen3_32b → OpenAIGPT5 |
-| `DescribeFallback` | Lightweight tool result summarization | GroqFast → OpenRouterGemma4 → OpenAIGPT5Mini |
+| `RouterAnthropic` | Intent classification | AnthropicHaiku45 → AnthropicSonnet46 |
+| `ControllerAnthropic` | Tool loop controllers (simpleLoop + actor) | AnthropicSonnet46 → AnthropicHaiku45 |
+| `CriticAnthropic` | Evaluation/critique | AnthropicHaiku45 → AnthropicSonnet46 |
+| `SynthesizerAnthropic` | Response synthesis | AnthropicSonnet46 → AnthropicHaiku45 |
+| `DescribeAnthropic` | Lightweight tool result summarization | AnthropicHaiku45 |
+
+**Mixed-provider chains** (gated by `USE_MIXED_CHAINS=1`, see top of file) — declared in `baml_src/clients.baml`:
+
+| Client | Chain |
+|--------|-------|
+| `RouterFallback` | OpenRouterGemma4 → GroqFast → GroqGPT120B |
+| `ControllerFallback` | OpenRouterNemotron120B → OpenAIGPT5 → OpenRouterMiniMax2_5 → GroqGPT120B |
+| `CriticFallback` | GroqQwen3_32b → GroqGPT120B → OpenRouterMiniMax2_5 |
+| `SynthesizerFallback` | OpenRouterGemma4 → GroqQwen3_32b → OpenAIGPT5 |
+| `DescribeFallback` | GroqFast → OpenRouterGemma4 → OpenAIGPT5Mini |
 
 Local inference (`LocalGLM` — GLM 4.7 Flash on localhost:8080) is defined in `baml_src/local-client.baml` and available for manual wiring but not used in any fallback chain.
 
-Required env vars: `GROQ_API_KEY`, `OPENROUTER_API_KEY`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`.
+Required env vars: `ANTHROPIC_API_KEY` (always). With `USE_MIXED_CHAINS=1` also: `GROQ_API_KEY`, `OPENROUTER_API_KEY`, `OPENAI_API_KEY`.
 
-**Known limitation:** Groq `gpt-oss-120b` fails structured output (`BamlValidationError`) on turn 2+ with larger context. `baml-adapters.server.ts` catches this manually and retries with `GroqGPT120B` then `GroqFast`. Errors are tracked as events; synthesizer reads them via `view.hasErrors()` (scoped by ViewConfig, so they expire naturally across turns).
+**Known limitation (mixed-chains only):** Groq `gpt-oss-120b` fails structured output (`BamlValidationError`) on turn 2+ with larger context. `baml-adapters.server.ts` catches this manually and retries with `GroqGPT120B` then `GroqFast`. Anthropic-only runs propagate the validation error instead. Errors are tracked as events; synthesizer reads them via `view.hasErrors()` (scoped by ViewConfig, so they expire naturally across turns).
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -15,17 +15,17 @@
 - [ ] Collapsible sections for large JSON payloads in EventDetailOverlay
 - [ ] Show tool input arguments in detail overlay (currently only output/result is shown)
 
-### Code Mode (re-implementation using harness-patterns)
-Composable code execution with an evaluate loop. The previous implementation (`lib/baml-agent/`) has been removed. A new implementation should be built on top of harness-patterns.
-
-Core requirements:
-- [ ] Evaluate loop with `MAX_RETRIES` and graceful exit after N failures
-- [ ] Per-iteration output capture passed as context to the evaluator
-- [ ] Rich failure context for each retry iteration (what was tried, what failed, script diff)
-- [ ] Intermediate logging per iteration
-
 ### MCP Infrastructure
 - [ ] MCP catalog hot-swap without gateway restart (currently requires restart after config changes)
+
+### Harness pattern: Skill support
+- [ ] First-class **Skill** abstraction for pattern factories. Today the code-mode agent ships its actor guidance as a `contextPrefix` string + `fewShots` array inlined in `code-mode.server.ts` (see `ui/src/lib/harness-client/examples/code_mode_actor_critic.md`). Once Skill support exists, that same content moves into a reusable Skill the actor receives via the standard mechanism — same shape (text + few-shots), but composable across agents and discoverable in the registry. Other actorCritic / simpleLoop users (guardrailed, ontology-builder, neo4j) would migrate the same way.
+
+### Code-mode execution environment
+- [ ] [#64](https://github.com/mknw/harness-playground/issues/64) — Investigate where `code-mode-<name>({script})` actually runs (Node container / V8 isolate / sandbox) and what host-side write capability the JS has. Blocks shipping any few-shot whose script writes to the host filesystem directly (currently the agent only writes via MCP tools — e.g. Scenario F writes to Neo4j via `write_neo4j_cypher`).
+
+### Result summarization
+- [ ] [#65](https://github.com/mknw/harness-playground/issues/65) — Skip `ResultDescribe` for `code-mode` factory calls. The factory result is a multi-KB tool spec (description, full JSON schema, all bound MCP tools enumerated) and the summary is fully derivable from `{ tool === 'code-mode', success === true, args.name, args.servers }`. Short-circuit to a templated `"Created code-mode tool '<name>' bound to servers: <list>."` without an LLM round-trip. Saves ~1–2K input tokens and one Groq dependency per factory call. Same shape as the LLM-generated summary — observability stays intact.
 
 ### UI
 See [ui/ROADMAP.md](../ui/ROADMAP.md) for frontend-specific work: graph editing, Actions tab, Documents tab, Graph Layout improvements.
@@ -33,6 +33,17 @@ See [ui/ROADMAP.md](../ui/ROADMAP.md) for frontend-specific work: graph editing,
 ---
 
 ## Completed
+
+### Code Mode as a dedicated agent (actorCritic + factory workflow) ✅
+The kg-agent gateway's `code-mode` tool is a **factory** — its `args_schema` is `{name, servers}`, and calling it registers a new `code-mode-<name>` tool bound to the listed MCP servers (the generated tool is what actually executes JS). The first implementation tried to wedge this into the default agent as a simpleLoop with a single-tool toolbelt; that approach blew up the first time the LLM (correctly) tried to call `mcp-find` to discover servers. Closes #12; unblocks #28 row 1.3.
+
+The redesign moves code_mode out of the default agent into its own:
+
+- **New `code-mode` agent** — `ui/src/lib/harness-client/examples/code-mode.server.ts`. Shape: `router → routes(chain(actorCritic, synthesizer))`. The router either responds directly (Router's `needs_tool: false` path) or dispatches to the `code_mode` route. The inner chain runs `actorCritic` against the curated mcp-* family (`mcp-find`, `mcp-add`, `code-mode`, `mcp-exec`); the synthesizer that follows reads only actor-side events via `viewConfig.eventTypes: ['controller_action', 'tool_call', 'tool_result']` so the critic's reasoning never leaks into the final response.
+- **Default agent untouched** apart from losing its `code_mode` wiring — neo4j + web_search routes remain identical.
+- **Dynamic-tool support** — actorCritic + SimpleLoopConfig gain an optional `dynamicToolPattern: RegExp` so `code-mode-<name>` tools created by the factory pass the allowlist without enumerating every name upfront.
+- **Cross-turn tool reuse** — `createActorControllerAdapter` accepts `{ toolNames, dynamicPattern, refreshOnCall }`; the code-mode agent sets `refreshOnCall: true` so each actor invocation re-lists the gateway and surfaces tools created in earlier turns of the same session (the gateway persists those tools for its process lifetime). A new `invalidateToolDescriptions()` export lets `actorCritic.server.ts` drop the module-level cache after a successful `code-mode` call so the freshly-registered tool appears in the actor's next prompt.
+- **Test** — `ui/src/__tests__/agents/code-mode.test.ts` drives the agent end-to-end with mocked LLM + MCP, exercising both the factory workflow (mcp-find → code-mode({name, servers}) → Return) and the direct-response branch.
 
 ### Conversation Persistence + Functional Sidebar ✅
 Replaced the in-memory session `Map` with a Postgres-backed store; sidebar now shows real threads that survive restarts. Closes #22 (commit `f6b2822`).

--- a/docs/UI_ARCHITECTURE.md
+++ b/docs/UI_ARCHITECTURE.md
@@ -771,11 +771,17 @@ ui/
 ├── eslint.config.ts              # ESLint rules
 ├── uno.config.ts                 # UnoCSS config + theme
 ├── baml_src/                     # BAML function definitions
-│   ├── clients.baml              # LLM client config
-│   ├── routing.baml              # Message routing
-│   ├── neo4j.baml                # Neo4j planning
-│   ├── code_mode.baml            # Code mode composition
-│   └── response.baml             # Response generation
+│   ├── clients.baml              # LLM client config + fallback chains
+│   ├── local-client.baml         # Local GLM-4.7 client (manual wiring)
+│   ├── router.baml               # Router (intent classification)
+│   ├── simpleLoop.baml           # Generic LoopController (used by all simpleLoop routes incl. code_mode)
+│   ├── actorCritic.baml          # ActorController + Critic (used by guardrailed/ontology agents)
+│   ├── synthesizer.baml          # Final response synthesis
+│   ├── describe.baml             # Lightweight tool-result summarization
+│   ├── title.baml                # Conversation title generation
+│   ├── with-references.baml      # Reference selector for withReferences
+│   ├── types.baml                # Shared schema types
+│   └── generators.baml           # baml-generate output config
 ├── src/
 │   ├── shims.d.ts                # TypeScript augmentation
 │   ├── routes/

--- a/docs/harness-patterns/api.md
+++ b/docs/harness-patterns/api.md
@@ -81,10 +81,10 @@ type ScopedPattern<T> = (
 // From baml_client - standardized controller output
 interface ControllerAction {
   reasoning: string
-  tool_name: string           // Tool to call, or 'Return'
+  tool_name: string           // Tool to call. In simpleLoop, `'Return'` exits the loop. In actorCritic, the actor's exit signals are ignored — the critic alone decides termination via `is_sufficient`.
   tool_args: string           // JSON payload
   status: string
-  is_final: boolean
+  is_final: boolean           // simpleLoop only — actorCritic ignores this on the actor side
 }
 
 // Critic evaluation result

--- a/docs/harness-patterns/examples.md
+++ b/docs/harness-patterns/examples.md
@@ -29,22 +29,22 @@ All agents are registered in `registry.server.ts` and available via `getAgentLis
 
 **File:** `default.server.ts`
 
-Router-based multi-capability agent. Each route is wrapped with `withReferences` so the inner pattern receives an LLM-curated set of relevant prior `tool_result` events from any earlier turn (subsumes #26 / #29 — see [`with-references.md`](with-references.md)).
+Router-based agent with Neo4j and Web Search routes. Each route is wrapped with `withReferences` so the inner pattern receives an LLM-curated set of relevant prior `tool_result` events from any earlier turn (subsumes #26 / #29 — see [`with-references.md`](with-references.md)).
 
 ```typescript
-router({ neo4j: '...', web_search: '...', code_mode: '...' })
+router({ neo4j: '...', web_search: '...' })
 → routes({
     neo4j:      withReferences(neo4jPattern, { scope: 'global' }),
-    web_search: withReferences(webPattern,   { scope: 'global' }),
-    code_mode:  withReferences(codePattern,  { scope: 'global' })
+    web_search: withReferences(webPattern,   { scope: 'global' })
   })
 → synthesizer({ mode: 'thread' })
 ```
 
-- Neo4j queries with approval for mutations
-- Web search via DuckDuckGo
-- Code mode with actor-critic loop
+- Neo4j queries (`read_neo4j_cypher`, `write_neo4j_cypher`, `get_neo4j_schema`)
+- Web search via DuckDuckGo (`search`, `fetch`, `fetch_content`)
 - Cross-turn data flow: `withReferences` selector attaches relevant prior refs at each route's ingress; the controller can use `expandPreviousResult` or pass `ref:<id>` in tool args to inline-expand the full data
+
+For JS-orchestration workflows that span multiple servers, see [Agent 11 — Code Mode](#11-code-mode-agent).
 
 ---
 
@@ -204,6 +204,48 @@ cacheWriter:
 
 synthesizer
 ```
+
+---
+
+## 11. Code Mode Agent
+
+**File:** `code-mode.server.ts`
+
+Orchestrate multiple MCP tools via JavaScript snippets executed server-side by the kg-agent gateway's `code-mode` tool family. The gateway's `code-mode` tool is a **factory** — its `args_schema` is `{name, servers}` and a successful call registers a new `code-mode-<name>` tool bound to those servers. The generated tool is what actually runs JS.
+
+```typescript
+router({ code_mode: 'Compose JS across multiple MCP tools…' })
+→ routes({
+    code_mode: chain(
+      actorCritic(
+        createActorControllerAdapter({
+          toolNames: ['mcp-find', 'mcp-add', 'code-mode', 'mcp-exec'],
+          dynamicPattern: /^code-mode-/,
+          refreshOnCall: true,        // see newly-created tools across turns
+        }),
+        createCriticAdapter(),
+        ['mcp-find', 'mcp-add', 'code-mode', 'mcp-exec'],
+        {
+          patternId: 'code-mode-loop',
+          dynamicToolPattern: /^code-mode-/,   // allowlist for factory output
+        }
+      ),
+      synthesizer({
+        mode: 'thread',
+        patternId: 'code-mode-synth',
+        viewConfig: {
+          // Final response built only from actor-side events; critic_result events
+          // are filtered out so the critic's reasoning doesn't leak into the prompt.
+          eventTypes: ['controller_action', 'tool_call', 'tool_result'],
+        },
+      })
+    )
+  })
+```
+
+- **Direct-response branch**: when `Router` returns `needs_tool: false`, the router sets `scope.data.response` to the conversational reply and `routes()` passes through — no synthesizer needed at the top level.
+- **Cross-turn tool reuse**: `refreshOnCall: true` on the actor adapter forces a fresh `mcpListTools()` per invocation so `code-mode-<name>` tools created in earlier turns of the same session are still visible to the actor. `invalidateToolDescriptions()` is called from `actorCritic.server.ts` right after a successful `code-mode` execution, so the new tool appears in the next attempt's prompt.
+- **actorCritic over simpleLoop**: the find → add → factory → call-generated-tool sequence has many ways to go wrong on the first try; actorCritic's retry-with-critic-feedback semantics fit better than simpleLoop's break-on-first-error.
 
 ---
 

--- a/docs/harness-patterns/frontend.md
+++ b/docs/harness-patterns/frontend.md
@@ -309,11 +309,10 @@ async function createPatterns(): Promise<ConfiguredPattern<SessionData>[]> {
   const tools = await Tools()
   const schema = await getSchema()
 
-  // Bind BAML methods to preserve 'this' context
-  const neo4jController = b.Neo4jController.bind(b)
-  const webController = b.WebSearchController.bind(b)
-  const codeController = b.CodeModeController.bind(b)
-  const codeCritic = b.CodeModeCritic.bind(b)
+  // Use adapter factories (see baml-adapters.server.ts) — they wrap the generic
+  // LoopController with the right context for each domain.
+  const neo4jController = createNeo4jController(tools.neo4j ?? [])
+  const webController = createWebSearchController(tools.web ?? [])
 
   const neo4jPattern = withApproval(
     simpleLoop(neo4jController, tools.neo4j ?? [], {
@@ -327,20 +326,14 @@ async function createPatterns(): Promise<ConfiguredPattern<SessionData>[]> {
     patternId: 'web-search'
   })
 
-  const codePattern = actorCritic(codeController, codeCritic, tools.all, {
-    patternId: 'code-mode'
-  })
-
   const routerPattern = router(
     {
       neo4j: 'Database queries and graph operations',
-      web_search: 'Web lookups and information retrieval',
-      code_mode: 'Multi-tool script composition'
+      web_search: 'Web lookups and information retrieval'
     },
     {
       neo4j: neo4jPattern,
-      web_search: webPattern,
-      code_mode: codePattern
+      web_search: webPattern
     }
   )
 
@@ -353,6 +346,8 @@ async function createPatterns(): Promise<ConfiguredPattern<SessionData>[]> {
   return [routerPattern, responseSynth]
 }
 ```
+
+JS-orchestration workflows (the kg-agent gateway's `code-mode` factory + generated tools) live in a separate agent — see [`code-mode.server.ts`](../../ui/src/lib/harness-client/examples/code-mode.server.ts) and [`examples.md` § 11. Code Mode Agent](examples.md#11-code-mode-agent).
 
 ---
 

--- a/ui/.env.example
+++ b/ui/.env.example
@@ -33,3 +33,17 @@ CEREBRAS_API_KEY=''
 #   2. `pnpm dev` and sign in via /auth/signin with an email listed in
 #      VITE_ALLOWED_EMAILS above.
 VITE_DEV_BYPASS_AUTH='true'
+
+# ----- BAML client routing -----
+#
+# Every BAML call (Router / LoopController / ActorController / Critic /
+# Synthesize / ResultDescribe / GenerateConversationTitle / ReferenceSelector)
+# is declared with an Anthropic-only client (Sonnet 4.6 → Haiku 4.5) by
+# default. Cross-provider rate limits (Groq + OpenRouter + OpenAI) made the
+# mixed chain too noisy for dev iteration on actorCritic / multi-turn flows.
+#
+# Set to '1' to route through the mixed-provider fallback chains in
+# `baml_src/clients.baml` (RouterFallback / ControllerFallback / etc.) —
+# useful for reproducing production-chain bugs, or when Anthropic quota
+# becomes the bottleneck. See `ui/src/lib/harness-patterns/clients.server.ts`.
+# USE_MIXED_CHAINS='1'

--- a/ui/baml_src/actorCritic.baml
+++ b/ui/baml_src/actorCritic.baml
@@ -16,7 +16,7 @@ function ActorController(
   attempt_n: int?,
   max_attempts: int?
 ) -> ControllerAction {
-  client ControllerFallback
+  client ControllerAnthropic
   prompt #"
     {{ _.role("system") }}
     You are an AI agent that accomplishes tasks by calling tools.
@@ -44,7 +44,11 @@ function ActorController(
     - {{ tool.name }}: {{ tool.description }}
       {% if tool.args_schema %}  Args: {{ tool.args_schema }}{% endif %}
     {% endfor %}
-    - Return: Signal task completion (tool_args = final answer or summary)
+
+    The critic evaluates whether the data you've gathered is sufficient and
+    decides when the task is complete — you don't need a "Return" tool. Focus
+    on calling the right tool to make progress; the loop exits when the critic
+    says so.
 
     {% if attempts|length > 0 %}
     PREVIOUS ATTEMPTS:
@@ -64,16 +68,16 @@ function ActorController(
     {% if attempt_n is not none and max_attempts is not none %}
     BUDGET: Attempt {{ attempt_n }} of {{ max_attempts }}.
     {% if attempt_n >= max_attempts - 1 %}
-    This is your final or near-final attempt. Prefer `Return` with whatever
-    partial results you have over starting a new tool chain.
+    This is your final or near-final attempt. Call the tool most likely to
+    produce a useful partial answer — the critic will decide whether to accept.
+    Do NOT start a fresh tool chain that won't complete in time.
     {% endif %}
     {% endif %}
 
     {{ _.role("user") }}
     {{ user_message }}
 
-    {{ _.role("assistant") }}
-    Attempt {{ attempts|length + 1 }}.
+    You are on attempt {{ attempts|length + 1 }}. Respond with the next action.
 
     {{ ctx.output_format }}
   "#
@@ -87,7 +91,7 @@ function Critic(
   intent: string,
   attempts: Attempt[]
 ) -> CriticResult {
-  client CriticFallback
+  client CriticAnthropic
   prompt #"
     {{ _.role("system") }}
     You evaluate whether task execution results satisfy the user's intent.

--- a/ui/baml_src/actorCritic.baml
+++ b/ui/baml_src/actorCritic.baml
@@ -10,7 +10,11 @@ function ActorController(
   user_message: string,
   intent: string,
   tools: ToolDescription[],
-  attempts: Attempt[]
+  attempts: Attempt[],
+  context: string?,
+  few_shots: FewShot[]?,
+  attempt_n: int?,
+  max_attempts: int?
 ) -> ControllerAction {
   client ControllerFallback
   prompt #"
@@ -19,6 +23,21 @@ function ActorController(
     A critic evaluates your output. Learn from previous feedback.
 
     USER INTENT: {{ intent }}
+
+    {% if context %}
+    CONTEXT:
+    {{ context }}
+    {% endif %}
+
+    {% if few_shots and few_shots|length > 0 %}
+    EXAMPLES (illustrative — adapt to the actual request, do not copy verbatim):
+    {% for ex in few_shots %}
+    - User: {{ ex.user }}
+      Reasoning: {{ ex.reasoning }}
+      Tool: {{ ex.tool }}
+      Args: {{ ex.args }}
+    {% endfor %}
+    {% endif %}
 
     AVAILABLE TOOLS:
     {% for tool in tools %}
@@ -40,6 +59,14 @@ function ActorController(
     {% endfor %}
 
     You MUST address the critic's feedback. Do not repeat failed approaches.
+    {% endif %}
+
+    {% if attempt_n is not none and max_attempts is not none %}
+    BUDGET: Attempt {{ attempt_n }} of {{ max_attempts }}.
+    {% if attempt_n >= max_attempts - 1 %}
+    This is your final or near-final attempt. Prefer `Return` with whatever
+    partial results you have over starting a new tool chain.
+    {% endif %}
     {% endif %}
 
     {{ _.role("user") }}

--- a/ui/baml_src/anthropic-only.baml
+++ b/ui/baml_src/anthropic-only.baml
@@ -1,0 +1,48 @@
+// Anthropic-only client variants for development iteration.
+//
+// Used when `USE_ANTHROPIC_ONLY=1` is set — see `harness-patterns/clients.server.ts`.
+// Production code paths use the per-use-case fallback chains in clients.baml
+// (RouterFallback / ControllerFallback / CriticFallback / SynthesizerFallback /
+// DescribeFallback) which span multiple providers.
+//
+// Purpose: avoid Groq / OpenRouter / OpenAI rate-limit interference while
+// iterating on actorCritic / multi-turn / hallucination scenarios.
+
+client<llm> RouterAnthropic {
+  provider fallback
+  options {
+    strategy [AnthropicHaiku45, AnthropicSonnet46]
+  }
+}
+
+client<llm> ControllerAnthropic {
+  provider fallback
+  options {
+    // Sonnet 4.6 leads — best structured-output adherence for tool selection.
+    // Haiku 4.5 as cheap backstop if Sonnet rate-limits.
+    strategy [AnthropicSonnet46, AnthropicHaiku45]
+  }
+}
+
+client<llm> CriticAnthropic {
+  provider fallback
+  options {
+    // Haiku 4.5 leads — critic is short evaluative judgment, doesn't need
+    // Sonnet-tier reasoning. Sonnet as backstop.
+    strategy [AnthropicHaiku45, AnthropicSonnet46]
+  }
+}
+
+client<llm> SynthesizerAnthropic {
+  provider fallback
+  options {
+    strategy [AnthropicSonnet46, AnthropicHaiku45]
+  }
+}
+
+client<llm> DescribeAnthropic {
+  provider fallback
+  options {
+    strategy [AnthropicHaiku45]
+  }
+}

--- a/ui/baml_src/describe.baml
+++ b/ui/baml_src/describe.baml
@@ -8,7 +8,7 @@ function ResultDescribe(
   reasoning: string,
   result: string
 ) -> string {
-  client DescribeFallback
+  client DescribeAnthropic
   prompt #"
     {{ _.role("system") }}
     You are a concise data summarizer. Summarize what the following tool call

--- a/ui/baml_src/router.baml
+++ b/ui/baml_src/router.baml
@@ -7,7 +7,7 @@ function Router(
   routes: RouteOption[],
   history: Message[]
 ) -> RoutingResult {
-  client RouterFallback
+  client RouterAnthropic
   prompt #"
     {{ _.role("system") }}
     Analyze the user message and determine routing.
@@ -16,6 +16,15 @@ function Router(
     {% for route in routes %}
     - {{ route.name }}: {{ route.description }}
     {% endfor %}
+
+    ROUTING RULES:
+    - Set needs_tool=true if the message requires calling a tool or route
+    - Set route to the matching route name (null if no tool needed)
+    - Set needs_tool=false ONLY for greetings, thanks, help requests, or simple clarifications
+    - Any question about data, graphs, databases, stored information, or domain-specific lookups MUST route to the appropriate tool (needs_tool=true)
+    - If needs_tool=true, set response to a SHORT status like "Looking into that..." — do NOT attempt to answer the question yourself
+    - If needs_tool=false, provide a direct conversational reply
+    - NEVER generate a substantive answer when routing to a tool — the tool will provide the real answer
 
     {% if history|length > 0 %}
     CONVERSATION HISTORY (most recent last):
@@ -27,16 +36,6 @@ function Router(
 
     {{ _.role("user") }}
     {{ message }}
-
-    {{ _.role("assistant") }}
-    ROUTING RULES:
-    - Set needs_tool=true if the message requires calling a tool or route
-    - Set route to the matching route name (null if no tool needed)
-    - Set needs_tool=false ONLY for greetings, thanks, help requests, or simple clarifications
-    - Any question about data, graphs, databases, stored information, or domain-specific lookups MUST route to the appropriate tool (needs_tool=true)
-    - If needs_tool=true, set response to a SHORT status like "Looking into that..." — do NOT attempt to answer the question yourself
-    - If needs_tool=false, provide a direct conversational reply
-    - NEVER generate a substantive answer when routing to a tool — the tool will provide the real answer
 
     {{ ctx.output_format }}
   "#

--- a/ui/baml_src/simpleLoop.baml
+++ b/ui/baml_src/simpleLoop.baml
@@ -15,7 +15,7 @@ function LoopController(
   turns_previous_runs: PriorResult[]?,
   few_shots: FewShot[]?
 ) -> ControllerAction {
-  client ControllerFallback
+  client ControllerAnthropic
   prompt #"
     {{ _.role("system") }}
     You are an AI agent that accomplishes tasks by calling tools.
@@ -97,7 +97,6 @@ function LoopController(
     {{ _.role("user") }}
     INSTRUCTIONS: {{ user_message }}
 
-    {{ _.role("assistant") }}
     Turn {{ turns|length + 1 }}. Decide the next action.
 
     {{ ctx.output_format }}

--- a/ui/baml_src/synthesizer.baml
+++ b/ui/baml_src/synthesizer.baml
@@ -9,7 +9,7 @@ function Synthesize(
   has_error: bool,
   error_message: string?
 ) -> string {
-  client SynthesizerFallback
+  client SynthesizerAnthropic
   prompt #"
     {{ _.role("system") }}
     Create a user-friendly response from tool execution results.

--- a/ui/baml_src/title.baml
+++ b/ui/baml_src/title.baml
@@ -10,7 +10,7 @@
 // so the prompt rules are best-effort, not load-bearing.
 
 function GenerateConversationTitle(user_message: string) -> string {
-  client DescribeFallback
+  client DescribeAnthropic
   prompt #"
     {{ _.role("system") }}
     Generate a 3-to-5-word title summarizing what this conversation is

--- a/ui/baml_src/with-references.baml
+++ b/ui/baml_src/with-references.baml
@@ -25,7 +25,7 @@ function ReferenceSelector(
   recent_messages: Message[],
   candidates: ReferenceCandidate[]
 ) -> ReferenceSelectorResult {
-  client DescribeFallback
+  client DescribeAnthropic
   prompt #"
     {{ _.role("system") }}
     Select prior tool results that are relevant to the user's current intent.

--- a/ui/src/__tests__/agents/code-mode.test.ts
+++ b/ui/src/__tests__/agents/code-mode.test.ts
@@ -100,7 +100,7 @@ describe('code-mode agent — router → routes(chain(actorCritic, synth))', () 
       response: '',
     })
 
-    // Three actor attempts: find servers → create code-mode tool → done.
+    // Three actor attempts: find servers → create code-mode tool → invoke it.
     actorController
       .mockResolvedValueOnce(
         mockAction({
@@ -116,12 +116,19 @@ describe('code-mode agent — router → routes(chain(actorCritic, synth))', () 
           tool_args: JSON.stringify({ name: 'graph-search', servers: ['neo4j-cypher', 'fetch'] }),
         }),
       )
-      .mockResolvedValueOnce(mockFinalAction('Done.'))
+      .mockResolvedValueOnce(
+        mockAction({
+          reasoning: 'Invoke the registered tool with a query script.',
+          tool_name: 'code-mode-graph-search',  // matches dynamicToolPattern /^code-mode-/
+          tool_args: '{"script":"return ok;"}',
+        }),
+      )
 
-    // First two attempts (mcp-find, code-mode factory) are setup steps —
-    // critic must say "not done yet" so the loop continues to the next actor
-    // call. After the factory creates the tool, the actor returns `Return` on
-    // its next call, which breaks the loop at the top before the critic runs.
+    // First two attempts (mcp-find, code-mode factory) are setup steps — critic
+    // says "not done yet" so the loop continues to the next actor call. On the
+    // third attempt the actor invokes the registered tool; the critic accepts
+    // the result (post-P0 Return-from-critic: the loop exits when the critic
+    // says `is_sufficient: true`, never when the actor calls "Return").
     critic
       .mockResolvedValueOnce(mockCriticResult({ is_sufficient: false, explanation: 'Need to create code-mode tool' }))
       .mockResolvedValueOnce(mockCriticResult({ is_sufficient: false, explanation: 'Need to call generated tool' }))
@@ -241,25 +248,30 @@ describe('code-mode agent — retry budget + per-conversation allowlist', () => 
   })
 
   it('survives more than 3 non-final turns (maxRetries: 8 vs default 3)', async () => {
-    // Five non-final actor turns, then the default (mockResolvedValue) flips
-    // to final so any call past the 5th returns Return and breaks the loop.
-    // Default maxRetries=3 (settings.ts:18) would emit "Max retries (3)
-    // exceeded" at turn 3. With maxRetries: 8 on the code-mode loop, the
-    // loop reaches the final action.
+    // Five setup/exploration actor turns, then the default (mockResolvedValue)
+    // flips to a real tool action that the critic eventually accepts. Default
+    // maxRetries=3 (settings.ts:18) would emit "Max retries (3) exceeded" at
+    // turn 3. With maxRetries: 8 on the code-mode loop, the loop reaches the
+    // turn where the critic returns is_sufficient: true (post-P0: only the
+    // critic can exit the loop).
     actorController
       .mockResolvedValueOnce(mockAction({ tool_name: 'mcp-find', tool_args: '{}' }))
       .mockResolvedValueOnce(mockAction({ tool_name: 'mcp-find', tool_args: '{}' }))
       .mockResolvedValueOnce(mockAction({ tool_name: 'mcp-add', tool_args: '{"name":"memory"}' }))
       .mockResolvedValueOnce(mockAction({ tool_name: 'mcp-add', tool_args: '{"name":"web_search"}' }))
-      .mockResolvedValueOnce(
+      .mockResolvedValue(
         mockAction({
           tool_name: 'code-mode',
           tool_args: JSON.stringify({ name: 'graph-search', servers: ['neo4j-cypher'] }),
         }),
       )
-      .mockResolvedValue(mockFinalAction('All steps complete.'))
 
-    critic.mockResolvedValue(mockCriticResult({ is_sufficient: false, explanation: 'keep going' }))
+    critic
+      .mockResolvedValueOnce(mockCriticResult({ is_sufficient: false, explanation: 'keep going' }))
+      .mockResolvedValueOnce(mockCriticResult({ is_sufficient: false, explanation: 'keep going' }))
+      .mockResolvedValueOnce(mockCriticResult({ is_sufficient: false, explanation: 'keep going' }))
+      .mockResolvedValueOnce(mockCriticResult({ is_sufficient: false, explanation: 'keep going' }))
+      .mockResolvedValue(mockCriticResult({ is_sufficient: true }))
     synthesize.mockResolvedValue('All steps complete.')
 
     const { codeModeAgent } = await import('../../lib/harness-client/examples/code-mode.server')
@@ -299,7 +311,10 @@ describe('code-mode agent — retry budget + per-conversation allowlist', () => 
       agentId: 'code-mode',
     })
 
-    actorController.mockResolvedValue(mockFinalAction('Done.'))
+    // Post-P0: actor exits via critic, not via Return. Use a real tool action
+    // and let the critic say sufficient after one turn.
+    actorController.mockResolvedValue(mockAction({ tool_name: 'code-mode', tool_args: '{"name":"x","servers":["x"]}' }))
+    critic.mockResolvedValue(mockCriticResult({ is_sufficient: true }))
 
     const { codeModeAgent } = await import('../../lib/harness-client/examples/code-mode.server')
     const { harness } = await import('../../lib/harness-patterns/harness.server')

--- a/ui/src/__tests__/agents/code-mode.test.ts
+++ b/ui/src/__tests__/agents/code-mode.test.ts
@@ -1,0 +1,322 @@
+/**
+ * Code Mode Agent — E2E-shaped (Issue #12 / #28 row 1.3)
+ *
+ * Drives the dedicated code-mode agent through router → routes(chain(actorCritic, synth))
+ * with mocked LLM + MCP. Asserts:
+ *  - pattern_enter sequence covers router → code-mode-loop → code-mode-synth
+ *  - the gateway's `code-mode` factory is called, the cache invalidation hook
+ *    fires (Synthesize sees only actor-side events, no critic_result leak)
+ *  - direct-response branch (Router needs_tool=false) skips the loop entirely
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mockAction, mockFinalAction, mockCriticResult } from '../mocks/baml'
+import { mockCallTool, mockListTools } from '../mocks/mcp'
+
+const mockToolSets = {
+  code: ['mcp-find', 'mcp-add', 'code-mode', 'mcp-exec', 'Return'],
+  all: [] as string[],
+}
+mockToolSets.all = [...mockToolSets.code]
+
+vi.mock('../../lib/harness-patterns/assert.server', () => ({
+  assertServerOnImport: vi.fn(),
+}))
+
+const callToolMock = mockCallTool({
+  responses: {
+    'mcp-find': { servers: ['neo4j-cypher', 'fetch'] },
+    'mcp-add': { ok: true },
+    'code-mode': { tool_name: 'code-mode-graph-search' },
+    'code-mode-graph-search': { nodes: [{ name: 'planning-agent', degree: 12 }] },
+  },
+})
+
+vi.mock('../../lib/harness-patterns/mcp-client.server', () => ({
+  callTool: callToolMock,
+  listTools: mockListTools(mockToolSets.all),
+}))
+
+const actorController = vi.fn()
+const critic = vi.fn()
+const router = vi.fn()
+const synthesize = vi.fn()
+
+vi.mock('../../../baml_client', () => ({
+  b: {
+    LoopController: vi.fn(async () => mockFinalAction()),
+    ActorController: actorController,
+    Critic: critic,
+    Router: router,
+    Synthesize: synthesize,
+    ResultDescribe: vi.fn(async () => ''),
+  },
+}))
+
+vi.mock('@boundaryml/baml', () => {
+  class MockCollector {
+    last = {
+      rawLlmResponse: 'raw',
+      usage: { inputTokens: 10, outputTokens: 5 },
+      calls: [{ httpRequest: { body: {} } }],
+    }
+    constructor(_name?: string) {}
+  }
+  class BamlValidationError extends Error {}
+  return { Collector: MockCollector, BamlValidationError }
+})
+
+vi.mock('../../lib/harness-patterns/tools.server', () => ({
+  Tools: vi.fn(async () => mockToolSets),
+  ToolsFrom: vi.fn(() => mockToolSets),
+}))
+
+// The code-mode agent dynamically imports `loadSession` inside its
+// toolNamesProvider closure to avoid a top-level circular import with the
+// agent registry. Tests that exercise the allowlist branch override this
+// mock per-test via vi.mocked(loadSession).mockResolvedValueOnce(...).
+const loadSessionMock = vi.fn(async () => null as null | { serializedContext: string; agentId: string })
+vi.mock('../../lib/harness-client/session.server', () => ({
+  loadSession: loadSessionMock,
+}))
+
+// Default to "no userId scope" so the existing tests (which don't care about
+// the allowlist) flow through the closure's null guard. Tests that need it
+// override per-test.
+const getRequestUserIdMock = vi.fn(() => null as string | null)
+vi.mock('../../lib/harness-client/request-user.server', () => ({
+  getRequestUserId: getRequestUserIdMock,
+  runWithUserId: (_uid: string, fn: () => Promise<unknown>) => fn(),
+}))
+
+describe('code-mode agent — router → routes(chain(actorCritic, synth))', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    router.mockResolvedValue({
+      intent: 'Find the most connected node and search the web for it',
+      needs_tool: true,
+      route: 'code_mode',
+      response: '',
+    })
+
+    // Three actor attempts: find servers → create code-mode tool → done.
+    actorController
+      .mockResolvedValueOnce(
+        mockAction({
+          reasoning: 'Discover available gateway servers.',
+          tool_name: 'mcp-find',
+          tool_args: '{}',
+        }),
+      )
+      .mockResolvedValueOnce(
+        mockAction({
+          reasoning: 'Create a code-mode tool bound to neo4j and fetch.',
+          tool_name: 'code-mode',
+          tool_args: JSON.stringify({ name: 'graph-search', servers: ['neo4j-cypher', 'fetch'] }),
+        }),
+      )
+      .mockResolvedValueOnce(mockFinalAction('Done.'))
+
+    // First two attempts (mcp-find, code-mode factory) are setup steps —
+    // critic must say "not done yet" so the loop continues to the next actor
+    // call. After the factory creates the tool, the actor returns `Return` on
+    // its next call, which breaks the loop at the top before the critic runs.
+    critic
+      .mockResolvedValueOnce(mockCriticResult({ is_sufficient: false, explanation: 'Need to create code-mode tool' }))
+      .mockResolvedValueOnce(mockCriticResult({ is_sufficient: false, explanation: 'Need to call generated tool' }))
+      .mockResolvedValue(mockCriticResult({ is_sufficient: true }))
+    synthesize.mockResolvedValue('Most connected node is planning-agent.')
+  })
+
+  afterEach(() => {
+    vi.resetModules()
+  })
+
+  it('runs the factory workflow and synthesizes from actor events only', async () => {
+    const { codeModeAgent } = await import('../../lib/harness-client/examples/code-mode.server')
+    const { harness } = await import('../../lib/harness-patterns/harness.server')
+
+    const patterns = await codeModeAgent.createPatterns('test-session')
+    const agent = harness(...patterns)
+
+    const result = await agent('Find the most connected node and search the web for it.')
+
+    expect(result.status).not.toBe('error')
+    expect(result.response).toContain('planning-agent')
+
+    expect(router).toHaveBeenCalledTimes(1)
+
+    // Pattern lifecycle covers the router and inner chain (loop + synth).
+    const enterEvents = result.context.events.filter(e => e.type === 'pattern_enter')
+    const enteredIds = enterEvents.map(e => e.patternId)
+    expect(enteredIds.some(id => id === 'code-mode-loop')).toBe(true)
+    expect(enteredIds.some(id => id === 'code-mode-synth')).toBe(true)
+
+    // Factory was invoked.
+    const codeModeCalls = callToolMock.mock.calls.filter(([tool]) => tool === 'code-mode')
+    expect(codeModeCalls.length).toBe(1)
+    expect((codeModeCalls[0][1] as { name?: string }).name).toBe('graph-search')
+
+    // Synthesizer's view was filtered: when Synthesize was called, the turns
+    // it received describe only actor-side tool events, no critic verdicts.
+    // (`viewConfig.eventTypes` excludes 'critic_result'.)
+    //
+    // BAML signature: Synthesize(userMessage, intent, turns, hasError, errorMessage).
+    expect(synthesize).toHaveBeenCalledTimes(1)
+    const synthCallArgs = synthesize.mock.calls[0]
+    const turnsArg = synthCallArgs[2] as unknown[]
+    const turnsJson = JSON.stringify(turnsArg)
+    expect(turnsJson.includes('is_sufficient')).toBe(false)  // critic_result never leaked
+
+    // Regression for the chain() scope-reuse bug (hallucination-codemode-3.json):
+    // Events emitted inside the loop must carry the loop's patternId, not the
+    // chain's auto-generated id. Without this, the synth's `fromLastPattern`
+    // view filter excludes the actor's tool events, and the synth fabricates
+    // a response over an empty turns array.
+    const actorActionEvents = result.context.events.filter(e => e.type === 'controller_action')
+    expect(actorActionEvents.length).toBeGreaterThan(0)
+    expect(actorActionEvents.every(e => e.patternId === 'code-mode-loop')).toBe(true)
+    // And the synth's view did surface non-empty turns.
+    expect(Array.isArray(turnsArg)).toBe(true)
+    expect(turnsArg.length).toBeGreaterThan(0)
+  })
+
+  it('skips the loop on direct-response (Router needs_tool=false)', async () => {
+    router.mockResolvedValue({
+      intent: 'Greeting',
+      needs_tool: false,
+      route: null,
+      response: 'Hi! I orchestrate MCP tools via code-mode.',
+    })
+
+    const { codeModeAgent } = await import('../../lib/harness-client/examples/code-mode.server')
+    const { harness } = await import('../../lib/harness-patterns/harness.server')
+
+    const patterns = await codeModeAgent.createPatterns('test-session')
+    const agent = harness(...patterns)
+
+    const result = await agent('Hello, what can you do?')
+
+    expect(actorController).not.toHaveBeenCalled()
+    expect(callToolMock.mock.calls.filter(([t]) => t === 'code-mode').length).toBe(0)
+    expect(result.response).toContain('I orchestrate MCP tools')
+  })
+
+})
+
+describe('code-mode agent — retry budget + per-conversation allowlist', () => {
+  beforeEach(() => {
+    // Full reset (not just clearAllMocks): the previous describe's "needs_tool=false"
+    // test queues 3 actor/critic Once-values it never consumes, and vi.clearAllMocks
+    // leaves those queues intact — they'd pollute our actor queue here.
+    actorController.mockReset()
+    critic.mockReset()
+    router.mockReset()
+    synthesize.mockReset()
+    callToolMock.mockClear()
+    loadSessionMock.mockReset()
+    loadSessionMock.mockResolvedValue(null)
+    getRequestUserIdMock.mockReset()
+    getRequestUserIdMock.mockReturnValue(null)
+    router.mockResolvedValue({
+      intent: 'multi-step',
+      needs_tool: true,
+      route: 'code_mode',
+      response: '',
+    })
+    synthesize.mockResolvedValue('Done.')
+  })
+
+  afterEach(() => {
+    vi.resetModules()
+    // Restore shared module-level state mutated by individual tests so the
+    // ordering doesn't leak between cases. NOTE: mockListTools captured a
+    // reference to mockToolSets.all at module load; we must mutate the
+    // existing array in place rather than reassign, otherwise the captured
+    // reference still points at the previous test's array.
+    mockToolSets.all.length = 0
+    mockToolSets.all.push(...mockToolSets.code)
+    getRequestUserIdMock.mockReturnValue(null)
+  })
+
+  it('survives more than 3 non-final turns (maxRetries: 8 vs default 3)', async () => {
+    // Five non-final actor turns, then the default (mockResolvedValue) flips
+    // to final so any call past the 5th returns Return and breaks the loop.
+    // Default maxRetries=3 (settings.ts:18) would emit "Max retries (3)
+    // exceeded" at turn 3. With maxRetries: 8 on the code-mode loop, the
+    // loop reaches the final action.
+    actorController
+      .mockResolvedValueOnce(mockAction({ tool_name: 'mcp-find', tool_args: '{}' }))
+      .mockResolvedValueOnce(mockAction({ tool_name: 'mcp-find', tool_args: '{}' }))
+      .mockResolvedValueOnce(mockAction({ tool_name: 'mcp-add', tool_args: '{"name":"memory"}' }))
+      .mockResolvedValueOnce(mockAction({ tool_name: 'mcp-add', tool_args: '{"name":"web_search"}' }))
+      .mockResolvedValueOnce(
+        mockAction({
+          tool_name: 'code-mode',
+          tool_args: JSON.stringify({ name: 'graph-search', servers: ['neo4j-cypher'] }),
+        }),
+      )
+      .mockResolvedValue(mockFinalAction('All steps complete.'))
+
+    critic.mockResolvedValue(mockCriticResult({ is_sufficient: false, explanation: 'keep going' }))
+    synthesize.mockResolvedValue('All steps complete.')
+
+    const { codeModeAgent } = await import('../../lib/harness-client/examples/code-mode.server')
+    const { harness } = await import('../../lib/harness-patterns/harness.server')
+
+    const patterns = await codeModeAgent.createPatterns('test-session')
+    const agent = harness(...patterns)
+    const result = await agent('Do a multi-step thing.')
+
+    // No "Max retries exceeded" — the regression that motivated maxRetries: 8.
+    const retryExhausted = result.context.events.filter(
+      e => e.type === 'error' && /Max retries/.test(((e.data as { error?: string }).error ?? '')),
+    )
+    expect(retryExhausted).toEqual([])
+    expect(actorController.mock.calls.length).toBeGreaterThan(3)
+    expect(result.response).toContain('All steps complete.')
+  })
+
+  it('passes the per-conversation allowlist to the actor', async () => {
+    // Gateway exposes the meta-tools plus the user's extras. Mutate in place
+    // — mockListTools captured the array reference at module load.
+    mockToolSets.all.push('read_neo4j_cypher', 'search')
+
+    // Pretend we're inside a runWithUserId scope.
+    getRequestUserIdMock.mockReturnValue('user-1')
+
+    // Persisted conversation context with a user-curated allowlist on data.
+    loadSessionMock.mockResolvedValue({
+      serializedContext: JSON.stringify({
+        sessionId: 'test-session',
+        input: 'do thing',
+        status: 'running',
+        createdAt: 0,
+        events: [],
+        data: { codeModeAllowedTools: ['read_neo4j_cypher', 'search'] },
+      }),
+      agentId: 'code-mode',
+    })
+
+    actorController.mockResolvedValue(mockFinalAction('Done.'))
+
+    const { codeModeAgent } = await import('../../lib/harness-client/examples/code-mode.server')
+    const { harness } = await import('../../lib/harness-patterns/harness.server')
+
+    const patterns = await codeModeAgent.createPatterns('test-session')
+    const agent = harness(...patterns)
+    await agent('do thing')
+
+    // The actor receives ToolDescription[] at arg index 2 of ActorController:
+    // (user_message, intent, tools, attempts, ...). The allowlist union
+    // (meta-tools ∪ user picks) must be present.
+    expect(actorController).toHaveBeenCalledTimes(1)
+    const toolsArg = actorController.mock.calls[0][2] as Array<{ name: string }>
+    const toolNames = toolsArg.map(t => t.name)
+    expect(toolNames).toEqual(expect.arrayContaining([
+      'mcp-find', 'mcp-add', 'code-mode', 'mcp-exec',
+      'read_neo4j_cypher', 'search',
+    ]))
+  })
+})

--- a/ui/src/__tests__/lib/harness-client/examples/agent-execution.test.ts
+++ b/ui/src/__tests__/lib/harness-client/examples/agent-execution.test.ts
@@ -165,7 +165,7 @@ describe('LLM Judge Evaluator Execution', () => {
 
   it('should score high for substantial content (>500 chars)', async () => {
     const { llmJudgeAgent } = await import('../../../../lib/harness-client/examples/llm-judge.server')
-    const patterns = await llmJudgeAgent.createPatterns() as Pattern[]
+    const patterns = await llmJudgeAgent.createPatterns('test-session') as Pattern[]
     const judgePattern = patterns.find(p => p.config.patternId === 'quality-judge')!
 
     const scope = createMockScope({ input: 'react hooks tutorial' })
@@ -190,7 +190,7 @@ describe('LLM Judge Evaluator Execution', () => {
 
   it('should score higher for content containing query terms', async () => {
     const { llmJudgeAgent } = await import('../../../../lib/harness-client/examples/llm-judge.server')
-    const patterns = await llmJudgeAgent.createPatterns() as Pattern[]
+    const patterns = await llmJudgeAgent.createPatterns('test-session') as Pattern[]
     const judgePattern = patterns.find(p => p.config.patternId === 'quality-judge')!
 
     const scope = createMockScope({ input: 'react hooks tutorial' })
@@ -213,7 +213,7 @@ describe('LLM Judge Evaluator Execution', () => {
 
   it('should give source authority bonus', async () => {
     const { llmJudgeAgent } = await import('../../../../lib/harness-client/examples/llm-judge.server')
-    const patterns = await llmJudgeAgent.createPatterns() as Pattern[]
+    const patterns = await llmJudgeAgent.createPatterns('test-session') as Pattern[]
     const judgePattern = patterns.find(p => p.config.patternId === 'quality-judge')!
 
     const scope = createMockScope({ input: 'test query' })
@@ -233,7 +233,7 @@ describe('LLM Judge Evaluator Execution', () => {
 
   it('should give bonus for code blocks', async () => {
     const { llmJudgeAgent } = await import('../../../../lib/harness-client/examples/llm-judge.server')
-    const patterns = await llmJudgeAgent.createPatterns() as Pattern[]
+    const patterns = await llmJudgeAgent.createPatterns('test-session') as Pattern[]
     const judgePattern = patterns.find(p => p.config.patternId === 'quality-judge')!
 
     const scope = createMockScope({ input: 'code example' })
@@ -254,7 +254,7 @@ describe('LLM Judge Evaluator Execution', () => {
 
   it('should give bonus for lists', async () => {
     const { llmJudgeAgent } = await import('../../../../lib/harness-client/examples/llm-judge.server')
-    const patterns = await llmJudgeAgent.createPatterns() as Pattern[]
+    const patterns = await llmJudgeAgent.createPatterns('test-session') as Pattern[]
     const judgePattern = patterns.find(p => p.config.patternId === 'quality-judge')!
 
     const scope = createMockScope({ input: 'list items' })
@@ -276,7 +276,7 @@ describe('LLM Judge Evaluator Execution', () => {
 
   it('should cap score at 1.0', async () => {
     const { llmJudgeAgent } = await import('../../../../lib/harness-client/examples/llm-judge.server')
-    const patterns = await llmJudgeAgent.createPatterns() as Pattern[]
+    const patterns = await llmJudgeAgent.createPatterns('test-session') as Pattern[]
     const judgePattern = patterns.find(p => p.config.patternId === 'quality-judge')!
 
     // Create content that would score > 1.0 uncapped
@@ -295,7 +295,7 @@ describe('LLM Judge Evaluator Execution', () => {
 
   it('should handle empty candidates', async () => {
     const { llmJudgeAgent } = await import('../../../../lib/harness-client/examples/llm-judge.server')
-    const patterns = await llmJudgeAgent.createPatterns() as Pattern[]
+    const patterns = await llmJudgeAgent.createPatterns('test-session') as Pattern[]
     const judgePattern = patterns.find(p => p.config.patternId === 'quality-judge')!
 
     const scope = createMockScope()
@@ -310,7 +310,7 @@ describe('LLM Judge Evaluator Execution', () => {
 
   it('should handle query with no terms > 3 chars', async () => {
     const { llmJudgeAgent } = await import('../../../../lib/harness-client/examples/llm-judge.server')
-    const patterns = await llmJudgeAgent.createPatterns() as Pattern[]
+    const patterns = await llmJudgeAgent.createPatterns('test-session') as Pattern[]
     const judgePattern = patterns.find(p => p.config.patternId === 'quality-judge')!
 
     const scope = createMockScope({ input: 'a b c' }) // All terms <= 3 chars
@@ -340,7 +340,7 @@ describe('Multi-Source Research Evaluator Execution', () => {
 
   it('should score based on content length and relevance', async () => {
     const { multiSourceResearchAgent } = await import('../../../../lib/harness-client/examples/multi-source-research.server')
-    const patterns = await multiSourceResearchAgent.createPatterns() as Pattern[]
+    const patterns = await multiSourceResearchAgent.createPatterns('test-session') as Pattern[]
     const judgePattern = patterns.find(p => p.config.patternId === 'quality-judge')!
 
     const scope = createMockScope({ input: 'python flask tutorial' })
@@ -368,7 +368,7 @@ describe('Multi-Source Research Evaluator Execution', () => {
 
   it('should handle candidates with only content length', async () => {
     const { multiSourceResearchAgent } = await import('../../../../lib/harness-client/examples/multi-source-research.server')
-    const patterns = await multiSourceResearchAgent.createPatterns() as Pattern[]
+    const patterns = await multiSourceResearchAgent.createPatterns('test-session') as Pattern[]
     const judgePattern = patterns.find(p => p.config.patternId === 'quality-judge')!
 
     const scope = createMockScope({ input: 'xyz123' }) // No matching terms
@@ -388,7 +388,7 @@ describe('Multi-Source Research Evaluator Execution', () => {
 
   it('should give correct reason for limited content', async () => {
     const { multiSourceResearchAgent } = await import('../../../../lib/harness-client/examples/multi-source-research.server')
-    const patterns = await multiSourceResearchAgent.createPatterns() as Pattern[]
+    const patterns = await multiSourceResearchAgent.createPatterns('test-session') as Pattern[]
     const judgePattern = patterns.find(p => p.config.patternId === 'quality-judge')!
 
     const scope = createMockScope({ input: 'test' })
@@ -408,7 +408,7 @@ describe('Multi-Source Research Evaluator Execution', () => {
 
   it('should select best candidate', async () => {
     const { multiSourceResearchAgent } = await import('../../../../lib/harness-client/examples/multi-source-research.server')
-    const patterns = await multiSourceResearchAgent.createPatterns() as Pattern[]
+    const patterns = await multiSourceResearchAgent.createPatterns('test-session') as Pattern[]
     const judgePattern = patterns.find(p => p.config.patternId === 'quality-judge')!
 
     const scope = createMockScope({ input: 'test query' })
@@ -440,7 +440,7 @@ describe('Ontology Builder ontologyJudge Execution', () => {
 
   it('should score for class/concept definitions', async () => {
     const { ontologyBuilderAgent } = await import('../../../../lib/harness-client/examples/ontology-builder.server')
-    const patterns = await ontologyBuilderAgent.createPatterns() as Pattern[]
+    const patterns = await ontologyBuilderAgent.createPatterns('test-session') as Pattern[]
     const judgePattern = patterns.find(p => p.config.patternId === 'ontology-judge')!
 
     const scope = createMockScope({ input: 'domain ontology' })
@@ -460,7 +460,7 @@ describe('Ontology Builder ontologyJudge Execution', () => {
 
   it('should score for relationships', async () => {
     const { ontologyBuilderAgent } = await import('../../../../lib/harness-client/examples/ontology-builder.server')
-    const patterns = await ontologyBuilderAgent.createPatterns() as Pattern[]
+    const patterns = await ontologyBuilderAgent.createPatterns('test-session') as Pattern[]
     const judgePattern = patterns.find(p => p.config.patternId === 'ontology-judge')!
 
     const scope = createMockScope({ input: 'domain ontology' })
@@ -480,7 +480,7 @@ describe('Ontology Builder ontologyJudge Execution', () => {
 
   it('should score for hierarchical structure', async () => {
     const { ontologyBuilderAgent } = await import('../../../../lib/harness-client/examples/ontology-builder.server')
-    const patterns = await ontologyBuilderAgent.createPatterns() as Pattern[]
+    const patterns = await ontologyBuilderAgent.createPatterns('test-session') as Pattern[]
     const judgePattern = patterns.find(p => p.config.patternId === 'ontology-judge')!
 
     const scope = createMockScope({ input: 'domain ontology' })
@@ -500,7 +500,7 @@ describe('Ontology Builder ontologyJudge Execution', () => {
 
   it('should score for substantial coverage', async () => {
     const { ontologyBuilderAgent } = await import('../../../../lib/harness-client/examples/ontology-builder.server')
-    const patterns = await ontologyBuilderAgent.createPatterns() as Pattern[]
+    const patterns = await ontologyBuilderAgent.createPatterns('test-session') as Pattern[]
     const judgePattern = patterns.find(p => p.config.patternId === 'ontology-judge')!
 
     const scope = createMockScope({ input: 'domain ontology' })
@@ -520,7 +520,7 @@ describe('Ontology Builder ontologyJudge Execution', () => {
 
   it('should always add consistency check', async () => {
     const { ontologyBuilderAgent } = await import('../../../../lib/harness-client/examples/ontology-builder.server')
-    const patterns = await ontologyBuilderAgent.createPatterns() as Pattern[]
+    const patterns = await ontologyBuilderAgent.createPatterns('test-session') as Pattern[]
     const judgePattern = patterns.find(p => p.config.patternId === 'ontology-judge')!
 
     const scope = createMockScope({ input: 'domain ontology' })
@@ -554,7 +554,7 @@ describe('Guardrailed Agent Rails Execution', () => {
 
   it('should create guardrail with all rails configured', async () => {
     const { guardrailedAgent } = await import('../../../../lib/harness-client/examples/guardrailed-agent.server')
-    const patterns = await guardrailedAgent.createPatterns() as Pattern[]
+    const patterns = await guardrailedAgent.createPatterns('test-session') as Pattern[]
 
     const guardrailPattern = patterns.find(p => p.config.patternId === 'safe-file-edit')
     expect(guardrailPattern).toBeDefined()
@@ -570,7 +570,7 @@ describe('Guardrailed Agent Rails Execution', () => {
 
   it('should execute guardrail pattern with safe input', async () => {
     const { guardrailedAgent } = await import('../../../../lib/harness-client/examples/guardrailed-agent.server')
-    const patterns = await guardrailedAgent.createPatterns() as Pattern[]
+    const patterns = await guardrailedAgent.createPatterns('test-session') as Pattern[]
     const guardrailPattern = patterns.find(p => p.config.patternId === 'safe-file-edit')!
 
     const scope = createMockScope({ input: 'edit my file.txt' })
@@ -583,7 +583,7 @@ describe('Guardrailed Agent Rails Execution', () => {
 
   it('should block destructive commands via topicalRail', async () => {
     const { guardrailedAgent } = await import('../../../../lib/harness-client/examples/guardrailed-agent.server')
-    const patterns = await guardrailedAgent.createPatterns() as Pattern[]
+    const patterns = await guardrailedAgent.createPatterns('test-session') as Pattern[]
     const guardrailPattern = patterns.find(p => p.config.patternId === 'safe-file-edit')!
 
     // Use a destructive command pattern that topicalRail should block
@@ -598,7 +598,7 @@ describe('Guardrailed Agent Rails Execution', () => {
 
   it('should block delete database command via topicalRail', async () => {
     const { guardrailedAgent } = await import('../../../../lib/harness-client/examples/guardrailed-agent.server')
-    const patterns = await guardrailedAgent.createPatterns() as Pattern[]
+    const patterns = await guardrailedAgent.createPatterns('test-session') as Pattern[]
     const guardrailPattern = patterns.find(p => p.config.patternId === 'safe-file-edit')!
 
     const scope = createMockScope({ input: 'delete all from database' })
@@ -611,7 +611,7 @@ describe('Guardrailed Agent Rails Execution', () => {
 
   it('should block drop table command via topicalRail', async () => {
     const { guardrailedAgent } = await import('../../../../lib/harness-client/examples/guardrailed-agent.server')
-    const patterns = await guardrailedAgent.createPatterns() as Pattern[]
+    const patterns = await guardrailedAgent.createPatterns('test-session') as Pattern[]
     const guardrailPattern = patterns.find(p => p.config.patternId === 'safe-file-edit')!
 
     const scope = createMockScope({ input: 'DROP TABLE users' })
@@ -624,7 +624,7 @@ describe('Guardrailed Agent Rails Execution', () => {
 
   it('should block format drive command via topicalRail', async () => {
     const { guardrailedAgent } = await import('../../../../lib/harness-client/examples/guardrailed-agent.server')
-    const patterns = await guardrailedAgent.createPatterns() as Pattern[]
+    const patterns = await guardrailedAgent.createPatterns('test-session') as Pattern[]
     const guardrailPattern = patterns.find(p => p.config.patternId === 'safe-file-edit')!
 
     const scope = createMockScope({ input: 'format my drive C:' })
@@ -651,7 +651,7 @@ describe('Conversational Memory Distillation', () => {
 
   it('should have hook configured for session_close trigger', async () => {
     const { conversationalMemoryAgent } = await import('../../../../lib/harness-client/examples/conversational-memory.server')
-    const patterns = await conversationalMemoryAgent.createPatterns() as Pattern[]
+    const patterns = await conversationalMemoryAgent.createPatterns('test-session') as Pattern[]
 
     const hookPattern = patterns.find(p => p.config.patternId === 'session-close-hook')
     expect(hookPattern).toBeDefined()
@@ -659,7 +659,7 @@ describe('Conversational Memory Distillation', () => {
 
   it('should configure hook as background task', async () => {
     const { conversationalMemoryAgent } = await import('../../../../lib/harness-client/examples/conversational-memory.server')
-    const patterns = await conversationalMemoryAgent.createPatterns() as Pattern[]
+    const patterns = await conversationalMemoryAgent.createPatterns('test-session') as Pattern[]
 
     const hookPattern = patterns.find(p => p.config.patternId === 'session-close-hook')
     expect(hookPattern).toBeDefined()

--- a/ui/src/__tests__/lib/harness-client/examples/agents.test.ts
+++ b/ui/src/__tests__/lib/harness-client/examples/agents.test.ts
@@ -113,7 +113,7 @@ interface AgentConfig {
   description: string
   icon: string
   servers: string[]
-  createPatterns: () => Promise<unknown[]>
+  createPatterns: (sessionId: string) => Promise<unknown[]>
 }
 
 function validateAgentConfig(config: AgentConfig) {
@@ -135,7 +135,7 @@ interface Pattern {
 }
 
 async function validatePatterns(config: AgentConfig): Promise<Pattern[]> {
-  const patterns = await config.createPatterns() as Pattern[]
+  const patterns = await config.createPatterns('test-session') as Pattern[]
 
   expect(patterns).toBeInstanceOf(Array)
   expect(patterns.length).toBeGreaterThan(0)
@@ -213,10 +213,30 @@ describe('Agent Harnesses', () => {
 
     it('should have unique pattern IDs', async () => {
       const { defaultAgent } = await import('../../../../lib/harness-client/examples/default.server')
-      const patterns = await defaultAgent.createPatterns() as Pattern[]
+      const patterns = await defaultAgent.createPatterns('test-session') as Pattern[]
       const ids = patterns.map(p => p.config.patternId)
       const uniqueIds = new Set(ids)
       expect(uniqueIds.size).toBe(ids.length)
+    })
+  })
+
+  describe('codeModeAgent', () => {
+    it('should have valid config', async () => {
+      const { codeModeAgent } = await import('../../../../lib/harness-client/examples/code-mode.server')
+      validateAgentConfig(codeModeAgent)
+      expect(codeModeAgent.id).toBe('code-mode')
+    })
+
+    it('should create patterns: router + routes(chain(loop, synth))', async () => {
+      const { codeModeAgent } = await import('../../../../lib/harness-client/examples/code-mode.server')
+      const patterns = await validatePatterns(codeModeAgent)
+
+      const names = patterns.map(p => p.name)
+      // Two top-level patterns: router + routes.
+      expect(patterns.length).toBe(2)
+      expect(names).toContain('router')
+      // The routes name embeds the route key.
+      expect(names.some(n => n.includes('code_mode'))).toBe(true)
     })
   })
 
@@ -238,14 +258,14 @@ describe('Agent Harnesses', () => {
 
     it('should include session tracking pattern', async () => {
       const { conversationalMemoryAgent } = await import('../../../../lib/harness-client/examples/conversational-memory.server')
-      const patterns = await conversationalMemoryAgent.createPatterns() as Pattern[]
+      const patterns = await conversationalMemoryAgent.createPatterns('test-session') as Pattern[]
       const hasSessionTracker = patterns.some(p => p.config.patternId === 'session-tracker')
       expect(hasSessionTracker).toBe(true)
     })
 
     it('should execute session tracker pattern', async () => {
       const { conversationalMemoryAgent } = await import('../../../../lib/harness-client/examples/conversational-memory.server')
-      const patterns = await conversationalMemoryAgent.createPatterns() as Pattern[]
+      const patterns = await conversationalMemoryAgent.createPatterns('test-session') as Pattern[]
       const sessionTracker = patterns.find(p => p.config.patternId === 'session-tracker')
 
       expect(sessionTracker).toBeDefined()
@@ -262,7 +282,7 @@ describe('Agent Harnesses', () => {
 
     it('should handle redis failure gracefully in session tracker', async () => {
       const { conversationalMemoryAgent } = await import('../../../../lib/harness-client/examples/conversational-memory.server')
-      const patterns = await conversationalMemoryAgent.createPatterns() as Pattern[]
+      const patterns = await conversationalMemoryAgent.createPatterns('test-session') as Pattern[]
       const sessionTracker = patterns.find(p => p.config.patternId === 'session-tracker')
 
       // Make callTool fail for this test
@@ -295,7 +315,7 @@ describe('Agent Harnesses', () => {
 
     it('should start with doc lookup pattern', async () => {
       const { docAssistantAgent } = await import('../../../../lib/harness-client/examples/doc-assistant.server')
-      const patterns = await docAssistantAgent.createPatterns() as Pattern[]
+      const patterns = await docAssistantAgent.createPatterns('test-session') as Pattern[]
       expect(patterns[0].config.patternId).toBe('doc-lookup')
     })
   })
@@ -317,7 +337,7 @@ describe('Agent Harnesses', () => {
 
     it('should include guardrail pattern', async () => {
       const { guardrailedAgent } = await import('../../../../lib/harness-client/examples/guardrailed-agent.server')
-      const patterns = await guardrailedAgent.createPatterns() as Pattern[]
+      const patterns = await guardrailedAgent.createPatterns('test-session') as Pattern[]
       // guardrail pattern name includes wrapped pattern: 'guardrail(withApproval)'
       const hasGuardrail = patterns.some(p => p.name.startsWith('guardrail('))
       expect(hasGuardrail).toBe(true)
@@ -358,7 +378,7 @@ describe('Agent Harnesses', () => {
 
     it('should include approval pattern for neo4j persist', async () => {
       const { kgBuilderAgent } = await import('../../../../lib/harness-client/examples/kg-builder.server')
-      const patterns = await kgBuilderAgent.createPatterns() as Pattern[]
+      const patterns = await kgBuilderAgent.createPatterns('test-session') as Pattern[]
       const hasApproval = patterns.some(p => p.name === 'withApproval')
       expect(hasApproval).toBe(true)
     })
@@ -381,7 +401,7 @@ describe('Agent Harnesses', () => {
 
     it('should include parallel and judge patterns', async () => {
       const { llmJudgeAgent } = await import('../../../../lib/harness-client/examples/llm-judge.server')
-      const patterns = await llmJudgeAgent.createPatterns() as Pattern[]
+      const patterns = await llmJudgeAgent.createPatterns('test-session') as Pattern[]
       const names = patterns.map(p => p.name)
       expect(names).toContain('parallel')
       // judge pattern uses patternId as name
@@ -423,7 +443,7 @@ describe('Agent Harnesses', () => {
 
     it('should include multiple pattern types', async () => {
       const { ontologyBuilderAgent } = await import('../../../../lib/harness-client/examples/ontology-builder.server')
-      const patterns = await ontologyBuilderAgent.createPatterns() as Pattern[]
+      const patterns = await ontologyBuilderAgent.createPatterns('test-session') as Pattern[]
       const names = new Set(patterns.map(p => p.name))
 
       // Should use variety of patterns
@@ -449,7 +469,7 @@ describe('Agent Harnesses', () => {
 
     it('should start with cache check pattern', async () => {
       const { semanticCacheAgent } = await import('../../../../lib/harness-client/examples/semantic-cache.server')
-      const patterns = await semanticCacheAgent.createPatterns() as Pattern[]
+      const patterns = await semanticCacheAgent.createPatterns('test-session') as Pattern[]
       expect(patterns[0].config.patternId).toBe('semantic-cache')
     })
   })
@@ -472,7 +492,7 @@ describe('Judge Evaluators', () => {
     it('should score candidates based on content length', async () => {
       // Import the agent to get access to the evaluator via patterns
       const { llmJudgeAgent } = await import('../../../../lib/harness-client/examples/llm-judge.server')
-      const patterns = await llmJudgeAgent.createPatterns() as Pattern[]
+      const patterns = await llmJudgeAgent.createPatterns('test-session') as Pattern[]
 
       // Find the judge pattern
       const judgePattern = patterns.find(p => p.config.patternId === 'quality-judge')
@@ -484,7 +504,7 @@ describe('Judge Evaluators', () => {
 
     it('should create source patterns for web, docs, and github', async () => {
       const { llmJudgeAgent } = await import('../../../../lib/harness-client/examples/llm-judge.server')
-      const patterns = await llmJudgeAgent.createPatterns() as Pattern[]
+      const patterns = await llmJudgeAgent.createPatterns('test-session') as Pattern[]
 
       // Find the parallel pattern containing sources
       const parallelPattern = patterns.find(p => p.config.patternId === 'parallel-sources')
@@ -496,7 +516,7 @@ describe('Judge Evaluators', () => {
   describe('multiSourceResearchAgent judgeEvaluator', () => {
     it('should have quality judge pattern', async () => {
       const { multiSourceResearchAgent } = await import('../../../../lib/harness-client/examples/multi-source-research.server')
-      const patterns = await multiSourceResearchAgent.createPatterns() as Pattern[]
+      const patterns = await multiSourceResearchAgent.createPatterns('test-session') as Pattern[]
 
       const judgePattern = patterns.find(p => p.config.patternId === 'quality-judge')
       expect(judgePattern).toBeDefined()
@@ -504,7 +524,7 @@ describe('Judge Evaluators', () => {
 
     it('should have parallel research pattern', async () => {
       const { multiSourceResearchAgent } = await import('../../../../lib/harness-client/examples/multi-source-research.server')
-      const patterns = await multiSourceResearchAgent.createPatterns() as Pattern[]
+      const patterns = await multiSourceResearchAgent.createPatterns('test-session') as Pattern[]
 
       const parallelPattern = patterns.find(p => p.config.patternId === 'parallel-research')
       expect(parallelPattern).toBeDefined()
@@ -528,7 +548,7 @@ describe('Semantic Cache Patterns', () => {
   describe('semanticCache pattern', () => {
     it('should return cache hit when cached data exists', async () => {
       const { semanticCacheAgent } = await import('../../../../lib/harness-client/examples/semantic-cache.server')
-      const patterns = await semanticCacheAgent.createPatterns() as Pattern[]
+      const patterns = await semanticCacheAgent.createPatterns('test-session') as Pattern[]
       const cachePattern = patterns.find(p => p.config.patternId === 'semantic-cache')
 
       expect(cachePattern).toBeDefined()
@@ -545,7 +565,7 @@ describe('Semantic Cache Patterns', () => {
 
     it('should return cache miss when no cached data', async () => {
       const { semanticCacheAgent } = await import('../../../../lib/harness-client/examples/semantic-cache.server')
-      const patterns = await semanticCacheAgent.createPatterns() as Pattern[]
+      const patterns = await semanticCacheAgent.createPatterns('test-session') as Pattern[]
       const cachePattern = patterns.find(p => p.config.patternId === 'semantic-cache')
 
       // Mock cache miss - need to mock both json_get failure and empty vector_search_hash
@@ -562,7 +582,7 @@ describe('Semantic Cache Patterns', () => {
 
     it('should handle vector search errors gracefully', async () => {
       const { semanticCacheAgent } = await import('../../../../lib/harness-client/examples/semantic-cache.server')
-      const patterns = await semanticCacheAgent.createPatterns() as Pattern[]
+      const patterns = await semanticCacheAgent.createPatterns('test-session') as Pattern[]
       const cachePattern = patterns.find(p => p.config.patternId === 'semantic-cache')
 
       // Mock cache miss followed by vector search error
@@ -580,7 +600,7 @@ describe('Semantic Cache Patterns', () => {
 
     it('should return cache hit from vector similarity search', async () => {
       const { semanticCacheAgent } = await import('../../../../lib/harness-client/examples/semantic-cache.server')
-      const patterns = await semanticCacheAgent.createPatterns() as Pattern[]
+      const patterns = await semanticCacheAgent.createPatterns('test-session') as Pattern[]
       const cachePattern = patterns.find(p => p.config.patternId === 'semantic-cache')
 
       // Mock cache miss from json_get but hit from vector search
@@ -600,7 +620,7 @@ describe('Semantic Cache Patterns', () => {
   describe('conditionalRetrieval pattern', () => {
     it('should skip retrieval on cache hit', async () => {
       const { semanticCacheAgent } = await import('../../../../lib/harness-client/examples/semantic-cache.server')
-      const patterns = await semanticCacheAgent.createPatterns() as Pattern[]
+      const patterns = await semanticCacheAgent.createPatterns('test-session') as Pattern[]
       const conditionalPattern = patterns.find(p => p.config.patternId === 'conditional-retrieval')
 
       expect(conditionalPattern).toBeDefined()
@@ -617,7 +637,7 @@ describe('Semantic Cache Patterns', () => {
   describe('cacheWriter pattern', () => {
     it('should skip writing on cache hit', async () => {
       const { semanticCacheAgent } = await import('../../../../lib/harness-client/examples/semantic-cache.server')
-      const patterns = await semanticCacheAgent.createPatterns() as Pattern[]
+      const patterns = await semanticCacheAgent.createPatterns('test-session') as Pattern[]
       const writerPattern = patterns.find(p => p.config.patternId === 'cache-writer')
 
       expect(writerPattern).toBeDefined()
@@ -632,7 +652,7 @@ describe('Semantic Cache Patterns', () => {
 
     it('should write to cache on cache miss', async () => {
       const { semanticCacheAgent } = await import('../../../../lib/harness-client/examples/semantic-cache.server')
-      const patterns = await semanticCacheAgent.createPatterns() as Pattern[]
+      const patterns = await semanticCacheAgent.createPatterns('test-session') as Pattern[]
       const writerPattern = patterns.find(p => p.config.patternId === 'cache-writer')
 
       const scope = createMockScope({ cacheHit: false, input: 'test query' })
@@ -646,7 +666,7 @@ describe('Semantic Cache Patterns', () => {
 
     it('should handle cache write errors gracefully', async () => {
       const { semanticCacheAgent } = await import('../../../../lib/harness-client/examples/semantic-cache.server')
-      const patterns = await semanticCacheAgent.createPatterns() as Pattern[]
+      const patterns = await semanticCacheAgent.createPatterns('test-session') as Pattern[]
       const writerPattern = patterns.find(p => p.config.patternId === 'cache-writer')
 
       // Mock the cache write to fail
@@ -678,7 +698,7 @@ describe('Ontology Builder Patterns', () => {
   describe('ontology patterns', () => {
     it('should create scoping pattern', async () => {
       const { ontologyBuilderAgent } = await import('../../../../lib/harness-client/examples/ontology-builder.server')
-      const patterns = await ontologyBuilderAgent.createPatterns() as Pattern[]
+      const patterns = await ontologyBuilderAgent.createPatterns('test-session') as Pattern[]
 
       const scopingPattern = patterns.find(p => p.config.patternId === 'ontology-scope')
       expect(scopingPattern).toBeDefined()
@@ -686,7 +706,7 @@ describe('Ontology Builder Patterns', () => {
 
     it('should create research parallel pattern', async () => {
       const { ontologyBuilderAgent } = await import('../../../../lib/harness-client/examples/ontology-builder.server')
-      const patterns = await ontologyBuilderAgent.createPatterns() as Pattern[]
+      const patterns = await ontologyBuilderAgent.createPatterns('test-session') as Pattern[]
 
       const researchPattern = patterns.find(p => p.config.patternId === 'onto-research')
       expect(researchPattern).toBeDefined()
@@ -695,7 +715,7 @@ describe('Ontology Builder Patterns', () => {
 
     it('should create guardrailed proposal pattern', async () => {
       const { ontologyBuilderAgent } = await import('../../../../lib/harness-client/examples/ontology-builder.server')
-      const patterns = await ontologyBuilderAgent.createPatterns() as Pattern[]
+      const patterns = await ontologyBuilderAgent.createPatterns('test-session') as Pattern[]
 
       const validatedPattern = patterns.find(p => p.config.patternId === 'ontology-validated')
       expect(validatedPattern).toBeDefined()
@@ -704,7 +724,7 @@ describe('Ontology Builder Patterns', () => {
 
     it('should create judge pattern for ontology evaluation', async () => {
       const { ontologyBuilderAgent } = await import('../../../../lib/harness-client/examples/ontology-builder.server')
-      const patterns = await ontologyBuilderAgent.createPatterns() as Pattern[]
+      const patterns = await ontologyBuilderAgent.createPatterns('test-session') as Pattern[]
 
       const judgePattern = patterns.find(p => p.config.patternId === 'ontology-judge')
       expect(judgePattern).toBeDefined()
@@ -712,7 +732,7 @@ describe('Ontology Builder Patterns', () => {
 
     it('should create commit pattern with approval', async () => {
       const { ontologyBuilderAgent } = await import('../../../../lib/harness-client/examples/ontology-builder.server')
-      const patterns = await ontologyBuilderAgent.createPatterns() as Pattern[]
+      const patterns = await ontologyBuilderAgent.createPatterns('test-session') as Pattern[]
 
       const hasApproval = patterns.some(p => p.name === 'withApproval')
       expect(hasApproval).toBe(true)
@@ -736,7 +756,7 @@ describe('Guardrailed Agent Rails', () => {
   describe('topicalRail', () => {
     it('should have safe file edit pattern with guardrails', async () => {
       const { guardrailedAgent } = await import('../../../../lib/harness-client/examples/guardrailed-agent.server')
-      const patterns = await guardrailedAgent.createPatterns() as Pattern[]
+      const patterns = await guardrailedAgent.createPatterns('test-session') as Pattern[]
 
       const safePattern = patterns.find(p => p.config.patternId === 'safe-file-edit')
       expect(safePattern).toBeDefined()
@@ -753,6 +773,7 @@ describe('Agent Consistency', () => {
   it('all agents should have unique IDs', async () => {
     // Import all agents statically
     const { defaultAgent } = await import('../../../../lib/harness-client/examples/default.server')
+    const { codeModeAgent } = await import('../../../../lib/harness-client/examples/code-mode.server')
     const { conversationalMemoryAgent } = await import('../../../../lib/harness-client/examples/conversational-memory.server')
     const { docAssistantAgent } = await import('../../../../lib/harness-client/examples/doc-assistant.server')
     const { guardrailedAgent } = await import('../../../../lib/harness-client/examples/guardrailed-agent.server')
@@ -765,6 +786,7 @@ describe('Agent Consistency', () => {
 
     const ids = [
       defaultAgent.id,
+      codeModeAgent.id,
       conversationalMemoryAgent.id,
       docAssistantAgent.id,
       guardrailedAgent.id,
@@ -806,7 +828,7 @@ describe('Agent Consistency', () => {
     ]
 
     for (const config of agents) {
-      const patterns = await config.createPatterns() as Pattern[]
+      const patterns = await config.createPatterns('test-session') as Pattern[]
       // All agents should contain a synthesizer pattern somewhere in the chain
       const hasSynthesizer = patterns.some(p => p.name === 'synthesizer')
       expect(hasSynthesizer).toBe(true)

--- a/ui/src/__tests__/lib/harness-client/examples/evaluators.test.ts
+++ b/ui/src/__tests__/lib/harness-client/examples/evaluators.test.ts
@@ -135,7 +135,7 @@ describe('LLM Judge qualityJudgeEvaluator', () => {
 
       // Import and access the judge pattern
       const { llmJudgeAgent } = await import('../../../../lib/harness-client/examples/llm-judge.server')
-      const patterns = await llmJudgeAgent.createPatterns()
+      const patterns = await llmJudgeAgent.createPatterns('test-session')
 
       // The judge pattern exists
       const judgePattern = patterns.find(p => (p as { config: { patternId?: string } }).config.patternId === 'quality-judge')
@@ -150,7 +150,7 @@ describe('LLM Judge qualityJudgeEvaluator', () => {
       ]
 
       const { llmJudgeAgent } = await import('../../../../lib/harness-client/examples/llm-judge.server')
-      const patterns = await llmJudgeAgent.createPatterns()
+      const patterns = await llmJudgeAgent.createPatterns('test-session')
       expect(patterns.length).toBe(3)
     })
   })
@@ -159,7 +159,7 @@ describe('LLM Judge qualityJudgeEvaluator', () => {
     it('should score higher when query terms are in content', async () => {
       // Testing that the judge pattern is properly configured
       const { llmJudgeAgent } = await import('../../../../lib/harness-client/examples/llm-judge.server')
-      const patterns = await llmJudgeAgent.createPatterns()
+      const patterns = await llmJudgeAgent.createPatterns('test-session')
 
       const judgePattern = patterns.find(p => (p as { config: { patternId?: string } }).config.patternId === 'quality-judge')
       expect(judgePattern).toBeDefined()
@@ -171,7 +171,7 @@ describe('LLM Judge qualityJudgeEvaluator', () => {
   describe('source authority scoring', () => {
     it('should give highest bonus for doc-lookup source', async () => {
       const { llmJudgeAgent } = await import('../../../../lib/harness-client/examples/llm-judge.server')
-      const patterns = await llmJudgeAgent.createPatterns()
+      const patterns = await llmJudgeAgent.createPatterns('test-session')
 
       // Verify all three source patterns exist in parallel
       const parallelPattern = patterns.find(p =>
@@ -210,7 +210,7 @@ describe('Multi-Source Research judgeEvaluator', () => {
 
   it('should create parallel research with three sources', async () => {
     const { multiSourceResearchAgent } = await import('../../../../lib/harness-client/examples/multi-source-research.server')
-    const patterns = await multiSourceResearchAgent.createPatterns()
+    const patterns = await multiSourceResearchAgent.createPatterns('test-session')
 
     const parallelPattern = patterns.find(p =>
       (p as { config: { patternId?: string } }).config.patternId === 'parallel-research'
@@ -220,7 +220,7 @@ describe('Multi-Source Research judgeEvaluator', () => {
 
   it('should use quality judge for ranking', async () => {
     const { multiSourceResearchAgent } = await import('../../../../lib/harness-client/examples/multi-source-research.server')
-    const patterns = await multiSourceResearchAgent.createPatterns()
+    const patterns = await multiSourceResearchAgent.createPatterns('test-session')
 
     const judgePattern = patterns.find(p =>
       (p as { config: { patternId?: string } }).config.patternId === 'quality-judge'
@@ -230,7 +230,7 @@ describe('Multi-Source Research judgeEvaluator', () => {
 
   it('should have synthesizer for final response', async () => {
     const { multiSourceResearchAgent } = await import('../../../../lib/harness-client/examples/multi-source-research.server')
-    const patterns = await multiSourceResearchAgent.createPatterns()
+    const patterns = await multiSourceResearchAgent.createPatterns('test-session')
 
     const synthPattern = patterns.find(p =>
       (p as { config: { patternId?: string } }).config.patternId === 'research-synth'
@@ -255,7 +255,7 @@ describe('Ontology Builder ontologyJudge', () => {
 
   it('should create judge pattern for ontology evaluation', async () => {
     const { ontologyBuilderAgent } = await import('../../../../lib/harness-client/examples/ontology-builder.server')
-    const patterns = await ontologyBuilderAgent.createPatterns()
+    const patterns = await ontologyBuilderAgent.createPatterns('test-session')
 
     const judgePattern = patterns.find(p =>
       (p as { config: { patternId?: string } }).config.patternId === 'ontology-judge'
@@ -265,7 +265,7 @@ describe('Ontology Builder ontologyJudge', () => {
 
   it('should include naming convention rail in guardrail', async () => {
     const { ontologyBuilderAgent } = await import('../../../../lib/harness-client/examples/ontology-builder.server')
-    const patterns = await ontologyBuilderAgent.createPatterns()
+    const patterns = await ontologyBuilderAgent.createPatterns('test-session')
 
     const guardrailPattern = patterns.find(p =>
       (p as { config: { patternId?: string } }).config.patternId === 'ontology-validated'
@@ -276,7 +276,7 @@ describe('Ontology Builder ontologyJudge', () => {
 
   it('should include no-orphans rail in guardrail', async () => {
     const { ontologyBuilderAgent } = await import('../../../../lib/harness-client/examples/ontology-builder.server')
-    const patterns = await ontologyBuilderAgent.createPatterns()
+    const patterns = await ontologyBuilderAgent.createPatterns('test-session')
 
     // Both rails are included in the guardrail
     const guardrailPattern = patterns.find(p =>
@@ -287,7 +287,7 @@ describe('Ontology Builder ontologyJudge', () => {
 
   it('should have all phases: scoping, research, proposal, judge, commit, suggestions', async () => {
     const { ontologyBuilderAgent } = await import('../../../../lib/harness-client/examples/ontology-builder.server')
-    const patterns = await ontologyBuilderAgent.createPatterns()
+    const patterns = await ontologyBuilderAgent.createPatterns('test-session')
 
     // Check for each phase pattern
     const patternIds = patterns.map(p => (p as { config: { patternId?: string } }).config.patternId)
@@ -325,7 +325,7 @@ describe('Guardrailed Agent Rails', () => {
   describe('topicalRail', () => {
     it('should be configured with off-topic patterns', async () => {
       const { guardrailedAgent } = await import('../../../../lib/harness-client/examples/guardrailed-agent.server')
-      const patterns = await guardrailedAgent.createPatterns()
+      const patterns = await guardrailedAgent.createPatterns('test-session')
 
       const guardrailPattern = patterns.find(p =>
         (p as { config: { patternId?: string } }).config.patternId === 'safe-file-edit'
@@ -337,7 +337,7 @@ describe('Guardrailed Agent Rails', () => {
   describe('toolScopeRail', () => {
     it('should be included in guardrail with allowed filesystem tools', async () => {
       const { guardrailedAgent } = await import('../../../../lib/harness-client/examples/guardrailed-agent.server')
-      const patterns = await guardrailedAgent.createPatterns()
+      const patterns = await guardrailedAgent.createPatterns('test-session')
 
       const guardrailPattern = patterns.find(p =>
         (p as { config: { patternId?: string } }).config.patternId === 'safe-file-edit'
@@ -371,7 +371,7 @@ describe('Conversational Memory Distillation Hook', () => {
 
   it('should have session-close-hook pattern', async () => {
     const { conversationalMemoryAgent } = await import('../../../../lib/harness-client/examples/conversational-memory.server')
-    const patterns = await conversationalMemoryAgent.createPatterns()
+    const patterns = await conversationalMemoryAgent.createPatterns('test-session')
 
     const hookPattern = patterns.find(p =>
       (p as { config: { patternId?: string } }).config.patternId === 'session-close-hook'
@@ -383,7 +383,7 @@ describe('Conversational Memory Distillation Hook', () => {
 
   it('should have distill-chain configured as background task', async () => {
     const { conversationalMemoryAgent } = await import('../../../../lib/harness-client/examples/conversational-memory.server')
-    const patterns = await conversationalMemoryAgent.createPatterns()
+    const patterns = await conversationalMemoryAgent.createPatterns('test-session')
 
     // Hook exists with distill-chain
     const hookPattern = patterns.find(p =>
@@ -414,7 +414,7 @@ describe('Issue Triage Agent', () => {
 
   it('should create router pattern for GitHub routes', async () => {
     const { issueTriageAgent } = await import('../../../../lib/harness-client/examples/issue-triage.server')
-    const patterns = await issueTriageAgent.createPatterns()
+    const patterns = await issueTriageAgent.createPatterns('test-session')
 
     const routerPattern = patterns.find(p =>
       (p as { name: string }).name === 'router'
@@ -443,7 +443,7 @@ describe('KG Builder Agent', () => {
 
   it('should have web research pattern', async () => {
     const { kgBuilderAgent } = await import('../../../../lib/harness-client/examples/kg-builder.server')
-    const patterns = await kgBuilderAgent.createPatterns()
+    const patterns = await kgBuilderAgent.createPatterns('test-session')
 
     const webPattern = patterns.find(p =>
       (p as { config: { patternId?: string } }).config.patternId === 'web-research'
@@ -453,7 +453,7 @@ describe('KG Builder Agent', () => {
 
   it('should have memory extract pattern', async () => {
     const { kgBuilderAgent } = await import('../../../../lib/harness-client/examples/kg-builder.server')
-    const patterns = await kgBuilderAgent.createPatterns()
+    const patterns = await kgBuilderAgent.createPatterns('test-session')
 
     const memoryPattern = patterns.find(p =>
       (p as { config: { patternId?: string } }).config.patternId === 'memory-extract'
@@ -463,7 +463,7 @@ describe('KG Builder Agent', () => {
 
   it('should have neo4j persist with approval', async () => {
     const { kgBuilderAgent } = await import('../../../../lib/harness-client/examples/kg-builder.server')
-    const patterns = await kgBuilderAgent.createPatterns()
+    const patterns = await kgBuilderAgent.createPatterns('test-session')
 
     const approvalPattern = patterns.find(p =>
       (p as { name: string }).name === 'withApproval'

--- a/ui/src/__tests__/lib/harness-patterns/baml-adapters.test.ts
+++ b/ui/src/__tests__/lib/harness-patterns/baml-adapters.test.ts
@@ -4,9 +4,22 @@
  * Tests for controller and critic adapters that bridge patterns with BAML.
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, beforeAll, afterAll } from 'vitest'
 import { mockAction, mockFinalAction, mockCriticResult } from '../../mocks/baml'
 import { mockListTools } from '../../mocks/mcp'
+
+// These tests target the production mixed-provider fallback chain in
+// `baml_src/clients.baml` (RouterFallback / ControllerFallback / etc.) and
+// assert behavior like "fall back to GroqGPT120B on BamlValidationError".
+// The runtime default is Anthropic-only routing (see `clients.server.ts`),
+// which short-circuits the manual Groq fallback — so the tests must opt
+// back into the mixed chain explicitly.
+beforeAll(() => {
+  process.env.USE_MIXED_CHAINS = '1'
+})
+afterAll(() => {
+  delete process.env.USE_MIXED_CHAINS
+})
 
 // Mock server-only imports
 vi.mock('../../../lib/harness-patterns/assert.server', () => ({
@@ -556,11 +569,14 @@ describe('describeToolResultOp', () => {
     const result = await describeToolResultOp('read_neo4j_cypher', '{"query":"MATCH (n) RETURN n"}', 'Need to list nodes', '[{name:"A"},{name:"B"},{name:"C"}]')
 
     expect(result).toBe('Found 3 nodes in the graph.')
+    // 5th arg is the BAML options override (`{ client: 'DescribeFallback' }`)
+    // added under USE_MIXED_CHAINS=1 — see `clientOverrideFor`.
     expect(mockResultDescribe).toHaveBeenCalledWith(
       'read_neo4j_cypher',
       '{"query":"MATCH (n) RETURN n"}',
       'Need to list nodes',
-      '[{name:"A"},{name:"B"},{name:"C"}]'
+      '[{name:"A"},{name:"B"},{name:"C"}]',
+      expect.objectContaining({ client: 'DescribeFallback' })
     )
   })
 

--- a/ui/src/__tests__/lib/harness-patterns/tools.test.ts
+++ b/ui/src/__tests__/lib/harness-patterns/tools.test.ts
@@ -144,6 +144,16 @@ describe('tools', () => {
         expect(tools.redis).toContain('vector_search_hash')
       })
 
+      it('should group code-mode under code namespace', async () => {
+        const { ToolsFrom } = await import('../../../lib/harness-patterns/tools.server')
+
+        const tools = ToolsFrom([
+          { name: 'code-mode', description: 'JS executor', inputSchema: {} },
+        ])
+
+        expect(tools.code).toEqual(['code-mode'])
+      })
+
       it('should group filesystem tools under filesystem namespace', async () => {
         const { ToolsFrom } = await import('../../../lib/harness-patterns/tools.server')
 

--- a/ui/src/components/ark-ui/SupportPanel.tsx
+++ b/ui/src/components/ark-ui/SupportPanel.tsx
@@ -283,7 +283,7 @@ export const SupportPanel = (props: SupportPanelProps) => {
 
           {/* Tools Tab */}
           <Tabs.Content value="tools" h="full">
-            <ToolsPanel />
+            <ToolsPanel sessionId={props.sessionId} />
           </Tabs.Content>
 
           {/* Actions Tab (Future) */}

--- a/ui/src/components/ark-ui/ToolsPanel.tsx
+++ b/ui/src/components/ark-ui/ToolsPanel.tsx
@@ -1,81 +1,85 @@
 /**
  * Tools Panel Component
  *
- * Interface for managing tool configuration:
- * - Execution mode toggle (Static / Code)
- * - Catalog mode toggle (Minimal / Global)
- * - Individual tool selection checkboxes
+ * Per-conversation tool allowlist for the code-mode agent. Reads/writes the
+ * `data.codeModeAllowedTools` field on the conversation's serialized context
+ * (Postgres JSONB) via `getCodeModeAllowedTools` / `setCodeModeAllowedTools`.
+ * The code-mode agent's `toolNamesProvider` reads the same field live per
+ * actor invocation, so checkbox edits take effect on the next turn without
+ * a pattern rebuild.
+ *
+ * The Execution Mode / Catalog Mode switches are reserved for future planner
+ * + catalog hot-swap work — disabled in this revision.
  */
 
 import { Switch } from '@ark-ui/solid/switch';
 import { Checkbox } from '@ark-ui/solid/checkbox';
 import { createSignal, createResource, For, Show } from 'solid-js';
 import {
-  getToolConfig,
-  setExecutionMode,
-  setCatalogMode,
-  toggleTool,
-  getAvailableTools,
-  MINIMAL_TOOLS,
+  getCodeModeAllowedTools,
+  setCodeModeAllowedTools,
   fetchCodedTools,
-  type ExecutionMode,
-  type CatalogMode,
-  type CodedTool
+  MINIMAL_TOOLS,
+  type CodedTool,
 } from '~/lib/tool-config';
 
 // ============================================================================
 // Component
 // ============================================================================
 
-export const ToolsPanel = () => {
-  // Local state (mirrors server state)
-  const [executionMode, setExecutionModeLocal] = createSignal<ExecutionMode>('static');
-  const [catalogMode, setCatalogModeLocal] = createSignal<CatalogMode>('minimal');
-  const [selectedTools, setSelectedToolsLocal] = createSignal<string[]>([...MINIMAL_TOOLS]);
-  const [isLoading, setIsLoading] = createSignal(false);
+interface ToolsPanelProps {
+  /** Active conversation id. Required for the per-conversation allowlist;
+   *  when undefined the panel renders an empty state. */
+  sessionId?: string;
+}
 
-  // Fetch initial config (resource used for side effects)
-  const [_config] = createResource(async () => {
-    const cfg = await getToolConfig();
-    setExecutionModeLocal(cfg.executionMode);
-    setCatalogModeLocal(cfg.catalogMode);
-    setSelectedToolsLocal(cfg.selectedTools);
-    return cfg;
-  });
+export const ToolsPanel = (props: ToolsPanelProps) => {
+  const [isSaving, setIsSaving] = createSignal(false);
+  const [saveError, setSaveError] = createSignal<string | null>(null);
 
-  // Fetch available tools based on catalog mode
-  const [availableTools] = createResource(catalogMode, getAvailableTools);
+  // Single round-trip: returns allowed + available + meta-tool defaults.
+  // Re-fetches when sessionId changes (selecting a different chat).
+  const [state, { refetch }] = createResource(
+    () => props.sessionId,
+    async (sid) => {
+      if (!sid) return null;
+      try {
+        return await getCodeModeAllowedTools(sid);
+      } catch (err) {
+        console.error('[ToolsPanel] load failed:', err);
+        return null;
+      }
+    },
+  );
 
-  // Fetch coded tools from Neo4j repository
   const [codedTools, { refetch: refetchCodedTools }] = createResource(fetchCodedTools);
 
-  // Handle execution mode toggle
-  const handleExecutionModeChange = async (checked: boolean) => {
-    setIsLoading(true);
-    const mode: ExecutionMode = checked ? 'code' : 'static';
-    setExecutionModeLocal(mode);
-    await setExecutionMode(mode);
-    setIsLoading(false);
+  /** Compute the next allowlist for a click on `tool` and persist it. Meta-
+   *  tools (defaults) are locked-on — clicking them is a no-op. */
+  const handleToolToggle = async (tool: string) => {
+    const sid = props.sessionId;
+    const s = state();
+    if (!sid || !s) return;
+    if (s.defaults.includes(tool)) return; // locked
+
+    const isSelected = s.allowed.includes(tool);
+    const next = isSelected ? s.allowed.filter((t) => t !== tool) : [...s.allowed, tool];
+
+    setIsSaving(true);
+    setSaveError(null);
+    try {
+      await setCodeModeAllowedTools(sid, next);
+      await refetch();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      setSaveError(msg);
+    } finally {
+      setIsSaving(false);
+    }
   };
 
-  // Handle catalog mode toggle
-  const handleCatalogModeChange = async (checked: boolean) => {
-    setIsLoading(true);
-    const mode: CatalogMode = checked ? 'global' : 'minimal';
-    setCatalogModeLocal(mode);
-    const updated = await setCatalogMode(mode);
-    setSelectedToolsLocal(updated.selectedTools);
-    setIsLoading(false);
-  };
-
-  // Handle individual tool toggle
-  const handleToolToggle = async (toolName: string) => {
-    const updated = await toggleTool(toolName);
-    setSelectedToolsLocal(updated.selectedTools);
-  };
-
-  // Check if tool is selected
-  const isToolSelected = (toolName: string) => selectedTools().includes(toolName);
+  const isSelected = (tool: string) => state()?.allowed.includes(tool) ?? false;
+  const isLocked = (tool: string) => state()?.defaults.includes(tool) ?? false;
 
   return (
     <div flex="~ col" h="full" bg="dark-bg-primary" overflow="auto">
@@ -83,242 +87,200 @@ export const ToolsPanel = () => {
       <div p="4" border="b dark-border-primary">
         <h2 text="lg dark-text-primary" font="semibold">Tool Configuration</h2>
         <p text="sm dark-text-tertiary" m="t-1">
-          Configure execution mode, catalog, and available tools
+          Pick which MCP tools the code-mode agent can call in this conversation
         </p>
       </div>
 
-      {/* Loading indicator */}
-      <Show when={isLoading()}>
-        <div p="2" bg="dark-bg-secondary" text="xs dark-text-secondary" text-align="center">
-          Updating configuration...
+      {/* No session — empty state */}
+      <Show when={!props.sessionId}>
+        <div p="6" text="center" flex="~ col 1" justify="center" items="center">
+          <div text="sm dark-text-secondary">Start a conversation to configure tools.</div>
+          <div text="xs dark-text-tertiary" m="t-1">
+            The allowlist is saved per chat thread.
+          </div>
         </div>
       </Show>
 
-      {/* Mode Switches */}
-      <div p="4" border="b dark-border-primary" flex="~ col" gap="4">
-        {/* Execution Mode Switch */}
-        <div flex="~" items="center" justify="between">
-          <div>
-            <div text="sm dark-text-primary" font="medium">Execution Mode</div>
-            <div text="xs dark-text-tertiary" m="t-0.5">
-              {executionMode() === 'static'
-                ? 'Static: Uses namespace-specific planners'
-                : 'Code: Uses tool composition planner with repository'}
-            </div>
+      <Show when={props.sessionId}>
+        {/* Saving indicator + error toast */}
+        <Show when={isSaving()}>
+          <div p="2" bg="dark-bg-secondary" text="xs dark-text-secondary" text-align="center">
+            Saving...
           </div>
-          <Switch.Root
-            checked={executionMode() === 'code'}
-            onCheckedChange={(details) => handleExecutionModeChange(details.checked)}
-          >
-            <Switch.Control
-              w="14"
-              h="7"
-              bg={executionMode() === 'code' ? 'neon-cyan' : 'dark-bg-tertiary'}
-              rounded="full"
-              p="1"
-              cursor="pointer"
-              transition="all"
-              border="1 dark-border-primary"
-              flex="~"
-              items="center"
-            >
-              <Switch.Thumb
-                w="5"
-                h="5"
-                bg="dark-text-primary"
-                rounded="full"
-                transition="transform 200ms"
-                style={{
-                  transform: executionMode() === 'code' ? 'translateX(1.75rem)' : 'translateX(0)'
-                }}
-              />
-            </Switch.Control>
-            <Switch.HiddenInput />
-          </Switch.Root>
-        </div>
-
-        {/* Catalog Mode Switch */}
-        <div flex="~" items="center" justify="between">
-          <div>
-            <div text="sm dark-text-primary" font="medium">Catalog Mode</div>
-            <div text="xs dark-text-tertiary" m="t-0.5">
-              {catalogMode() === 'minimal'
-                ? 'Minimal: Neo4j + Web Search only'
-                : 'Global: All 50+ MCP servers'}
-            </div>
+        </Show>
+        <Show when={saveError()}>
+          <div p="2" bg="red-900/30" border="b red-700" text="xs" style={{ color: '#fca5a5' }}>
+            Save failed: {saveError()}
           </div>
-          <Switch.Root
-            checked={catalogMode() === 'global'}
-            onCheckedChange={(details) => handleCatalogModeChange(details.checked)}
-          >
-            <Switch.Control
-              w="14"
-              h="7"
-              bg={catalogMode() === 'global' ? 'neon-purple' : 'dark-bg-tertiary'}
-              rounded="full"
-              p="1"
-              cursor="pointer"
-              transition="all"
-              border="1 dark-border-primary"
-              flex="~"
-              items="center"
-            >
-              <Switch.Thumb
-                w="5"
-                h="5"
-                bg="dark-text-primary"
-                rounded="full"
-                transition="transform 200ms"
-                style={{
-                  transform: catalogMode() === 'global' ? 'translateX(1.75rem)' : 'translateX(0)'
-                }}
-              />
-            </Switch.Control>
-            <Switch.HiddenInput />
-          </Switch.Root>
-        </div>
-      </div>
-
-      {/* Available Tools Section */}
-      <div p="4" border="b dark-border-primary" flex="~ col" overflow="hidden" style={{ "max-height": "40vh" }}>
-        <div flex="~" items="center" justify="between" m="b-3" flex-shrink="0">
-          <h3 text="sm dark-text-primary" font="medium">Available Tools</h3>
-          <span text="xs dark-text-tertiary">
-            {selectedTools().length} of {availableTools()?.length || 0} selected
-          </span>
-        </div>
-
-        <Show when={availableTools.loading}>
-          <div text="xs dark-text-tertiary">Loading tools...</div>
         </Show>
 
-        <Show when={!availableTools.loading && availableTools()}>
-          <div flex="~ col 1" gap="2" overflow="auto" p="r-1">
-            <For each={availableTools()}>
-              {(tool) => (
-                <div
-                  flex="~"
-                  items="center"
-                  gap="3"
-                  p="2"
-                  bg="dark-bg-secondary hover:dark-bg-tertiary"
-                  rounded="md"
-                  cursor="pointer"
-                  transition="all"
-                  flex-shrink="0"
-                  onClick={(e) => {
-                    // Only toggle if not clicking the checkbox directly
-                    if (!(e.target as HTMLElement).closest('[data-scope="checkbox"]')) {
-                      handleToolToggle(tool);
-                    }
-                  }}
-                >
-                  <Checkbox.Root
-                    checked={isToolSelected(tool)}
-                    onCheckedChange={(_details) => {
-                      // Prevent propagation handled via onClick guard above
-                      handleToolToggle(tool);
+        {/* Mode Switches — reserved for future planner work */}
+        <div p="4" border="b dark-border-primary" flex="~ col" gap="4" opacity="60">
+          <div flex="~" items="center" justify="between">
+            <div>
+              <div text="sm dark-text-primary" font="medium">Execution Mode</div>
+              <div text="xs dark-text-tertiary" m="t-0.5">
+                Static (namespace planners) — code mode toggle coming soon
+              </div>
+            </div>
+            <Switch.Root checked={false} disabled>
+              <Switch.Control
+                w="14" h="7" bg="dark-bg-tertiary" rounded="full" p="1"
+                border="1 dark-border-primary" flex="~" items="center"
+                style={{ cursor: 'not-allowed' }}
+              >
+                <Switch.Thumb w="5" h="5" bg="dark-text-tertiary" rounded="full" />
+              </Switch.Control>
+              <Switch.HiddenInput />
+            </Switch.Root>
+          </div>
+
+          <div flex="~" items="center" justify="between">
+            <div>
+              <div text="sm dark-text-primary" font="medium">Catalog Mode</div>
+              <div text="xs dark-text-tertiary" m="t-0.5">
+                Gateway eagerly loads all catalog servers — hot-swap UI coming soon
+              </div>
+            </div>
+            <Switch.Root checked={false} disabled>
+              <Switch.Control
+                w="14" h="7" bg="dark-bg-tertiary" rounded="full" p="1"
+                border="1 dark-border-primary" flex="~" items="center"
+                style={{ cursor: 'not-allowed' }}
+              >
+                <Switch.Thumb w="5" h="5" bg="dark-text-tertiary" rounded="full" />
+              </Switch.Control>
+              <Switch.HiddenInput />
+            </Switch.Root>
+          </div>
+        </div>
+
+        {/* Available Tools Section */}
+        <div p="4" border="b dark-border-primary" flex="~ col" overflow="hidden" style={{ "max-height": "40vh" }}>
+          <div flex="~" items="center" justify="between" m="b-3" flex-shrink="0">
+            <h3 text="sm dark-text-primary" font="medium">Available Tools</h3>
+            <span text="xs dark-text-tertiary">
+              {state()?.allowed.length ?? 0} of {state()?.available.length ?? 0} selected
+            </span>
+          </div>
+
+          <Show when={state.loading}>
+            <div text="xs dark-text-tertiary">Loading tools...</div>
+          </Show>
+
+          <Show when={!state.loading && state()}>
+            <div flex="~ col 1" gap="2" overflow="auto" p="r-1">
+              <For each={state()!.available}>
+                {(tool) => (
+                  <div
+                    flex="~" items="center" gap="3" p="2"
+                    bg="dark-bg-secondary hover:dark-bg-tertiary"
+                    rounded="md"
+                    cursor={isLocked(tool) ? 'not-allowed' : 'pointer'}
+                    transition="all" flex-shrink="0"
+                    onClick={(e) => {
+                      if (isLocked(tool)) return;
+                      if (!(e.target as HTMLElement).closest('[data-scope="checkbox"]')) {
+                        handleToolToggle(tool);
+                      }
                     }}
                   >
-                    <Checkbox.Control
-                      w="4"
-                      h="4"
-                      border="1 dark-border-primary"
-                      rounded="sm"
-                      bg={isToolSelected(tool) ? 'neon-cyan' : 'transparent'}
-                      flex="~"
-                      items="center"
-                      justify="center"
+                    <Checkbox.Root
+                      checked={isSelected(tool)}
+                      disabled={isLocked(tool)}
+                      onCheckedChange={() => handleToolToggle(tool)}
                     >
-                      <Show when={isToolSelected(tool)}>
-                        <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
-                          <path
-                            d="M2 6L5 9L10 3"
-                            stroke="currentColor"
-                            stroke-width="2"
-                            stroke-linecap="round"
-                            stroke-linejoin="round"
-                            style={{ color: '#0d1117' }}
-                          />
-                        </svg>
-                      </Show>
-                    </Checkbox.Control>
-                    <Checkbox.HiddenInput />
-                  </Checkbox.Root>
+                      <Checkbox.Control
+                        w="4" h="4" border="1 dark-border-primary" rounded="sm"
+                        bg={isSelected(tool) ? 'neon-cyan' : 'transparent'}
+                        flex="~" items="center" justify="center"
+                      >
+                        <Show when={isSelected(tool)}>
+                          <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+                            <path
+                              d="M2 6L5 9L10 3"
+                              stroke="currentColor" stroke-width="2"
+                              stroke-linecap="round" stroke-linejoin="round"
+                              style={{ color: '#0d1117' }}
+                            />
+                          </svg>
+                        </Show>
+                      </Checkbox.Control>
+                      <Checkbox.HiddenInput />
+                    </Checkbox.Root>
 
-                  <div flex="1">
-                    <div text="sm dark-text-primary">{tool}</div>
-                    <div text="xs dark-text-tertiary">
-                      {getToolDescription(tool)}
+                    <div flex="1">
+                      <div text="sm dark-text-primary">{tool}</div>
+                      <div text="xs dark-text-tertiary">
+                        {getToolDescription(tool)}
+                      </div>
                     </div>
+
+                    <Show when={isLocked(tool)}>
+                      <span
+                        text="xs" p="x-1.5 y-0.5"
+                        bg="neon-magenta/10" border="1 neon-magenta/30" rounded="full"
+                        style={{ color: '#ff66ff' }}
+                      >
+                        Required
+                      </span>
+                    </Show>
+                    <Show when={!isLocked(tool) && MINIMAL_TOOLS.includes(tool)}>
+                      <span
+                        text="xs" p="x-1.5 y-0.5"
+                        bg="neon-cyan/10" border="1 neon-cyan/30" rounded="full"
+                        style={{ color: '#00ffff' }}
+                      >
+                        Core
+                      </span>
+                    </Show>
                   </div>
-
-                  {/* Indicator for minimal tools */}
-                  <Show when={MINIMAL_TOOLS.includes(tool)}>
-                    <span
-                      text="xs"
-                      p="x-1.5 y-0.5"
-                      bg="neon-cyan/10"
-                      border="1 neon-cyan/30"
-                      rounded="full"
-                      style={{ color: '#00ffff' }}
-                    >
-                      Core
-                    </span>
-                  </Show>
-                </div>
-              )}
-            </For>
-          </div>
-        </Show>
-      </div>
-
-      {/* Coded Tools Repository Section */}
-      <div p="4">
-        <div flex="~" items="center" justify="between" m="b-3">
-          <h3 text="sm dark-text-primary" font="medium">Coded Tools Repository</h3>
-          <button
-            onClick={() => refetchCodedTools()}
-            p="x-2 y-1"
-            text="xs dark-text-secondary hover:dark-text-primary"
-            bg="dark-bg-secondary hover:dark-bg-tertiary"
-            border="1 dark-border-primary"
-            rounded="md"
-            cursor="pointer"
-            transition="all"
-          >
-            Refresh
-          </button>
+                )}
+              </For>
+            </div>
+          </Show>
         </div>
 
-        <Show when={codedTools.loading}>
-          <div text="xs dark-text-tertiary">Loading coded tools...</div>
-        </Show>
+        {/* Coded Tools Repository Section */}
+        <div p="4">
+          <div flex="~" items="center" justify="between" m="b-3">
+            <h3 text="sm dark-text-primary" font="medium">Coded Tools Repository</h3>
+            <button
+              onClick={() => refetchCodedTools()}
+              p="x-2 y-1"
+              text="xs dark-text-secondary hover:dark-text-primary"
+              bg="dark-bg-secondary hover:dark-bg-tertiary"
+              border="1 dark-border-primary"
+              rounded="md"
+              cursor="pointer"
+              transition="all"
+            >
+              Refresh
+            </button>
+          </div>
 
-        <Show when={!codedTools.loading && codedTools()?.length === 0}>
-          <div
-            p="4"
-            bg="dark-bg-secondary"
-            rounded="md"
-            text="center"
-          >
-            <div text="sm dark-text-secondary">No coded tools yet</div>
-            <div text="xs dark-text-tertiary" m="t-1">
-              Tools will appear here as they are created and saved during code mode execution
+          <Show when={codedTools.loading}>
+            <div text="xs dark-text-tertiary">Loading coded tools...</div>
+          </Show>
+
+          <Show when={!codedTools.loading && codedTools()?.length === 0}>
+            <div p="4" bg="dark-bg-secondary" rounded="md" text="center">
+              <div text="sm dark-text-secondary">No coded tools yet</div>
+              <div text="xs dark-text-tertiary" m="t-1">
+                Tools will appear here as they are created and saved during code mode execution
+              </div>
             </div>
-          </div>
-        </Show>
+          </Show>
 
-        <Show when={!codedTools.loading && (codedTools()?.length || 0) > 0}>
-          <div flex="~ col" gap="2">
-            <For each={codedTools()}>
-              {(tool) => (
-                <CodedToolCard tool={tool} />
-              )}
-            </For>
-          </div>
-        </Show>
-      </div>
+          <Show when={!codedTools.loading && (codedTools()?.length || 0) > 0}>
+            <div flex="~ col" gap="2">
+              <For each={codedTools()}>
+                {(tool) => <CodedToolCard tool={tool} />}
+              </For>
+            </div>
+          </Show>
+        </div>
+      </Show>
     </div>
   );
 };
@@ -335,70 +297,44 @@ const CodedToolCard = (props: CodedToolCardProps) => {
   const [isExpanded, setIsExpanded] = createSignal(false);
 
   return (
-    <div
-      bg="dark-bg-secondary"
-      border="1 dark-border-primary"
-      rounded="md"
-      overflow="hidden"
-    >
-      {/* Header */}
+    <div bg="dark-bg-secondary" border="1 dark-border-primary" rounded="md" overflow="hidden">
       <div
-        flex="~"
-        items="center"
-        justify="between"
-        p="3"
-        cursor="pointer"
-        hover:bg="dark-bg-tertiary"
+        flex="~" items="center" justify="between" p="3"
+        cursor="pointer" hover:bg="dark-bg-tertiary"
         onClick={() => setIsExpanded(!isExpanded())}
       >
         <div flex="1">
           <div flex="~" items="center" gap="2">
-            <span text="sm dark-text-primary" font="medium">
-              {props.tool.name}
-            </span>
+            <span text="sm dark-text-primary" font="medium">{props.tool.name}</span>
             <span
-              text="xs"
-              p="x-1.5 y-0.5"
-              bg="neon-orange/10"
-              border="1 neon-orange/30"
-              rounded="full"
+              text="xs" p="x-1.5 y-0.5"
+              bg="neon-orange/10" border="1 neon-orange/30" rounded="full"
               style={{ color: '#ff6600' }}
             >
               {props.tool.usageCount} uses
             </span>
           </div>
-          <div text="xs dark-text-tertiary" m="t-0.5">
-            {props.tool.description}
-          </div>
+          <div text="xs dark-text-tertiary" m="t-0.5">{props.tool.description}</div>
         </div>
         <svg
-          width="16"
-          height="16"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="2"
+          width="16" height="16" viewBox="0 0 24 24" fill="none"
+          stroke="currentColor" stroke-width="2"
           style={{
             color: '#a1a1aa',
             transform: isExpanded() ? 'rotate(180deg)' : 'rotate(0deg)',
-            transition: 'transform 0.2s'
+            transition: 'transform 0.2s',
           }}
         >
           <path d="M19 9l-7 7-7-7" />
         </svg>
       </div>
 
-      {/* Expanded Script View */}
       <Show when={isExpanded()}>
         <div border="t dark-border-primary" p="3" bg="dark-bg-primary">
           <div text="xs dark-text-tertiary" m="b-2">Script:</div>
           <pre
-            text="xs dark-text-secondary"
-            bg="dark-bg-tertiary"
-            p="3"
-            rounded="md"
-            overflow="auto"
-            max-h="200px"
+            text="xs dark-text-secondary" bg="dark-bg-tertiary" p="3" rounded="md"
+            overflow="auto" max-h="200px"
             style={{ "white-space": "pre-wrap", "word-break": "break-all" }}
           >
             {props.tool.script}
@@ -417,20 +353,20 @@ const CodedToolCard = (props: CodedToolCardProps) => {
 // Helper Functions
 // ============================================================================
 
-/** Get human-readable description for a tool */
+/** Human-readable description for a few well-known tools. Falls back to a
+ *  generic label — the upstream MCP listTools response also carries
+ *  descriptions, which we could surface here as a follow-up. */
 function getToolDescription(tool: string): string {
   const descriptions: Record<string, string> = {
+    'mcp-find': 'Search the MCP catalog for available servers',
+    'mcp-add': 'Add a catalog server to the gateway',
+    'mcp-exec': 'Invoke a tool on a server one-shot',
+    'code-mode': 'Register a code-mode-<name> factory tool',
     read_neo4j_cypher: 'Execute read queries on Neo4j',
     write_neo4j_cypher: 'Execute write queries on Neo4j',
     get_neo4j_schema: 'Fetch Neo4j database schema',
     search: 'Search the web via DuckDuckGo',
     fetch_content: 'Fetch and parse web page content',
-    brave_search: 'Search via Brave Search API',
-    firecrawl: 'Advanced web scraping',
-    github: 'GitHub API operations',
-    linear: 'Linear project management',
-    slack: 'Slack messaging',
-    notion: 'Notion database operations'
   };
 
   return descriptions[tool] || 'MCP tool';

--- a/ui/src/lib/harness-client/actions.server.ts
+++ b/ui/src/lib/harness-client/actions.server.ts
@@ -31,6 +31,7 @@ import type { HarnessSettings } from "../settings";
 import { runWithSettings } from "../settings-context.server";
 import { getAuthenticatedUser } from "../auth/server";
 import { BYPASS_USER, isBypassEnabled } from "../auth/dev-bypass";
+import { runWithUserId } from "./request-user.server";
 
 // ============================================================================
 // Auth helper
@@ -99,28 +100,33 @@ async function runTurn(
   agentId: string,
   onEvent?: (event: ContextEvent) => void,
 ): Promise<HarnessResultScoped<SessionData>> {
-  // If the user switched agent within an existing conversation, treat it as
-  // a fresh conversation by ignoring the prior serialized context. The UI is
-  // expected to mint a new sessionId on agent change, but we double-guard
-  // here so a stale id can't continue with a different agent's patterns.
-  const loaded = await loadSession(sessionId, userId);
-  const patterns = await getOrBuildPatterns(sessionId, agentId);
+  // Establish the user-id scope so pattern closures that need to load
+  // per-conversation context at runtime (e.g. code-mode's tool allowlist
+  // reader) can resolve the right user without an explicit parameter.
+  return runWithUserId(userId, async () => {
+    // If the user switched agent within an existing conversation, treat it as
+    // a fresh conversation by ignoring the prior serialized context. The UI is
+    // expected to mint a new sessionId on agent change, but we double-guard
+    // here so a stale id can't continue with a different agent's patterns.
+    const loaded = await loadSession(sessionId, userId);
+    const patterns = await getOrBuildPatterns(sessionId, agentId);
 
-  let result: HarnessResultScoped<SessionData>;
-  if (loaded && loaded.agentId === agentId) {
-    result = await continueSession(
-      loaded.serializedContext,
-      patterns,
-      message,
-      onEvent,
-    );
-  } else {
-    const agent = harness(...patterns);
-    result = await agent(message, sessionId, undefined, onEvent);
-  }
+    let result: HarnessResultScoped<SessionData>;
+    if (loaded && loaded.agentId === agentId) {
+      result = await continueSession(
+        loaded.serializedContext,
+        patterns,
+        message,
+        onEvent,
+      );
+    } else {
+      const agent = harness(...patterns);
+      result = await agent(message, sessionId, undefined, onEvent);
+    }
 
-  await saveSession(sessionId, userId, agentId, result.serialized);
-  return result;
+    await saveSession(sessionId, userId, agentId, result.serialized);
+    return result;
+  });
 }
 
 /**
@@ -151,14 +157,16 @@ async function resolveApproval(
   if (!loaded) {
     throw new Error("No active session");
   }
-  const patterns = await getOrBuildPatterns(sessionId, loaded.agentId);
-  const result = await resumeHarness(
-    loaded.serializedContext,
-    patterns,
-    approved,
-  );
-  await saveSession(sessionId, user.id, loaded.agentId, result.serialized);
-  return result;
+  return runWithUserId(user.id, async () => {
+    const patterns = await getOrBuildPatterns(sessionId, loaded.agentId);
+    const result = await resumeHarness(
+      loaded.serializedContext,
+      patterns,
+      approved,
+    );
+    await saveSession(sessionId, user.id, loaded.agentId, result.serialized);
+    return result;
+  });
 }
 
 /**

--- a/ui/src/lib/harness-client/examples/code-mode.server.ts
+++ b/ui/src/lib/harness-client/examples/code-mode.server.ts
@@ -1,0 +1,301 @@
+/**
+ * Code-Mode Agent
+ *
+ * Dedicated agent for the kg-agent gateway's `code-mode` tool family.
+ *
+ * Workflow (per harness log at .harness-logs/code_mode_context-cl-28-2026-05-13.json):
+ *   `code-mode` is NOT a one-shot JS executor — its args_schema is
+ *   `{name: string, servers: string[]}`. Calling it registers a new
+ *   gateway tool named `code-mode-<name>` bound to the listed MCP servers,
+ *   and that generated tool is what actually runs JS. Sequence:
+ *
+ *     mcp-find → mcp-add → code-mode({name, servers}) → code-mode-<name>({script})
+ *
+ *   (`mcp-exec` may be a one-shot escape hatch — its args_schema isn't
+ *   captured in this repo. If present, the actor will likely converge on it
+ *   instead of the factory dance.)
+ *
+ * Why a separate agent: the workflow needs `actorCritic`'s retry-with-feedback
+ * semantics (the critic steers the actor through find → add → factory → call).
+ * `simpleLoop` breaks on the first allowlist failure, which made the previous
+ * default-agent code_mode route unable to recover from any step's setup error.
+ *
+ * Cross-turn tool reuse: `createActorControllerAdapter` is configured with
+ * `refreshOnCall + dynamicPattern: /^code-mode-/` so each actor invocation
+ * re-lists the gateway and surfaces any code-mode-* tools created in earlier
+ * turns. The gateway persists those tools for its process lifetime, so a
+ * `code-mode-search-graph` made in turn 1 is callable in turn 2 without
+ * re-creating it.
+ */
+"use server";
+
+import {
+  router,
+  routes,
+  actorCritic,
+  synthesizer,
+  chain,
+  Tools,
+  createActorControllerAdapter,
+  createCriticAdapter,
+  type ConfiguredPattern,
+  deserializeContext,
+} from "../../harness-patterns";
+import type { SessionData } from "../session.server";
+import type { AgentConfig } from "../registry.server";
+import { getRequestUserId } from "../request-user.server";
+import type { FewShot } from "../../../../baml_client/types";
+// NOTE: loadSession is imported dynamically inside the closure (not at the
+// top level) to avoid a circular import — registry.server.ts imports this
+// file, so any value import of session.server.ts would deadlock the
+// agent-registration sequence.
+
+const CODE_MODE_TOOLS = ['mcp-find', 'mcp-add', 'code-mode', 'mcp-exec'];
+
+/**
+ * Actor-side guidance prepended to the `ActorController` prompt via
+ * `createActorControllerAdapter({ contextPrefix })`. Covers the four
+ * behaviors the actor needs to do code-mode well. This is shipped as a
+ * code-string today; when the harness gains Skill support
+ * (docs/ROADMAP.md), the same content will live as a Skill the actor
+ * receives via the standard mechanism instead.
+ */
+const CODE_MODE_ACTOR_GUIDANCE = `
+The kg-agent gateway exposes a "code-mode" factory tool. Use it to:
+
+1. FACTORY PROTOCOL. Call code-mode with {name, servers} to register a
+   server-side script runner named code-mode-<name>. Then call
+   code-mode-<name> with {script} to execute JavaScript that can invoke
+   any tool from the listed servers (await each call).
+
+2. BATCH OPERATIONS. Write ONE script that performs the whole user
+   request (multiple tool calls + transformations + aggregations) instead
+   of one round-trip per operation. The factory tool is the leverage —
+   under-using it wastes turns.
+
+3. SKIP REDUNDANT DISCOVERY. Tools already present in AVAILABLE TOOLS
+   (above) don't need mcp-find or mcp-add — they're loaded.
+
+4. RETURN WHEN DONE OR NEAR BUDGET. When the script produces a usable
+   answer (or BUDGET shows you're near the max), call Return with the
+   data + a short summary. Do NOT chain more tools past that point.
+`.trim();
+
+/**
+ * Few-shots span four dimensions: complexity (simple → high), number of
+ * servers per script (1 → 2), reasoning pattern (transform, multi-step
+ * pipeline, conditional branch, write-back), and final-action shape. They
+ * are the actual script bodies passed to `code-mode-<name>({script})` —
+ * the factory-creation step before each is implied; we don't waste a
+ * few-shot slot on the `{name, servers}` registration call because
+ * CONTEXT teaches that protocol verbally.
+ *
+ * Four selected from a curated set of seven (see code_mode_actor_critic.md
+ * § "Few-shot catalog"). The other three (D, E, G) are documented
+ * alternates for future iteration but kept off the wire today to avoid
+ * over-anchoring small models.
+ */
+const CODE_MODE_FEW_SHOTS: FewShot[] = [
+  // A — Simple: 1 server, read + groupBy. Anchors the minimum viable script.
+  {
+    user: "How many entities of each type are in the knowledge graph?",
+    reasoning:
+      "One-server read + transform. Register a code-mode tool bound to memory, then run a tiny script that aggregates by entityType.",
+    tool: "code-mode-count_entities_by_type",
+    args: JSON.stringify({
+      script: [
+        "const g = await read_graph({});",
+        "const counts = {};",
+        "for (const e of g.entities) counts[e.entityType] = (counts[e.entityType] || 0) + 1;",
+        "return counts;",
+      ].join("\n"),
+    }),
+  },
+  // B — Medium-high: 2 servers, multi-step pipeline. Canonical case the
+  // hallucination log botched — show it done right.
+  {
+    user: "Find the 2 most-connected nodes in the knowledge graph and search the web for related tech for each.",
+    reasoning:
+      "Two servers (memory + web_search) in one script: read graph → count degree from relations → pick top-2 → loop a web search per name. ONE factory tool, ONE script — not four round-trips.",
+    tool: "code-mode-graph_web_analysis",
+    args: JSON.stringify({
+      script: [
+        "const g = await read_graph({});",
+        "const deg = new Map();",
+        "for (const r of g.relations) { deg.set(r.from, (deg.get(r.from)||0)+1); deg.set(r.to, (deg.get(r.to)||0)+1); }",
+        "const top2 = [...deg.entries()].sort((a,b)=>b[1]-a[1]).slice(0,2).map(([n])=>n);",
+        "const out = { top_nodes: top2, searches: {} };",
+        "for (const name of top2) { out.searches[name] = await search({query: name + ' related technologies'}); }",
+        "return out;",
+      ].join("\n"),
+    }),
+  },
+  // C — Medium: 2 servers, conditional branch on cache hit. The only
+  // branching example — without it, models default to linear chains.
+  {
+    user: "Search the web for 'rust async runtimes', but check Redis cache first; if miss, cache for 1 hour.",
+    reasoning:
+      "Cache-aware lookup. Get from redis; on hit return immediately, on miss run search and write back with TTL. Demonstrates conditional script flow.",
+    tool: "code-mode-cached_web_search",
+    args: JSON.stringify({
+      script: [
+        "const key = 'web:rust-async-runtimes';",
+        "const cached = await get({name: key});",
+        "if (cached) return { source: 'cache', data: JSON.parse(cached) };",
+        "const fresh = await search({query: 'rust async runtimes'});",
+        "await set({name: key, value: JSON.stringify(fresh), expire_seconds: 3600});",
+        "return { source: 'web', data: fresh };",
+      ].join("\n"),
+    }),
+  },
+  // F — High: 2 servers, file walk + batch write-back. Stretches the model
+  // toward persist patterns and shows parameterized Cypher.
+  {
+    user: "Walk ./docs, extract '##' headings from each .md, persist each as a Concept node linked to its source Doc.",
+    reasoning:
+      "Read-many → parse → one batch write. Collect all (concept, doc) pairs first, then UNWIND them in a single parameterized Cypher MERGE — cheaper than per-pair round-trips.",
+    tool: "code-mode-docs_to_graph",
+    args: JSON.stringify({
+      script: [
+        "const files = await list_directory({path: './docs'});",
+        "const ops = [];",
+        "for (const f of files.filter(x => x.endsWith('.md'))) {",
+        "  const body = await read_text_file({path: './docs/' + f});",
+        "  const heads = [...body.matchAll(/^##\\s+(.+)$/gm)].map(m => m[1]);",
+        "  for (const h of heads) ops.push({concept: h, doc: f});",
+        "}",
+        "const query = 'UNWIND $ops AS op MERGE (d:Doc {path: op.doc}) MERGE (c:Concept {name: op.concept}) MERGE (c)-[:DEFINED_IN]->(d)';",
+        "await write_neo4j_cypher({query, params: {ops}});",
+        "return { docs_processed: files.length, concepts_created: ops.length };",
+      ].join("\n"),
+    }),
+  },
+];
+
+async function createPatterns(sessionId: string): Promise<ConfiguredPattern<SessionData>[]> {
+  // Resolve the meta-tool subset live each call instead of snapshotting at
+  // construction. The previous design captured `tools.all` once at
+  // `createPatterns()` time — if the gateway was unreachable then
+  // (post-restart with a stale singleton, etc.), the snapshot stayed empty
+  // forever and every actor turn got rejected by the allowlist. Now the
+  // closure re-runs `Tools()` per invocation; combined with
+  // `mcp-client.server.ts`'s `withReconnect`, a transient gateway outage
+  // resolves on the next actor turn instead of poisoning the session.
+  const getDefaultCodeTools = async (): Promise<string[]> => {
+    const tools = await Tools();
+    return CODE_MODE_TOOLS.filter((t) => tools.all.includes(t));
+  };
+
+  // One-shot snapshot for actorCritic's `tools` argument (the static side of
+  // the allowlist check). May be empty if the gateway is down at startup —
+  // that's fine because the per-call `dynamicToolAllowlist` below always
+  // re-resolves and is consulted on every actor turn.
+  const initialDefaults = await getDefaultCodeTools();
+
+  // Resolves the actor's tool allowlist live per invocation. Reads the
+  // user's per-conversation selection from data.codeModeAllowedTools (set
+  // by the Tools tab via setCodeModeAllowedTools) and unions it with the
+  // meta-tools the actor always needs. When no userId scope is active
+  // (defensive — should never happen during a real turn) or no selection
+  // exists yet, falls back to the meta-tools alone.
+  const toolNamesProvider = async (): Promise<string[]> => {
+    const defaults = await getDefaultCodeTools();
+    const userId = getRequestUserId();
+    if (!userId) return defaults;
+    try {
+      const { loadSession } = await import("../session.server");
+      const loaded = await loadSession(sessionId, userId);
+      if (!loaded) return defaults;
+      const ctx = deserializeContext<SessionData>(loaded.serializedContext);
+      const allowed = ctx.data?.codeModeAllowedTools;
+      if (!allowed || allowed.length === 0) return defaults;
+      // User picks *additions*; meta-tools are always reachable so the
+      // agent's factory dance still works even with a sparse selection.
+      return Array.from(new Set([...defaults, ...allowed]));
+    } catch {
+      return defaults;
+    }
+  };
+
+  const actor = createActorControllerAdapter({
+    toolNamesProvider,
+    // Surface any `code-mode-<name>` tool the gateway has registered. This
+    // covers both intra-turn re-attempts (after the factory creates a tool)
+    // and cross-turn reuse (tools created in prior user turns persist on the
+    // gateway and reappear in fresh listTools calls).
+    dynamicPattern: /^code-mode-/,
+    refreshOnCall: true,
+    // Teach the actor about the factory protocol + batching heuristic.
+    // See code_mode_actor_critic.md and the constants above for rationale.
+    contextPrefix: CODE_MODE_ACTOR_GUIDANCE,
+    fewShots: CODE_MODE_FEW_SHOTS,
+  });
+  const critic = createCriticAdapter();
+
+  const loop = actorCritic<SessionData>(actor, critic, initialDefaults, {
+    patternId: "code-mode-loop",
+    liveEvents: true,
+    // Allow actorCritic to dispatch dynamically-created tools whose names
+    // start with `code-mode-` (factory output) without listing them in `tools`.
+    dynamicToolPattern: /^code-mode-/,
+    // Keep the strict allowlist in sync with what the actor's prompt
+    // advertises. Same provider closure as above so user-curated additions
+    // pass the loop's tool-allowed check (actorCritic.server.ts:117).
+    dynamicToolAllowlist: toolNamesProvider,
+    // Factory happy path is `mcp-find → mcp-add → code-mode → code-mode-<name>`
+    // = 4 productive turns minimum; multi-server prompts add a second find/add
+    // pair. Default 3 (settings.ts) exhausts the loop before any useful work.
+    maxRetries: 8,
+  });
+
+  // Synthesizer that reads actor-side events from the loop plus any error
+  // event the loop emitted (e.g. "Max retries (8) exceeded"). `thread` mode
+  // naturally consumes only `controller_action` + `tool_call` + `tool_result`
+  // via `view.tools()` / `view.actions()`, but `viewConfig.eventTypes` pins
+  // the filter explicitly so `critic_result` stays out of the prompt. We
+  // include 'error' so `view.hasErrors()` / `view.lastError()` surface a
+  // loop-exhaustion signal to the BAML Synthesize template — without it the
+  // synthesizer would happily fabricate a confident answer over an incomplete
+  // trace (see hallucination-code-mode.json: Max retries fired, synth invented
+  // node names and fake web search results). The error scoping is naturally
+  // bounded by this synthesizer's own view window — see harness-patterns
+  // README "Error scoping" note.
+  const synth = synthesizer<SessionData>({
+    mode: "thread",
+    patternId: "code-mode-synth",
+    liveEvents: true,
+    viewConfig: {
+      eventTypes: ["controller_action", "tool_call", "tool_result", "error"],
+    },
+  });
+
+  const codeChain = chain<SessionData>(loop, synth);
+
+  const routerPattern = router<SessionData>(
+    {
+      code_mode:
+        "Compose JavaScript that orchestrates multiple MCP tools — the gateway runs it server-side via the code-mode factory",
+    },
+    { liveEvents: true },
+  );
+
+  const routesPattern = routes<SessionData>(
+    { code_mode: codeChain },
+    { liveEvents: true },
+  );
+
+  // No top-level synthesizer: the inner chain handles the code_mode branch's
+  // response; the direct-response branch sets `scope.data.response` inside
+  // `routeMessageOp` and `routes()` passes through.
+  return [routerPattern, routesPattern];
+}
+
+export const codeModeAgent: AgentConfig = {
+  id: "code-mode",
+  name: "Code Mode Agent",
+  description:
+    "Orchestrate multiple MCP tools via JavaScript scripts run by the kg-agent gateway",
+  icon: "📜",
+  servers: ["kg-agent-mcp-gateway"],
+  createPatterns,
+};

--- a/ui/src/lib/harness-client/examples/code_mode_actor_critic.md
+++ b/ui/src/lib/harness-client/examples/code_mode_actor_critic.md
@@ -1,0 +1,179 @@
+# Code Mode Agent — actorCritic engineering
+
+> **File:** `code-mode.server.ts` · **Pattern:** `router → routes(chain(actorCritic, synthesizer))`
+> **Issue:** [#12](https://github.com/mknw/harness-playground/issues/12)
+
+The code-mode agent orchestrates multi-step MCP tool work by writing
+JavaScript that the kg-agent gateway runs server-side. Unlike the default
+agent's per-route `simpleLoop` shape, code-mode's loop is `actorCritic`
+because the workflow needs retry-with-feedback semantics — the factory
+dance has many ways to go wrong on the first try and `simpleLoop` would
+break on the first allowlist failure.
+
+This doc covers the actor-side engineering: the prompt prelude, the
+few-shots, the budget signal, and the synthesizer's error visibility.
+
+---
+
+## The factory tool
+
+The gateway's `code-mode` tool is a **factory**. Its `args_schema` is
+`{name, servers}`, and a successful call registers a new tool
+`code-mode-<name>` bound to those servers. That generated tool is what
+actually runs JavaScript:
+
+```
+mcp-find* → mcp-add* → code-mode({name, servers}) → code-mode-<name>({script})
+```
+
+Inside the script, every tool from the listed servers is callable as a
+top-level async function (`await read_graph({})`, `await search({query})`,
+etc.). One script can chain many operations server-side — that's the
+leverage, and the failure mode the actor's prompt is engineered to avoid
+is *under-using* it (treating `code-mode-<name>` as a thin shim around a
+single tool call, exhausting the retry budget on discovery instead).
+
+---
+
+## Actor prompt engineering
+
+Three additions to the generic `ActorController` BAML function
+(`baml_src/actorCritic.baml`), all already used by `LoopController`:
+
+1. **`context: string?`** — the adapter's `contextPrefix` option lands here
+   and renders under a `CONTEXT:` heading. We use it for code-mode-specific
+   guidance (see `CODE_MODE_ACTOR_GUIDANCE` in `code-mode.server.ts`).
+2. **`few_shots: FewShot[]?`** — adapter's `fewShots` option. Two
+   illustrative examples: one showing the factory `{name, servers}` call,
+   one showing a multi-step script inside `code-mode-<name>({script})`. We
+   keep it to two so a small model isn't over-anchored on the example
+   wording.
+3. **`attempt_n: int?` / `max_attempts: int?`** — `actorCritic.server.ts`
+   passes the current `attempt + 1` and the configured `maxRetries` so the
+   prompt can render `BUDGET: Attempt N of M` and, when N approaches M,
+   nudge the actor toward `Return` with whatever partial results it has.
+
+### What the guidance teaches
+
+The prelude covers four behaviors, in priority order:
+
+| # | Rule | Why it's there |
+|---|---|---|
+| 1 | Factory protocol: `code-mode {name, servers}` → `code-mode-<name>({script})` | Without this the actor doesn't know the factory step exists and tries `mcp-exec` as a shim. |
+| 2 | Write ONE script that batches multiple operations server-side | The failure case (`hallucination-code-mode.json`) was the actor calling `code-mode-<name>` with `return read_graph({})` — a one-liner that dumped data instead of doing the full pipeline. |
+| 3 | Skip `mcp-find` / `mcp-add` for tools already in `AVAILABLE TOOLS` | The user's per-conversation allowlist pre-loads tools; rediscovery wastes turns. |
+| 4 | Return when done or near budget exhaustion | Combined with the `BUDGET:` line from Decision 3, this lets the actor wrap partial work into a final answer instead of being cut off mid-thought. |
+
+---
+
+## Few-shot catalog
+
+Seven candidate few-shots were authored against the live gateway and vetted
+for tool availability. Four ship today (in `CODE_MODE_FEW_SHOTS`); three
+are documented alternates kept off the wire to avoid over-anchoring small
+models. They're listed here so a future iteration (or a Skill migration —
+see roadmap) can swap them in without re-discovery.
+
+Selection criteria: vary **complexity** (simple → high), **server count
+per script** (1–2), and **reasoning pattern** (transform · pipeline ·
+branch · write-back · external-distill · search-fetch · multi-source join).
+
+| ID | Status | Request | Servers | Reasoning |
+|----|--------|---------|---------|-----------|
+| **A** | ✅ shipped | "How many entities of each type are in the knowledge graph?" | memory | Read + groupBy |
+| **B** | ✅ shipped | "Find the 2 most-connected nodes and search the web for related tech for each." | memory + web_search | Read → compute → loop with external |
+| **C** | ✅ shipped | "Search the web for 'rust async runtimes' — check Redis cache first; cache for 1h on miss." | redis + web_search | Conditional branch on cache hit |
+| **D** | alternate | "Look up SolidJS `createSignal` docs and save the key facts as a memory entity." | context7 + memory | External lookup → distill → persist |
+| **E** | alternate | "Search 'WebAssembly 2026 spec changes' — return top-3 with title + first paragraph." | web_search (multi-step) | Search → iterate → fetch → extract |
+| **F** | ✅ shipped | "Walk `./docs`, extract `##` headings from each `.md`, persist each as a `Concept` node linked to its `Doc`." | rust-mcp-filesystem + neo4j-cypher | File walk → parse → batch write |
+| **G** | alternate | "List my last 5 PRs in repo X; mark any Concept node whose name appears in the PR body." | github + neo4j-cypher | Multi-source join + conditional write |
+
+**Why these four ship and the rest don't:**
+
+- **A** anchors the minimum-viable shape. Small LLMs need to see "even a one-server query goes through the factory."
+- **B** is the canonical multi-server pipeline and the exact case the original hallucination log botched — keeping it front-and-centre.
+- **C** is the only conditional/branching example. Without it, models default to linear chains.
+- **F** is the most complex (write-back via parameterized Cypher) and stretches the model toward persistence patterns.
+- **D** overlaps with A's read-and-transform shape and adds context7-specific noise.
+- **E** is a weaker version of B (no in-graph computation).
+- **G** is GitHub-specific and most users won't have that context loaded.
+
+**Note on F (write-back) and execution environment:** F writes to Neo4j
+via the standard MCP tool, but a parallel concern — what host-side write
+capability does the JS *itself* have (Node fs? V8 isolate? sandbox?) — is
+unresolved and tracked in
+[#64](https://github.com/mknw/harness-playground/issues/64). That issue's
+outcome may change whether a future few-shot can write to local files
+directly (e.g. dumping a report to disk) or whether such work must
+always route through an MCP server.
+
+---
+
+## Synthesizer error visibility
+
+`synthesizer.server.ts` already calls `view.hasErrors()` /
+`view.lastError()` and passes both to the BAML `Synthesize` template. The
+template's behavior changes when `hasError` is true (it should report the
+limitation honestly rather than fabricate). The code-mode synthesizer
+explicitly opts into seeing error events through its `ViewConfig`:
+
+```ts
+viewConfig: {
+  eventTypes: ["controller_action", "tool_call", "tool_result", "error"],
+}
+```
+
+`critic_result` is deliberately excluded so the critic's reasoning doesn't
+leak into the user-facing response — but `error` is in, so
+`view.hasErrors()` surfaces a loop-exhaustion signal. Without this, a
+`Max retries exceeded` event was silently filtered and the synthesizer
+invented confident-but-fake content over incomplete tool results (see
+`.harness-logs/hallucination-code-mode.json`).
+
+Error scoping is naturally bounded by the synthesizer's own view window —
+see the "Error scoping" note in
+[`ui/src/lib/harness-patterns/README.md`](../../harness-patterns/README.md).
+
+---
+
+## Per-conversation tool allowlist
+
+The actor's tool list isn't fixed at agent-construction time. The Tools
+tab persists the user's selection on `data.codeModeAllowedTools` (rides in
+the conversation's JSONB context blob). The adapter resolves the list
+fresh per actor invocation via a `toolNamesProvider` async closure that
+loads the conversation and unions the user's picks with the four required
+meta-tools (`mcp-find`, `mcp-add`, `code-mode`, `mcp-exec`).
+
+This means checkbox changes take effect on the **next actor turn** without
+a pattern rebuild — see `code-mode.server.ts`'s `toolNamesProvider`
+closure and `baml-adapters.server.ts`'s `ActorAdapterOptions`.
+
+`actorCritic.server.ts` mirrors the same provider on the loop's strict
+allowlist check via `dynamicToolAllowlist`, so the prompt and the runtime
+gate stay in sync.
+
+---
+
+## Future: migrate guidance to a Skill
+
+Once the harness gains Skill support (see [`docs/ROADMAP.md`](../../../../../docs/ROADMAP.md)
+§ Harness pattern: Skill support), the four-point guidance + few-shots
+move out of `code-mode.server.ts` into a reusable Skill the actor receives
+via the standard mechanism. The shape stays the same (text + few-shots
++ optional budget signal); the storage location changes from "inline
+const in the agent file" to "registered Skill". Other actorCritic agents
+(`guardrailed-agent`, `ontology-builder`) can adopt the same migration
+path for their domain-specific guidance.
+
+---
+
+## Files
+
+| File | Role |
+|---|---|
+| `code-mode.server.ts` | Agent definition: actor + critic, factory tool wiring, contextPrefix + fewShots, per-conversation allowlist closure, synthesizer with `error` in view. |
+| `baml_src/actorCritic.baml` · `ActorController` | BAML function with `context`, `few_shots`, `attempt_n`, `max_attempts` fields. |
+| `lib/harness-patterns/baml-adapters.server.ts` · `createActorControllerAdapter` | Adapter options: `contextPrefix`, `fewShots`, `toolNamesProvider`. |
+| `lib/harness-patterns/patterns/actorCritic.server.ts` | Threads `attempt + 1` / `maxRetries` into the actor call; consults `dynamicToolAllowlist` per turn. |
+| `__tests__/agents/code-mode.test.ts` | E2E-shaped: factory workflow, direct-response branch, retry-budget regression, per-conversation allowlist passthrough. |

--- a/ui/src/lib/harness-client/examples/conversational-memory.server.ts
+++ b/ui/src/lib/harness-client/examples/conversational-memory.server.ts
@@ -30,7 +30,7 @@ async function getSchema(): Promise<string> {
   return result.success ? JSON.stringify(result.data) : "";
 }
 
-async function createPatterns(): Promise<ConfiguredPattern<SessionData>[]> {
+async function createPatterns(_sessionId: string): Promise<ConfiguredPattern<SessionData>[]> {
   const tools = await Tools();
   const schema = await getSchema();
 

--- a/ui/src/lib/harness-client/examples/default.server.ts
+++ b/ui/src/lib/harness-client/examples/default.server.ts
@@ -1,7 +1,10 @@
 /**
  * Default Agent
  *
- * The original router-based agent with Neo4j, Web Search, and Code Mode.
+ * Router-based agent with Neo4j and Web Search routes.
+ * Code-mode lives in a dedicated agent (`code-mode.server.ts`) because the
+ * kg-agent gateway's `code-mode` tool is a factory that creates `code-mode-<name>`
+ * tools — that workflow needs an actorCritic loop rather than a simpleLoop.
  */
 "use server";
 
@@ -9,15 +12,12 @@ import {
   router,
   routes,
   simpleLoop,
-  actorCritic,
   synthesizer,
   withReferences,
   Tools,
   callTool,
   createNeo4jController,
   createWebSearchController,
-  createActorControllerAdapter,
-  createCriticAdapter,
   type ConfiguredPattern,
 } from "../../harness-patterns";
 import type { SessionData } from "../session.server";
@@ -30,15 +30,13 @@ async function getSchema(): Promise<string> {
   return result.success ? JSON.stringify(result.data) : "";
 }
 
-async function createPatterns(): Promise<ConfiguredPattern<SessionData>[]> {
+async function createPatterns(_sessionId: string): Promise<ConfiguredPattern<SessionData>[]> {
   const tools = await Tools();
   const schema = await getSchema();
 
   const neo4jController = createNeo4jController(tools.neo4j ?? []);
   const webTools = tools.web ?? [];
   const webController = createWebSearchController(webTools);
-  const codeController = createActorControllerAdapter(tools.all);
-  const codeCritic = createCriticAdapter();
 
   const neo4jPattern = simpleLoop<SessionData>(
     neo4jController,
@@ -59,21 +57,10 @@ async function createPatterns(): Promise<ConfiguredPattern<SessionData>[]> {
     rememberPriorTurns: false,
   });
 
-  const codePattern = actorCritic<SessionData>(
-    codeController,
-    codeCritic,
-    tools.all,
-    {
-      patternId: "code-mode",
-      liveEvents: true,
-    },
-  );
-
   const routerPattern = router<SessionData>(
     {
       neo4j: "Database queries and graph operations",
       web_search: "Web lookups and information retrieval",
-      code_mode: "Multi-tool script composition",
     },
     { liveEvents: true },
   );
@@ -85,7 +72,6 @@ async function createPatterns(): Promise<ConfiguredPattern<SessionData>[]> {
     {
       neo4j: withReferences<SessionData>(neo4jPattern, { scope: "global", liveEvents: true }),
       web_search: withReferences<SessionData>(webPattern, { scope: "global", liveEvents: true }),
-      code_mode: withReferences<SessionData>(codePattern, { scope: "global", liveEvents: true }),
     },
     { liveEvents: true },
   );
@@ -102,7 +88,7 @@ async function createPatterns(): Promise<ConfiguredPattern<SessionData>[]> {
 export const defaultAgent: AgentConfig = {
   id: "default",
   name: "Default Agent",
-  description: "Router-based agent with Neo4j, Web Search, and Code Mode",
+  description: "Router-based agent with Neo4j and Web Search",
   icon: "🤖",
   servers: ["neo4j-cypher", "web_search", "fetch"],
   createPatterns,

--- a/ui/src/lib/harness-client/examples/doc-assistant.server.ts
+++ b/ui/src/lib/harness-client/examples/doc-assistant.server.ts
@@ -17,7 +17,7 @@ import {
 import type { SessionData } from "../session.server";
 import type { AgentConfig } from "../registry.server";
 
-async function createPatterns(): Promise<ConfiguredPattern<SessionData>[]> {
+async function createPatterns(_sessionId: string): Promise<ConfiguredPattern<SessionData>[]> {
   const tools = await Tools();
 
   // Stage 1: Look up documentation using Context7

--- a/ui/src/lib/harness-client/examples/guardrailed-agent.server.ts
+++ b/ui/src/lib/harness-client/examples/guardrailed-agent.server.ts
@@ -82,7 +82,7 @@ const toolScopeRail: Rail<SessionData> = {
   },
 };
 
-async function createPatterns(): Promise<ConfiguredPattern<SessionData>[]> {
+async function createPatterns(_sessionId: string): Promise<ConfiguredPattern<SessionData>[]> {
   const tools = await Tools();
 
   // File editing pattern with actor-critic

--- a/ui/src/lib/harness-client/examples/issue-triage.server.ts
+++ b/ui/src/lib/harness-client/examples/issue-triage.server.ts
@@ -27,7 +27,7 @@ async function getSchema(): Promise<string> {
   return result.success ? JSON.stringify(result.data) : "";
 }
 
-async function createPatterns(): Promise<ConfiguredPattern<SessionData>[]> {
+async function createPatterns(_sessionId: string): Promise<ConfiguredPattern<SessionData>[]> {
   const tools = await Tools();
   const schema = await getSchema();
 

--- a/ui/src/lib/harness-client/examples/kg-builder.server.ts
+++ b/ui/src/lib/harness-client/examples/kg-builder.server.ts
@@ -26,7 +26,7 @@ async function getSchema(): Promise<string> {
   return result.success ? JSON.stringify(result.data) : "";
 }
 
-async function createPatterns(): Promise<ConfiguredPattern<SessionData>[]> {
+async function createPatterns(_sessionId: string): Promise<ConfiguredPattern<SessionData>[]> {
   const tools = await Tools();
   const schema = await getSchema();
 

--- a/ui/src/lib/harness-client/examples/llm-judge.server.ts
+++ b/ui/src/lib/harness-client/examples/llm-judge.server.ts
@@ -101,7 +101,7 @@ const qualityJudgeEvaluator: EvaluatorFn = async (query, candidates) => {
   };
 };
 
-async function createPatterns(): Promise<ConfiguredPattern<SessionData>[]> {
+async function createPatterns(_sessionId: string): Promise<ConfiguredPattern<SessionData>[]> {
   const tools = await Tools();
 
   // Create source patterns

--- a/ui/src/lib/harness-client/examples/multi-source-research.server.ts
+++ b/ui/src/lib/harness-client/examples/multi-source-research.server.ts
@@ -69,7 +69,7 @@ const judgeEvaluator: EvaluatorFn = async (query, candidates) => {
   };
 };
 
-async function createPatterns(): Promise<ConfiguredPattern<SessionData>[]> {
+async function createPatterns(_sessionId: string): Promise<ConfiguredPattern<SessionData>[]> {
   const tools = await Tools();
 
   // Create parallel search patterns

--- a/ui/src/lib/harness-client/examples/ontology-builder.server.ts
+++ b/ui/src/lib/harness-client/examples/ontology-builder.server.ts
@@ -163,7 +163,7 @@ const noOrphansRail: Rail<SessionData> = {
   },
 };
 
-async function createPatterns(): Promise<ConfiguredPattern<SessionData>[]> {
+async function createPatterns(_sessionId: string): Promise<ConfiguredPattern<SessionData>[]> {
   const tools = await Tools();
   const schema = await getSchema();
 

--- a/ui/src/lib/harness-client/examples/semantic-cache.server.ts
+++ b/ui/src/lib/harness-client/examples/semantic-cache.server.ts
@@ -37,7 +37,7 @@ async function getSchema(): Promise<string> {
   return result.success ? JSON.stringify(result.data) : "";
 }
 
-async function createPatterns(): Promise<ConfiguredPattern<SessionData>[]> {
+async function createPatterns(_sessionId: string): Promise<ConfiguredPattern<SessionData>[]> {
   const tools = await Tools();
   const schema = await getSchema();
 

--- a/ui/src/lib/harness-client/examples/title-generator.server.ts
+++ b/ui/src/lib/harness-client/examples/title-generator.server.ts
@@ -83,7 +83,11 @@ export const titleAgent = harness<TitleAgentData>(
     patternId: "title-gen",
     mode: "message",
     synthesize: async ({ userMessage }) => {
-      const raw = await b.GenerateConversationTitle(userMessage);
+      const { clientOverrideFor } = await import("../../harness-patterns/clients.server");
+      const titleOpts = clientOverrideFor('describe');
+      const raw = titleOpts
+        ? await b.GenerateConversationTitle(userMessage, titleOpts)
+        : await b.GenerateConversationTitle(userMessage);
       return sanitizeTitle(raw) ?? "";
     },
   }),

--- a/ui/src/lib/harness-client/registry.server.ts
+++ b/ui/src/lib/harness-client/registry.server.ts
@@ -24,8 +24,11 @@ export interface AgentConfig {
   icon: string;
   /** Server namespaces this agent uses */
   servers: string[];
-  /** Factory function that creates the pattern chain */
-  createPatterns: () => Promise<ConfiguredPattern<SessionData>[]>;
+  /** Factory function that creates the pattern chain. Receives the
+   *  sessionId so per-conversation context (e.g. code-mode's user-curated
+   *  tool allowlist) can be loaded inside the pattern closures. Most
+   *  agents accept and ignore the parameter. */
+  createPatterns: (sessionId: string) => Promise<ConfiguredPattern<SessionData>[]>;
 }
 
 // ============================================================================
@@ -80,6 +83,7 @@ export function getAgentMetadata(): Array<{
 
 // Import and register all example agents
 import { defaultAgent } from "./examples/default.server";
+import { codeModeAgent } from "./examples/code-mode.server";
 import { docAssistantAgent } from "./examples/doc-assistant.server";
 import { multiSourceResearchAgent } from "./examples/multi-source-research.server";
 import { guardrailedAgent } from "./examples/guardrailed-agent.server";
@@ -92,6 +96,7 @@ import { semanticCacheAgent } from "./examples/semantic-cache.server";
 
 // Register all agents
 registerAgent(defaultAgent);
+registerAgent(codeModeAgent);
 registerAgent(docAssistantAgent);
 registerAgent(multiSourceResearchAgent);
 registerAgent(guardrailedAgent);

--- a/ui/src/lib/harness-client/request-user.server.ts
+++ b/ui/src/lib/harness-client/request-user.server.ts
@@ -1,0 +1,28 @@
+/**
+ * Request-scoped user context for harness execution.
+ *
+ * Mirrors `settings-context.server.ts`: a tiny AsyncLocalStorage that lets
+ * pattern closures read the authenticated userId at runtime without
+ * threading it through every signature.
+ *
+ * `runTurn` (actions.server.ts) wraps its body in `runWithUserId(userId, …)`.
+ * Pattern factories that need to load per-conversation context inside their
+ * closures (e.g. code-mode reading `data.codeModeAllowedTools`) call
+ * `getRequestUserId()` at the point of execution.
+ */
+import { AsyncLocalStorage } from "node:async_hooks";
+import { assertServerOnImport } from "../harness-patterns/assert.server";
+
+assertServerOnImport();
+
+const userStore = new AsyncLocalStorage<string>();
+
+export function runWithUserId<T>(userId: string, fn: () => Promise<T>): Promise<T> {
+  return userStore.run(userId, fn);
+}
+
+/** Returns the request's userId, or null when called outside a runWithUserId
+ *  scope (e.g. background summarization). Callers must handle null. */
+export function getRequestUserId(): string | null {
+  return userStore.getStore() ?? null;
+}

--- a/ui/src/lib/harness-client/session.server.ts
+++ b/ui/src/lib/harness-client/session.server.ts
@@ -34,6 +34,11 @@ assertServerOnImport()
 
 export interface SessionData extends HarnessData, RouterData, SimpleLoopData, WithApproval {
   response?: string
+  /** User-curated allowlist for the code-mode actor's tool selection.
+   *  Undefined → fall back to the agent's hardcoded CODE_MODE_TOOLS. Set
+   *  from the Tools tab via `setCodeModeAllowedTools(sessionId, tools)`
+   *  and read live per-actor-call by code-mode.server.ts's toolNamesProvider. */
+  codeModeAllowedTools?: string[]
   [key: string]: unknown
 }
 
@@ -62,7 +67,7 @@ export async function getOrBuildPatterns(
 
   const agent = getAgent(agentId)
   if (!agent) throw new Error(`Unknown agent: ${agentId}`)
-  const patterns = await agent.createPatterns()
+  const patterns = await agent.createPatterns(sessionId)
   patternCache.set(sessionId, { agentId, patterns })
   return patterns
 }

--- a/ui/src/lib/harness-patterns/README.md
+++ b/ui/src/lib/harness-patterns/README.md
@@ -155,10 +155,10 @@ interface ConfiguredPattern<T> {
 // Controller output (standardized across all BAML controllers)
 interface ControllerAction {
   reasoning: string      // Chain-of-thought
-  tool_name: string      // Tool to call or 'Return'
+  tool_name: string      // Tool to call. simpleLoop: `'Return'` exits the loop. actorCritic: actor's `'Return'` is ignored — the critic alone owns termination.
   tool_args: string      // JSON payload
   status: string         // User-facing message
-  is_final: boolean      // Exit loop flag
+  is_final: boolean      // simpleLoop only — actorCritic ignores it on the actor side
 }
 
 // Critic result for actor-critic pattern
@@ -797,14 +797,14 @@ BAML Inputs (ActorController):
   tools        : ToolDescription[]← MCP listTools()
   attempts     : Attempt[]        ← assembled from scope events per attempt
 
-BAML Return → ControllerAction (same as simpleLoop)
+BAML Return → ControllerAction (same shape as simpleLoop; actor's `is_final` / `tool_name: 'Return'` are *not* honored — exit is the critic's call)
 
 BAML Inputs (Critic):
   intent   : string      ← same intent
   attempts : Attempt[]   ← same assembled attempts
 
 BAML Return → CriticResult:
-  is_sufficient      : bool    → if true, exits retry loop
+  is_sufficient      : bool    → sole termination signal; true exits the retry loop
   explanation        : string  → logged
   suggested_approach : string? → forwarded as next Attempt.feedback
 ```

--- a/ui/src/lib/harness-patterns/baml-adapters.server.ts
+++ b/ui/src/lib/harness-patterns/baml-adapters.server.ts
@@ -23,6 +23,7 @@ import type { ToolDescription, LoopTurn, Attempt, PriorResult, FewShot } from '.
 import { listTools as mcpListTools } from './mcp-client.server'
 import { Collector, BamlValidationError } from '@boundaryml/baml'
 import { getBamlFiles } from '../../../baml_client/inlinedbaml'
+import { clientOverrideFor } from './clients.server'
 
 assertServerOnImport()
 
@@ -339,16 +340,28 @@ export function createLoopControllerAdapter(
     const variables = { user_message, intent, tools, turns, context, turns_previous_runs: priorResults, few_shots: fewShots }
 
     // Call with or without collector.
-    // On BamlValidationError, BAML's built-in fallback won't retry (it only covers network/API
-    // errors). Manually escalate: first to GroqGPT120B (fast, reliable structured output at
-    // moderate context), then to GroqFast as a last resort.
+    //
+    // Default (no override): BAML routes the call to `ControllerAnthropic` —
+    // its declared client in `actorCritic.baml` / `simpleLoop.baml`. Anthropic
+    // models rarely fail structured output, so the manual Groq fallback below
+    // is unhelpful and would defeat the Anthropic-by-default purpose.
+    //
+    // `USE_MIXED_CHAINS=1`: `clientOverrideFor('controller')` returns
+    // `{ client: 'ControllerFallback' }`, swapping in the mixed Groq /
+    // OpenRouter / OpenAI chain. Groq's gpt-oss-120b has a known structured-
+    // output failure on turn 2+ with larger context — manual escalation to
+    // GroqGPT120B → GroqFast kicks in on `BamlValidationError` here, because
+    // BAML's built-in fallback only retries on network/API errors.
+    const clientOverride = clientOverrideFor('controller')
+    const baseOpts = { ...(collector ? { collector } : {}), ...clientOverride }
+    const hasBaseOpts = Object.keys(baseOpts).length > 0
     let action: ControllerAction
     try {
-      action = collector
-        ? await b.LoopController(user_message, intent, tools, turns, context, priorResults, fewShots, { collector })
+      action = hasBaseOpts
+        ? await b.LoopController(user_message, intent, tools, turns, context, priorResults, fewShots, baseOpts)
         : await b.LoopController(user_message, intent, tools, turns, context, priorResults, fewShots)
     } catch (e) {
-      if (!(e instanceof BamlValidationError)) {
+      if (!(e instanceof BamlValidationError) || !clientOverride) {
         throw wrapAsLLMCallError(e, 'LoopController', variables, startTime, collector)
       }
       try {
@@ -553,22 +566,30 @@ export function createActorControllerAdapter(
     }
 
     // Call with or without collector.
-    // On BamlValidationError, BAML's built-in fallback won't retry (it only
-    // covers network/API errors). Manually escalate: first to GroqGPT120B
-    // (fast, reliable structured output at moderate context), then to
-    // GroqFast as a last resort. Mirrors createLoopControllerAdapter above
-    // — without this, a single Groq structured-output failure on the very
-    // first actor call kills the whole code-mode loop with no retry (see
-    // .harness-logs/parsing-error.json). Non-validation failures (network,
-    // pre-call errors) are wrapped as LLMCallError so the catching pattern
-    // gets the captured prompt/variables for the observability panel.
+    //
+    // Default (no override): BAML routes to `ControllerAnthropic` (declared
+    // in `actorCritic.baml`). Anthropic models rarely fail structured output,
+    // so the manual Groq fallback below is skipped.
+    //
+    // `USE_MIXED_CHAINS=1`: `clientOverrideFor('controller')` swaps in
+    // `ControllerFallback` (the mixed Groq/OpenRouter/OpenAI chain). Groq's
+    // gpt-oss-120b has a known structured-output failure on turn 2+ — manual
+    // escalation to GroqGPT120B → GroqFast kicks in on `BamlValidationError`
+    // here, mirroring `createLoopControllerAdapter` above. Without this, a
+    // single failure on the first actor call would kill the loop (see
+    // `.harness-logs/parsing-error.json`). Non-validation failures (network,
+    // pre-call) are wrapped as `LLMCallError` so the observability panel
+    // keeps the captured prompt/variables drill-down.
+    const clientOverride = clientOverrideFor('controller')
+    const baseOpts = { ...(collector ? { collector } : {}), ...clientOverride }
+    const hasBaseOpts = Object.keys(baseOpts).length > 0
     let action: ControllerAction
     try {
-      action = collector
-        ? await b.ActorController(user_message, intent, tools, attempts, context, fewShots, attemptNumber, maxAttempts, { collector })
+      action = hasBaseOpts
+        ? await b.ActorController(user_message, intent, tools, attempts, context, fewShots, attemptNumber, maxAttempts, baseOpts)
         : await b.ActorController(user_message, intent, tools, attempts, context, fewShots, attemptNumber, maxAttempts)
     } catch (e) {
-      if (!(e instanceof BamlValidationError)) {
+      if (!(e instanceof BamlValidationError) || !clientOverride) {
         throw wrapAsLLMCallError(e, 'ActorController', variables, startTime, collector)
       }
       try {
@@ -627,11 +648,14 @@ export function createCriticAdapter(): CriticFnWithLLMData {
 
     const variables = { intent, attempts }
 
-    // Call with or without collector
+    // Call with or without collector. Anthropic override applied when
+    // `USE_ANTHROPIC_ONLY=1` — routes through `CriticAnthropic`.
+    const criticOpts = { ...(collector ? { collector } : {}), ...clientOverrideFor('critic') }
+    const hasCriticOpts = Object.keys(criticOpts).length > 0
     let result: CriticResult
     try {
-      result = collector
-        ? await b.Critic(intent, attempts, { collector })
+      result = hasCriticOpts
+        ? await b.Critic(intent, attempts, criticOpts)
         : await b.Critic(intent, attempts)
     } catch (e) {
       throw wrapAsLLMCallError(e, 'Critic', variables, startTime, collector)
@@ -662,7 +686,10 @@ export async function describeToolResultOp(
 ): Promise<string> {
   try {
     const { b } = await import('../../../baml_client')
-    return await b.ResultDescribe(tool, toolArgs, reasoning, result)
+    const describeOpts = clientOverrideFor('describe')
+    return describeOpts
+      ? await b.ResultDescribe(tool, toolArgs, reasoning, result, describeOpts)
+      : await b.ResultDescribe(tool, toolArgs, reasoning, result)
   } catch {
     return ''
   }

--- a/ui/src/lib/harness-patterns/baml-adapters.server.ts
+++ b/ui/src/lib/harness-patterns/baml-adapters.server.ts
@@ -258,7 +258,8 @@ function extractPromptTemplates(source: string, cache: Record<string, string>): 
 
 let toolDescCache: ToolDescription[] | null = null
 
-async function getToolDescriptions(): Promise<ToolDescription[]> {
+async function getToolDescriptions(refresh = false): Promise<ToolDescription[]> {
+  if (refresh) toolDescCache = null
   if (!toolDescCache) {
     const tools = await mcpListTools()
     toolDescCache = tools.map((t) => ({
@@ -270,11 +271,26 @@ async function getToolDescriptions(): Promise<ToolDescription[]> {
   return toolDescCache
 }
 
-/** Filter tool descriptions by tool names */
-async function filterToolDescriptions(toolNames: string[]): Promise<ToolDescription[]> {
-  const all = await getToolDescriptions()
+/** Drop the cached tool description list. Use after operations that mutate
+ *  the gateway's registered tools (e.g. the kg-agent `code-mode` factory)
+ *  so the next adapter call re-fetches a fresh listing and the LLM sees
+ *  newly-registered tools in subsequent attempts/turns. */
+export function invalidateToolDescriptions(): void {
+  toolDescCache = null
+}
+
+/** Filter tool descriptions by names plus an optional regex pattern for
+ *  dynamically-discoverable tools. `refresh: true` forces a fresh listTools()
+ *  call — needed when the toolset may have changed (e.g. the gateway created
+ *  a `code-mode-<name>` tool on a prior turn that should now be visible). */
+async function filterToolDescriptions(
+  toolNames: string[],
+  options?: { dynamicPattern?: RegExp; refresh?: boolean }
+): Promise<ToolDescription[]> {
+  const all = await getToolDescriptions(options?.refresh)
   const nameSet = new Set(toolNames)
-  return all.filter((t) => nameSet.has(t.name))
+  const pattern = options?.dynamicPattern
+  return all.filter((t) => nameSet.has(t.name) || (pattern?.test(t.name) ?? false))
 }
 
 // ============================================================================
@@ -418,41 +434,102 @@ export function annotateExpansions(refs: PriorResult[], turns: LoopTurn[]): Prio
 // Adapters for actorCritic
 // ============================================================================
 
-/** Code mode controller function that returns action + observability data */
+/** Code mode controller function that returns action + observability data.
+ *  `attemptNumber` / `maxAttempts` are passed by `actorCritic.server.ts` so the
+ *  actor's prompt can show "Attempt N of M" and prefer Return as budget runs low. */
 export type CodeModeControllerFnWithLLMData = (
   user_message: string,
   intent: string,
   available_tools: string[],
   previous_attempts: ScriptExecutionEvent[],
-  collector?: Collector
+  collector?: Collector,
+  attemptNumber?: number,
+  maxAttempts?: number
 ) => Promise<ControllerCallResult>
+
+/** Options for `createActorControllerAdapter` when the actor's toolset may
+ *  change at runtime (e.g. kg-agent's `code-mode` factory creates new tools
+ *  that should be visible to subsequent actor calls in the same session). */
+export interface ActorAdapterOptions {
+  /** Static tool names always available to the actor. Mutually exclusive
+   *  with `toolNamesProvider`; if both are set, the provider wins. */
+  toolNames?: string[]
+  /** Async closure resolved per actor invocation. Use this when the
+   *  allowlist is user-curated and may change between turns of the same
+   *  session (e.g. the code-mode agent reads `data.codeModeAllowedTools`
+   *  from the persisted conversation context). Adds one DB read per call. */
+  toolNamesProvider?: () => Promise<string[]>
+  /** Regex matched against gateway-listed tool names. Any match is added to
+   *  the actor's prompt alongside the static names. */
+  dynamicPattern?: RegExp
+  /** When true, re-list gateway tools on every actor call (instead of using
+   *  the module-level cache). Set this for agents whose toolset evolves
+   *  across turns. Adds one MCP roundtrip per actor invocation. */
+  refreshOnCall?: boolean
+  /** Optional domain-specific guidance prepended to the actor's prompt under
+   *  the `CONTEXT:` heading. Mirrors `createLoopControllerAdapter(contextPrefix)`.
+   *  Used by the code-mode agent to teach the actor about the factory
+   *  protocol, batching heuristics, etc. */
+  contextPrefix?: string
+  /** Optional FewShot examples rendered into the actor's prompt under
+   *  `EXAMPLES:`. Mirrors LoopController's few-shots. Keep small (2–4). */
+  fewShots?: FewShot[]
+}
 
 /**
  * Create a CodeModeControllerFn adapter that uses the generic ActorController.
  *
- * @param toolNames - Array of tool names available
- * @returns CodeModeControllerFnWithLLMData compatible with actorCritic pattern
+ * Two call shapes:
+ *   createActorControllerAdapter(['t1', 't2'])           // static toolset (back-compat)
+ *   createActorControllerAdapter({ toolNames, dynamicPattern, refreshOnCall })  // dynamic
+ *
+ * The dynamic form is for agents whose backend creates tools at runtime —
+ * the actor needs to see them in its prompt to call them, and a fresh
+ * listing per call ensures the LLM is aware of tools created in earlier
+ * turns of the same session (the kg-agent gateway persists them across turns).
  */
-export function createActorControllerAdapter(toolNames: string[]): CodeModeControllerFnWithLLMData {
+export function createActorControllerAdapter(
+  toolsOrOptions: string[] | ActorAdapterOptions
+): CodeModeControllerFnWithLLMData {
+  const options: ActorAdapterOptions = Array.isArray(toolsOrOptions)
+    ? { toolNames: toolsOrOptions }
+    : toolsOrOptions
+
   return async (
     user_message: string,
     intent: string,
     available_tools: string[],
     previous_attempts: ScriptExecutionEvent[],
-    collector?: Collector
+    collector?: Collector,
+    attemptNumber?: number,
+    maxAttempts?: number,
   ): Promise<ControllerCallResult> => {
     const { b } = await import('../../../baml_client')
     const startTime = Date.now()
 
-    // Get tool descriptions
-    const tools = await filterToolDescriptions(toolNames)
+    // Resolve the actor's allowlist. `toolNamesProvider` (if set) is called
+    // fresh per invocation so user-curated selections persisted to the
+    // session context surface live; otherwise fall back to the static array.
+    const names = options.toolNamesProvider
+      ? await options.toolNamesProvider()
+      : options.toolNames ?? []
 
-    // Convert ScriptExecutionEvent to Attempt format
+    // Get tool descriptions — optionally refresh + include pattern matches.
+    const tools = await filterToolDescriptions(names, {
+      dynamicPattern: options.dynamicPattern,
+      refresh: options.refreshOnCall,
+    })
+
+    // Convert ScriptExecutionEvent to Attempt format. `toolName` records the
+    // actor's actual tool_name per push — so a rejected `mcp-exec` attempt
+    // renders as `Action: mcp-exec(<bad args>)` instead of the misleading
+    // `code-mode(<empty>)` it used to show. Falls back to `'code-mode'` for
+    // legacy callers that don't set `toolName`.
     const attempts: Attempt[] = previous_attempts.map((event, i) => ({
       n: i + 1,
       action: {
         reasoning: '',
-        tool_name: 'code-mode',
+        tool_name: event.toolName ?? 'code-mode',
         tool_args: event.script,
         status: event.error ? 'error' : 'success',
         is_final: false
@@ -462,16 +539,50 @@ export function createActorControllerAdapter(toolNames: string[]): CodeModeContr
       feedback: undefined
     }))
 
-    const variables = { user_message, intent, tools, attempts }
+    const context = options.contextPrefix
+    const fewShots = options.fewShots
+    const variables = {
+      user_message,
+      intent,
+      tools,
+      attempts,
+      context,
+      few_shots: fewShots,
+      attempt_n: attemptNumber,
+      max_attempts: maxAttempts,
+    }
 
-    // Call with or without collector
+    // Call with or without collector.
+    // On BamlValidationError, BAML's built-in fallback won't retry (it only
+    // covers network/API errors). Manually escalate: first to GroqGPT120B
+    // (fast, reliable structured output at moderate context), then to
+    // GroqFast as a last resort. Mirrors createLoopControllerAdapter above
+    // — without this, a single Groq structured-output failure on the very
+    // first actor call kills the whole code-mode loop with no retry (see
+    // .harness-logs/parsing-error.json). Non-validation failures (network,
+    // pre-call errors) are wrapped as LLMCallError so the catching pattern
+    // gets the captured prompt/variables for the observability panel.
     let action: ControllerAction
     try {
       action = collector
-        ? await b.ActorController(user_message, intent, tools, attempts, { collector })
-        : await b.ActorController(user_message, intent, tools, attempts)
+        ? await b.ActorController(user_message, intent, tools, attempts, context, fewShots, attemptNumber, maxAttempts, { collector })
+        : await b.ActorController(user_message, intent, tools, attempts, context, fewShots, attemptNumber, maxAttempts)
     } catch (e) {
-      throw wrapAsLLMCallError(e, 'ActorController', variables, startTime, collector)
+      if (!(e instanceof BamlValidationError)) {
+        throw wrapAsLLMCallError(e, 'ActorController', variables, startTime, collector)
+      }
+      try {
+        action = await b.ActorController(user_message, intent, tools, attempts, context, fewShots, attemptNumber, maxAttempts, collector ? { collector, client: 'GroqGPT120B' } : { client: 'GroqGPT120B' })
+      } catch (e2) {
+        if (!(e2 instanceof BamlValidationError)) {
+          throw wrapAsLLMCallError(e2, 'ActorController', variables, startTime, collector)
+        }
+        try {
+          action = await b.ActorController(user_message, intent, tools, attempts, context, fewShots, attemptNumber, maxAttempts, collector ? { collector, client: 'GroqFast' } : { client: 'GroqFast' })
+        } catch (e3) {
+          throw wrapAsLLMCallError(e3, 'ActorController', variables, startTime, collector)
+        }
+      }
     }
 
     // Extract LLM call data if collector present
@@ -497,12 +608,14 @@ export function createCriticAdapter(): CriticFnWithLLMData {
     const { b } = await import('../../../baml_client')
     const startTime = Date.now()
 
-    // Convert ScriptExecutionEvent to Attempt format
+    // Convert ScriptExecutionEvent to Attempt format. See the actor adapter
+    // above for why `toolName` is preferred over the legacy `'code-mode'`
+    // placeholder.
     const attempts: Attempt[] = previous_attempts.map((event, i) => ({
       n: i + 1,
       action: {
         reasoning: '',
-        tool_name: 'code-mode',
+        tool_name: event.toolName ?? 'code-mode',
         tool_args: event.script,
         status: event.error ? 'error' : 'success',
         is_final: false
@@ -597,4 +710,18 @@ export function createRedisController(toolNames: string[]): ControllerFnWithLLMD
 /** Database controller */
 export function createDatabaseController(toolNames: string[]): ControllerFnWithLLMData {
   return createLoopControllerAdapter(toolNames)
+}
+
+/** Code-mode controller — drives a simpleLoop whose only tool is the MCP
+ *  `code-mode` JS executor. The contextPrefix tells the LLM to author a JS
+ *  script (passed via tool_args) that the gateway runs against the available
+ *  MCP tools, then returns the script's output as a normal tool_result. */
+export function createCodeModeController(toolNames: string[]): ControllerFnWithLLMData {
+  return createLoopControllerAdapter(
+    toolNames,
+    'You compose JavaScript that orchestrates multiple MCP tools in a single turn. ' +
+    'Call the `code-mode` tool with tool_args = { "script": "<your JS>" }. ' +
+    'The script runs server-side with access to the gateway\'s tools; its return ' +
+    'value comes back as the tool_result. Use Return when the result answers the user.'
+  )
 }

--- a/ui/src/lib/harness-patterns/clients.server.ts
+++ b/ui/src/lib/harness-patterns/clients.server.ts
@@ -1,0 +1,55 @@
+/**
+ * Client overrides — Server Only
+ *
+ * Single source of truth for per-call BAML client overrides.
+ *
+ * **Default behaviour:** every BAML function's declared client in `baml_src/`
+ * is the Anthropic-only variant (`ControllerAnthropic`, `CriticAnthropic`,
+ * etc.). The runtime override is `undefined` — no swap happens.
+ *
+ * **`USE_MIXED_CHAINS=1`:** the override returns the function's mixed-provider
+ * fallback (`ControllerFallback`, `CriticFallback`, etc.) defined in
+ * `baml_src/clients.baml`. Call sites spread the override into the BAML
+ * options bag to swap at runtime. Production deployments and occasional
+ * mixed-chain testing both go through this.
+ *
+ * Why default to Anthropic: cross-provider rate limits (Groq + OpenRouter +
+ * OpenAI) interfered too much during dev iteration of multi-turn / actorCritic
+ * scenarios. See `SCRATCHPAD.md` P1.5 for context.
+ */
+
+import { assertServerOnImport } from './assert.server'
+
+assertServerOnImport()
+
+export type BamlRole =
+  | 'controller'   // ActorController + LoopController
+  | 'critic'       // Critic
+  | 'synth'        // Synthesize
+  | 'router'       // Router
+  | 'describe'     // ResultDescribe + GenerateConversationTitle + ReferenceSelector
+
+const MIXED_CLIENT_BY_ROLE: Record<BamlRole, string> = {
+  controller: 'ControllerFallback',
+  critic: 'CriticFallback',
+  synth: 'SynthesizerFallback',
+  router: 'RouterFallback',
+  describe: 'DescribeFallback',
+}
+
+/**
+ * Returns `{ client: 'XFallback' }` when `USE_MIXED_CHAINS=1` is set,
+ * otherwise `undefined` — letting the BAML function fall through to its
+ * declared client (the Anthropic variant).
+ *
+ * Spread the result into the BAML call's options bag:
+ *   await b.ActorController(..., { ...(collector ? { collector } : {}), ...clientOverrideFor('controller') })
+ *
+ * The adapter's manual `BamlValidationError` fallback (Groq → Groq) only
+ * fires when the override IS active — it's only useful inside the mixed
+ * chain where Groq's structured-output issues actually surface.
+ */
+export function clientOverrideFor(role: BamlRole): { client: string } | undefined {
+  if (process.env.USE_MIXED_CHAINS !== '1') return undefined
+  return { client: MIXED_CLIENT_BY_ROLE[role] }
+}

--- a/ui/src/lib/harness-patterns/index.ts
+++ b/ui/src/lib/harness-patterns/index.ts
@@ -203,5 +203,8 @@ export {
   createGitHubController,
   createFilesystemController,
   createRedisController,
-  createDatabaseController
+  createDatabaseController,
+  createCodeModeController,
+  invalidateToolDescriptions,
+  type ActorAdapterOptions
 } from './baml-adapters.server'

--- a/ui/src/lib/harness-patterns/mcp-client.server.ts
+++ b/ui/src/lib/harness-patterns/mcp-client.server.ts
@@ -41,6 +41,57 @@ export async function getMcpClient(): Promise<Client> {
   return client;
 }
 
+/** Drop the singleton so the next getMcpClient() reconnects. Used by the
+ *  reconnect-once retry below when an operation fails with a transport-level
+ *  error (the gateway restarted while we held a stale connection). */
+async function resetMcpClient(): Promise<void> {
+  if (client) {
+    try {
+      await client.close();
+    } catch {
+      // best-effort; the connection is already broken
+    }
+  }
+  client = null;
+  transport = null;
+}
+
+/** Heuristic: does this error look like a dead/closed transport rather than
+ *  a tool-level failure? Covers the typical shapes that surface when the
+ *  MCP gateway restarts under us. */
+function isConnectionError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  const msg = err.message.toLowerCase();
+  return (
+    msg.includes('econnrefused') ||
+    msg.includes('econnreset') ||
+    msg.includes('socket hang up') ||
+    msg.includes('fetch failed') ||
+    msg.includes('connection closed') ||
+    msg.includes('transport') ||
+    msg.includes('terminated') ||
+    msg.includes('aborted')
+  );
+}
+
+/** Run an MCP operation with a single reconnect attempt on connection errors.
+ *  The first failure resets the client singleton; the second attempt builds a
+ *  fresh transport. If that still fails, the error is propagated.
+ *
+ *  Tool-level errors (the gateway responding with a structured failure) are
+ *  not retried — only transport-level errors trigger reconnect. */
+async function withReconnect<T>(op: (c: Client) => Promise<T>): Promise<T> {
+  try {
+    const c = await getMcpClient();
+    return await op(c);
+  } catch (err) {
+    if (!isConnectionError(err)) throw err;
+    await resetMcpClient();
+    const c = await getMcpClient();
+    return await op(c);
+  }
+}
+
 // ============================================================================
 // Tool Operations
 // ============================================================================
@@ -50,8 +101,7 @@ export async function callTool(
   args: Record<string, unknown>
 ): Promise<ToolCallResult> {
   try {
-    const c = await getMcpClient();
-    const result = await c.callTool({ name, arguments: args });
+    const result = await withReconnect((c) => c.callTool({ name, arguments: args }));
 
     // Extract text content
     if (result.content && Array.isArray(result.content)) {
@@ -101,14 +151,20 @@ function demoteErrorString(
 
 export async function listTools(): Promise<MCPToolDescription[]> {
   try {
-    const c = await getMcpClient();
-    const { tools } = await c.listTools();
+    const { tools } = await withReconnect((c) => c.listTools());
     return tools.map((t) => ({
       name: t.name,
       description: t.description ?? '',
       inputSchema: (t.inputSchema as Record<string, unknown>) ?? {}
     }));
-  } catch {
+  } catch (err) {
+    // Reconnect already tried once. If we still failed here, this is a real
+    // problem (gateway down, URL misconfigured, etc.) — log it loudly so the
+    // operator can see it. Returning [] still degrades gracefully for callers
+    // that don't want to crash on a missing tool list, but the cause is no
+    // longer hidden the way it was before this change.
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error('[mcp-client] listTools failed after reconnect:', msg);
     return [];
   }
 }

--- a/ui/src/lib/harness-patterns/patterns/actorCritic.server.ts
+++ b/ui/src/lib/harness-patterns/patterns/actorCritic.server.ts
@@ -118,17 +118,17 @@ export function actorCritic<T extends ActorCriticData>(
           actorLlmCall
         )
 
-        // Check if done (is_final flag OR tool_name === 'Return'). Return
-        // early — `break` would fall through to the "Max retries exceeded"
-        // tracker below and spuriously emit an error event even on a clean
-        // exit. (Pre-existing bug surfaced by the code-mode retry-budget test.)
-        if (action.is_final || action.tool_name === 'Return') {
-          scope.data = {
-            ...scope.data,
-            lastAction: action,
-          }
-          return scope
-        }
+        // P0 (Return-from-critic redesign): the actor used to be able to exit
+        // the loop by calling `tool_name === 'Return'` or setting `is_final`.
+        // We removed that — sufficiency-to-exit is the critic's job by
+        // definition, and the dual responsibility let the actor self-terminate
+        // with fabricated data (see `.harness-logs/one-turn-codemode.json`).
+        // If the actor still proposes `Return` (or anything else not on the
+        // allowlist), it falls through to the allowlist check below, which
+        // rejects it as "Tool not allowed: Return" and continues the loop —
+        // letting the critic actually evaluate the next real tool call.
+        // `is_final` is preserved on `ControllerAction` for backwards compat
+        // but is now advisory; nothing in the loop honours it.
 
         // Validate tool. The strict allowlist is augmented by an optional
         // `dynamicToolPattern` regex so agents whose backends create tools at

--- a/ui/src/lib/harness-patterns/patterns/actorCritic.server.ts
+++ b/ui/src/lib/harness-patterns/patterns/actorCritic.server.ts
@@ -7,7 +7,8 @@
 
 import { Collector } from '@boundaryml/baml'
 import { assertServerOnImport } from '../assert.server'
-import { callTool } from '../mcp-client.server'
+import { callTool, listTools as mcpListTools } from '../mcp-client.server'
+import { invalidateToolDescriptions } from '../baml-adapters.server'
 import { repairJson } from '../json-repair'
 import type {
   ControllerAction,
@@ -79,16 +80,32 @@ export function actorCritic<T extends ActorCriticData>(
 
     try {
       for (let attempt = 0; attempt < maxRetries; attempt++) {
-        // Get user message from view
-        const userMessage = view.messages().last(1).get()[0]
+        // Get the original user input. Use `ofType('user_message')` (not
+        // `messages()`, which also includes assistant_message) so a router or
+        // other upstream pattern emitting an intermediate `assistant_message`
+        // (e.g. a transient "Looking into that..." status) can't bump itself
+        // into the "last message" slot and end up rendered as the user's input
+        // in the actor prompt. `fromAll()` bypasses the per-pattern view scope —
+        // the user_message lives at the harness level, outside this loop's id.
+        const userMessage = view.fromAll().ofType('user_message').last(1).get()[0]
         const userContent = userMessage
           ? (userMessage.data as { content: string }).content
           : ''
         const intent = scope.data.intent ?? userContent
 
-        // Call actor
+        // Call actor. We pass `attempt + 1` (1-indexed for the prompt) and
+        // maxRetries so the actor's prompt can surface "Attempt N of M" and
+        // nudge the model toward `Return` when the budget is nearly exhausted.
         const actorCollector = new Collector('actor')
-        const { action, llmCall: actorLlmCall } = await actor(userContent, intent, availableTools, previousAttempts, actorCollector)
+        const { action, llmCall: actorLlmCall } = await actor(
+          userContent,
+          intent,
+          availableTools,
+          previousAttempts,
+          actorCollector,
+          attempt + 1,
+          maxRetries,
+        )
 
         // Track controller action with LLM call data. `turn` and `maxTurns`
         // (mapped from attempt / maxRetries) are exposed so live progress
@@ -101,21 +118,65 @@ export function actorCritic<T extends ActorCriticData>(
           actorLlmCall
         )
 
-        // Check if done (is_final flag OR tool_name === 'Return')
+        // Check if done (is_final flag OR tool_name === 'Return'). Return
+        // early — `break` would fall through to the "Max retries exceeded"
+        // tracker below and spuriously emit an error event even on a clean
+        // exit. (Pre-existing bug surfaced by the code-mode retry-budget test.)
         if (action.is_final || action.tool_name === 'Return') {
           scope.data = {
             ...scope.data,
             lastAction: action,
           }
-          break
+          return scope
         }
 
-        // Validate tool
-        if (!tools.includes(action.tool_name)) {
+        // Validate tool. The strict allowlist is augmented by an optional
+        // `dynamicToolPattern` regex so agents whose backends create tools at
+        // runtime (e.g. the kg-agent gateway's `code-mode-<name>` factory)
+        // can accept those names without enumerating them upfront. A second
+        // augmentation, `dynamicToolAllowlist`, is a per-turn callback for
+        // user-curated selections (e.g. the code-mode agent's per-conversation
+        // tool picker) — kept in sync with the adapter's `toolNamesProvider`.
+        const dynamicAllowlist = config?.dynamicToolAllowlist
+          ? await config.dynamicToolAllowlist()
+          : []
+        const allowed =
+          tools.includes(action.tool_name) ||
+          dynamicAllowlist.includes(action.tool_name) ||
+          (config?.dynamicToolPattern?.test(action.tool_name) ?? false)
+        if (!allowed) {
+          const errMsg = `Tool not allowed: ${action.tool_name}`
+          // Only surface as a visible error event when the allowlist has
+          // SOME entries — that's a real actor mistake (proposed wrong tool
+          // name). When the combined allowlist is empty, that's almost
+          // always a transient MCP gateway issue, and a per-turn flood of
+          // identical "Tool not allowed" events would spam the synth's view
+          // and observability UI without helping. The actor still sees the
+          // rejection via `previousAttempts` either way (its standard
+          // feedback channel), and the gateway-down case resolves on the
+          // next turn once `withReconnect` rebuilds the transport and
+          // `toolNamesProvider` re-resolves to a non-empty list.
+          const allowlistHasContent = tools.length > 0 || dynamicAllowlist.length > 0
+          if (allowlistHasContent) {
+            trackEvent(
+              scope,
+              'error',
+              {
+                error: errMsg,
+                severity: 'recoverable',
+                hint:
+                  'Actor proposed a tool not on the allowlist (and not matched by ' +
+                  'dynamicToolPattern / dynamicToolAllowlist).',
+                iteration: attempt,
+              } as ErrorEventData,
+              resolved.trackHistory,
+            )
+          }
           previousAttempts.push({
-            script: '',
+            toolName: action.tool_name,
+            script: action.tool_args,
             output: '',
-            error: `Tool not allowed: ${action.tool_name}`
+            error: errMsg,
           })
           continue
         }
@@ -125,10 +186,28 @@ export function actorCritic<T extends ActorCriticData>(
         try {
           args = repairJson(action.tool_args)
         } catch {
+          // Surface unparseable tool_args as a recoverable error too — same
+          // observability reasoning as the allowlist branch above.
+          const errMsg = `Invalid tool_args JSON for ${action.tool_name}: ${action.tool_args}`
+          trackEvent(
+            scope,
+            'error',
+            {
+              error: errMsg,
+              severity: 'recoverable',
+              hint:
+                'Actor produced unparseable tool_args. Common causes: unquoted ' +
+                'keys/values, unescaped newlines inside scripts. The actor will ' +
+                'see this in previousAttempts and (hopefully) retry with valid JSON.',
+              iteration: attempt,
+            } as ErrorEventData,
+            resolved.trackHistory,
+          )
           previousAttempts.push({
-            script: '',
+            toolName: action.tool_name,
+            script: action.tool_args,
             output: '',
-            error: `Invalid tool_args JSON: ${action.tool_args}`
+            error: errMsg,
           })
           continue
         }
@@ -146,6 +225,21 @@ export function actorCritic<T extends ActorCriticData>(
 
         // Execute tool
         const result = await callTool(action.tool_name, args)
+
+        // The kg-agent `code-mode` tool is a factory: a successful call
+        // registers a new tool (`code-mode-<args.name>`). Invalidate the
+        // adapter's tool-description cache so the next actor invocation
+        // re-fetches a fresh listing and includes the newly-created tool in
+        // the LLM's prompt. The gateway persists these tools across turns, so
+        // this also makes them visible to future user turns in the same session.
+        if (result.success && action.tool_name === 'code-mode') {
+          invalidateToolDescriptions()
+          try {
+            await mcpListTools()  // warm the gateway's own cache; non-fatal
+          } catch {
+            // Non-fatal — the actor can still try to invoke the new tool by name.
+          }
+        }
 
         // onToolResult hook: enrich/transform result before commit. See SimpleLoop for full doc.
         if (config?.onToolResult) {
@@ -175,6 +269,7 @@ export function actorCritic<T extends ActorCriticData>(
         // Track result
         const script = typeof args.script === 'string' ? args.script : JSON.stringify(args)
         previousAttempts.push({
+          toolName: action.tool_name,
           script,
           output: result.success ? JSON.stringify(result.data) : '',
           error: result.success ? null : (result.error ?? 'Execution failed')

--- a/ui/src/lib/harness-patterns/patterns/chain.server.ts
+++ b/ui/src/lib/harness-patterns/patterns/chain.server.ts
@@ -159,18 +159,45 @@ export function chain<T extends Record<string, unknown>>(
   return {
     name: `chain(${patterns.map(p => p.name).join(', ')})`,
     fn: async (scope, view) => {
-      let current = scope
+      // Run each sub-pattern in a fresh child scope so its events get tagged
+      // with its OWN patternId (e.g. 'code-mode-loop'), not the outer
+      // composition's auto-generated id. Without this, `view.fromLastPattern()`
+      // and `ViewConfig.fromLast: true` silently exclude the sub-pattern's
+      // events because they filter on `e.patternId === lastPatternId`.
+      //
+      // We also build a fresh EventView per sub-pattern with the correct
+      // `selfPatternId` and a synthetic context that includes events
+      // accumulated by previous sub-patterns in this same chain. Without
+      // this, a later sub-pattern's `fromLastPattern()` either sees stale
+      // ancestry (no view of its sibling's emit) or — worse — selects its
+      // OWN patternId as "last" (because the outer view was constructed
+      // for the wrapping pattern, not for the synth). Mirrors `runChain`
+      // above (chain.server.ts:60-122) and `withApproval.server.ts:93-104`.
+      const outerCtx = (view as unknown as { ctx: UnifiedContext }).ctx
+      let currentData = scope.data
       for (const pattern of patterns) {
-        current.events.push(
-          createEvent('pattern_enter', pattern.config.patternId ?? pattern.name, { pattern: pattern.name })
+        const subId = pattern.config.patternId ?? pattern.name
+        scope.events.push(
+          createEvent('pattern_enter', subId, { pattern: pattern.name })
         )
-        const result = await pattern.fn(current, view)
-        result.events.push(
-          createEvent('pattern_exit', pattern.config.patternId ?? pattern.name, { status: 'completed' })
+        // Synthetic ctx: original events + everything this chain has
+        // accumulated so far (including the pattern_enter just pushed).
+        // Read-only view — events array is freshly composed each iteration.
+        const syntheticCtx: UnifiedContext = {
+          ...outerCtx,
+          events: [...outerCtx.events, ...scope.events] as ContextEvent[],
+        }
+        const subView = createEventView(syntheticCtx, pattern.config.viewConfig, subId)
+        const childScope = createScope<T>(subId, currentData)
+        const result = await pattern.fn(childScope, subView)
+        scope.events.push(...result.events)
+        scope.events.push(
+          createEvent('pattern_exit', subId, { status: 'completed' })
         )
-        current = result
+        currentData = result.data
       }
-      return current
+      scope.data = currentData
+      return scope
     },
     config: resolved,
     estimateTurns: (s) =>

--- a/ui/src/lib/harness-patterns/patterns/guardrail.server.ts
+++ b/ui/src/lib/harness-patterns/patterns/guardrail.server.ts
@@ -14,7 +14,7 @@ import type {
   PatternConfig,
   ContextEvent
 } from '../types'
-import { trackEvent, resolveConfig, createEvent } from '../context.server'
+import { trackEvent, resolveConfig, createEvent, createScope } from '../context.server'
 
 assertServerOnImport()
 
@@ -137,23 +137,27 @@ export function guardrail<T extends Record<string, unknown>>(
           }
         }
 
-        // --- Execute wrapped pattern ---
-        const beforeLen = scope.events.length
-        const result = await pattern.fn(scope, view)
-
-        // Wrap inner pattern events with enter/exit markers
+        // --- Execute wrapped pattern in a fresh child scope ---
+        // The wrapped pattern needs its own scope so its events are tagged
+        // with its own patternId (not the guardrail's). Without this,
+        // `view.fromLastPattern()` filters the wrapped pattern's events out.
+        // Mirrors `withApproval.server.ts:93-104`.
         const innerPatternId = pattern.config.patternId ?? pattern.name
-        const innerEvents = result.events.splice(beforeLen)
-        result.events.push(createEvent('pattern_enter', innerPatternId, { pattern: pattern.name }))
-        result.events.push(...innerEvents)
-        result.events.push(createEvent('pattern_exit', innerPatternId, { status: 'completed' }))
+        const childScope = createScope(innerPatternId, scope.data) as typeof scope
+        const result = await pattern.fn(childScope, view)
+
+        // Wrap inner pattern events with enter/exit markers and merge back
+        scope.events.push(createEvent('pattern_enter', innerPatternId, { pattern: pattern.name }))
+        scope.events.push(...result.events)
+        scope.events.push(createEvent('pattern_exit', innerPatternId, { status: 'completed' }))
+        scope.data = result.data
 
         // --- Output rails ---
         for (const rail of outputRails) {
           const check = await rail.check({
             ...railCtx,
-            scope: result,
-            lastToolResult: result.events.filter((e) => e.type === 'tool_result').pop()
+            scope,
+            lastToolResult: scope.events.filter((e) => e.type === 'tool_result').pop()
           })
 
           if (!check.ok) {
@@ -170,18 +174,18 @@ export function guardrail<T extends Record<string, unknown>>(
                   // Redis may not be available
                 }
               }
-              trackEvent(result, 'error', {
+              trackEvent(scope, 'error', {
                 error: `Output rail '${rail.name}' rejected: ${check.reason}`
               }, true)
             } else if (check.action === 'warn') {
-              trackEvent(result, 'error', {
+              trackEvent(scope, 'error', {
                 error: `Output rail '${rail.name}' warning: ${check.reason}`
               }, true)
             }
           }
         }
 
-        return result
+        return scope
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error)
         trackEvent(scope, 'error', { error: msg }, true)

--- a/ui/src/lib/harness-patterns/patterns/hook.server.ts
+++ b/ui/src/lib/harness-patterns/patterns/hook.server.ts
@@ -10,7 +10,7 @@ import type {
   ConfiguredPattern,
   PatternConfig
 } from '../types'
-import { resolveConfig, createEvent } from '../context.server'
+import { resolveConfig, createEvent, createScope } from '../context.server'
 
 assertServerOnImport()
 
@@ -58,11 +58,17 @@ export function hook<T extends Record<string, unknown>>(
     name: `hook:${config.trigger}(${pattern.name})`,
     fn: async (scope, view) => {
       try {
+        const innerPatternId = pattern.config.patternId ?? pattern.name
+
         if (config.background) {
-          // Fire-and-forget: schedule for execution after response
+          // Fire-and-forget: schedule for execution after response. Uses a
+          // detached child scope so the hook's events (if anything ever
+          // reads them) are tagged with the hook's patternId, not the
+          // outer pattern's. Mirrors the sync path below.
           queueMicrotask(async () => {
             try {
-              await pattern.fn(scope, view)
+              const childScope = createScope(innerPatternId, scope.data) as typeof scope
+              await pattern.fn(childScope, view)
             } catch (e) {
               console.error(`Hook ${config.trigger} failed:`, e)
             }
@@ -70,16 +76,18 @@ export function hook<T extends Record<string, unknown>>(
           return scope
         }
 
-        // Synchronous: run and wait
-        const beforeLen = scope.events.length
-        const result = await pattern.fn(scope, view)
+        // Synchronous: run wrapped pattern in a fresh child scope so its
+        // events carry its own patternId. Without this, the wrapped
+        // pattern's events are tagged with the hook's id and become
+        // invisible to `view.fromLastPattern()`. Mirrors
+        // `withApproval.server.ts:93-104`.
+        const childScope = createScope(innerPatternId, scope.data) as typeof scope
+        const result = await pattern.fn(childScope, view)
 
-        // Wrap inner pattern events with enter/exit markers
-        const innerPatternId = pattern.config.patternId ?? pattern.name
-        const innerEvents = result.events.splice(beforeLen)
-        result.events.push(createEvent('pattern_enter', innerPatternId, { pattern: pattern.name }))
-        result.events.push(...innerEvents)
-        result.events.push(createEvent('pattern_exit', innerPatternId, { status: 'completed' }))
+        // Wrap inner pattern events with enter/exit markers and merge back
+        scope.events.push(createEvent('pattern_enter', innerPatternId, { pattern: pattern.name }))
+        scope.events.push(...result.events)
+        scope.events.push(createEvent('pattern_exit', innerPatternId, { status: 'completed' }))
         scope.data = { ...scope.data, ...result.data }
 
         return scope

--- a/ui/src/lib/harness-patterns/patterns/synthesizer.server.ts
+++ b/ui/src/lib/harness-patterns/patterns/synthesizer.server.ts
@@ -24,6 +24,7 @@ import { trackEvent, resolveConfig } from '../context.server'
 import { Collector } from '@boundaryml/baml'
 import { trimToFit, getContextWindow } from '../token-budget.server'
 import { extractFailureLLMCallData } from '../baml-adapters.server'
+import { clientOverrideFor } from '../clients.server'
 
 assertServerOnImport()
 
@@ -87,15 +88,19 @@ async function defaultSynthesize(input: SynthesizerInput, collector?: Collector)
     errorMessage: input.errorMessage
   }
 
-  // Call with or without collector, including error context
-  const content = collector
+  // Call with or without collector, including error context.
+  // Anthropic override applied when `USE_ANTHROPIC_ONLY=1` — routes through
+  // `SynthesizerAnthropic` (Sonnet 4.6 → Haiku 4.5).
+  const synthOpts = { ...(collector ? { collector } : {}), ...clientOverrideFor('synth') }
+  const hasSynthOpts = Object.keys(synthOpts).length > 0
+  const content = hasSynthOpts
     ? await b.Synthesize(
         input.userMessage,
         input.intent,
         trimmedTurns,
         input.hasError ?? false,
         input.errorMessage,
-        { collector }
+        synthOpts
       )
     : await b.Synthesize(
         input.userMessage,

--- a/ui/src/lib/harness-patterns/patterns/with-references.server.ts
+++ b/ui/src/lib/harness-patterns/patterns/with-references.server.ts
@@ -174,6 +174,7 @@ function toPriorResults(refs: ReferenceCandidate[]): PriorResult[] {
 
 const defaultSelector: SelectorFn = async (input) => {
   const { b } = await import('../../../../baml_client')
+  const { clientOverrideFor } = await import('../clients.server')
   const now = Date.now()
   const collector = new Collector('reference-selector')
   const result = await b.ReferenceSelector(
@@ -186,7 +187,7 @@ const defaultSelector: SelectorFn = async (input) => {
       tool_args: c.tool_args ?? null,
       ts_offset_s: Math.max(0, Math.floor((now - c.ts) / 1000))
     })),
-    { collector }
+    { collector, ...clientOverrideFor('describe') }
   )
   return {
     selected: result.selected.map(s => ({ ref_id: s.ref_id, reason: s.reason })),

--- a/ui/src/lib/harness-patterns/routing.server.ts
+++ b/ui/src/lib/harness-patterns/routing.server.ts
@@ -7,6 +7,7 @@
 import { assertServerOnImport } from './assert.server'
 import { Collector } from '@boundaryml/baml'
 import { extractLLMCallData } from './baml-adapters.server'
+import { clientOverrideFor } from './clients.server'
 import type { LLMCallData } from './types'
 
 assertServerOnImport()
@@ -51,8 +52,12 @@ export async function routeMessageOp(
   // Build a lookup from route names for validation
   const validRoutes = new Set(routes.map((r) => r.name))
 
-  const result = collector
-    ? await b.Router(message, routes, history, { collector })
+  // Anthropic override applied when `USE_ANTHROPIC_ONLY=1` — routes through
+  // `RouterAnthropic` (Haiku 4.5 primary, Sonnet 4.6 backstop).
+  const routerOpts = { ...(collector ? { collector } : {}), ...clientOverrideFor('router') }
+  const hasRouterOpts = Object.keys(routerOpts).length > 0
+  const result = hasRouterOpts
+    ? await b.Router(message, routes, history, routerOpts)
     : await b.Router(message, routes, history)
 
   // Extract LLM call data if collector present

--- a/ui/src/lib/harness-patterns/tools.server.ts
+++ b/ui/src/lib/harness-patterns/tools.server.ts
@@ -68,6 +68,9 @@ for (const t of [
 for (const t of ['resolve-library-id', 'get-library-docs'])
   KNOWN_TOOL_SERVERS[t] = 'context7'
 
+// Code-mode JS execution tool (kg-agent gateway built-in)
+KNOWN_TOOL_SERVERS['code-mode'] = 'code'
+
 // Web search / fetch server
 for (const t of ['search', 'fetch', 'fetch_content'])
   KNOWN_TOOL_SERVERS[t] = 'web'

--- a/ui/src/lib/harness-patterns/types.ts
+++ b/ui/src/lib/harness-patterns/types.ts
@@ -15,8 +15,14 @@ export type {
 /**
  * Script execution event for actor-critic pattern.
  * Internal type used by actorCritic to track code mode executions.
+ *
+ * `toolName` records the actor's actual `action.tool_name` so the BAML
+ * adapter can render each rejected/executed attempt with the right tool
+ * name (not a placeholder). Defaults to `'code-mode'` in the adapter when
+ * absent, preserving back-compat for legacy callers.
  */
 export interface ScriptExecutionEvent {
+  toolName?: string
   script: string
   output: string
   error?: string | null
@@ -232,6 +238,11 @@ export interface SimpleLoopConfig extends PatternConfig {
   /** Hook to enrich/transform a tool result before the `tool_result` event is
    *  committed. See `OnToolResult`. */
   onToolResult?: OnToolResult
+  /** Regex matched against `action.tool_name` after the strict allowlist
+   *  fails. Lets agents accept dynamically-created tools (e.g. the kg-agent
+   *  gateway's `code-mode-<name>` factory output) without enumerating every
+   *  possible name upfront. */
+  dynamicToolPattern?: RegExp
 }
 
 /** Configuration for actorCritic pattern */
@@ -243,6 +254,17 @@ export interface ActorCriticConfig extends PatternConfig {
   /** Hook to enrich/transform a tool result before the `tool_result` event is
    *  committed. See `OnToolResult`. */
   onToolResult?: OnToolResult
+  /** Regex matched against `action.tool_name` after the strict allowlist
+   *  fails. Lets agents accept dynamically-created tools (e.g. the kg-agent
+   *  gateway's `code-mode-<name>` factory output) without enumerating every
+   *  possible name upfront. */
+  dynamicToolPattern?: RegExp
+  /** Async closure resolved per actor invocation. Returns the live allowlist
+   *  the loop should use *in addition to* `tools` and `dynamicToolPattern`.
+   *  Mirrors `ActorAdapterOptions.toolNamesProvider` so the actor's prompt
+   *  and the loop's strict allowlist stay in sync when the user mutates the
+   *  selection mid-conversation. */
+  dynamicToolAllowlist?: () => Promise<string[]>
 }
 
 /** Synthetic tool injected into LoopController's tools list when prior results

--- a/ui/src/lib/tool-config/config.server.ts
+++ b/ui/src/lib/tool-config/config.server.ts
@@ -1,186 +1,115 @@
 /**
- * Tool Configuration State Management
+ * Tool Configuration — Per-Conversation Allowlist
  *
- * Manages execution mode, catalog selection, and tool availability
- * for the Tools tab interface.
+ * The code-mode agent's actor allowlist is curated per-conversation by the
+ * user from the Tools tab. Storage rides in the conversation's serialized
+ * UnifiedContext.data.codeModeAllowedTools field (JSONB column on the
+ * `conversations` table — see lib/db/conversations.server.ts). No new schema.
+ *
+ * Read path:   ToolsPanel resource → getCodeModeAllowedTools(sessionId)
+ * Write path:  Tools tab checkbox  → setCodeModeAllowedTools(sessionId, names)
+ * Agent path:  createPatterns(sid) builds a toolNamesProvider closure that
+ *              calls getCodeModeAllowedTools live per actor invocation
+ *              (see harness-client/examples/code-mode.server.ts).
  */
+"use server";
+
+import { deserializeContext, serializeContext } from "../harness-patterns";
+import type { UnifiedContext } from "../harness-patterns";
+import { listTools } from "../harness-patterns/mcp-client.server";
+import { loadSession, saveSession, type SessionData } from "../harness-client/session.server";
+import { getAuthenticatedUser } from "../auth/server";
+import { CODE_MODE_DEFAULTS, type CodeModeToolsState } from "./constants";
+
+// Constants and types live in ./constants because SolidStart's `"use server"`
+// transform rewrites every export from this file into an RPC stub on the
+// client — non-function exports come through as `undefined`-like, which
+// would break `MINIMAL_TOOLS.includes(...)` in ToolsPanel.tsx.
 
 // ============================================================================
-// Types (shared between client and server)
+// Auth helper (mirrors actions.server.ts:43)
 // ============================================================================
 
-/** Execution mode determines which planning flow to use */
-export type ExecutionMode = 'static' | 'code';
-
-/** Catalog mode determines which tools are available */
-export type CatalogMode = 'minimal' | 'global';
-
-/** Tool configuration state */
-export interface ToolConfig {
-  executionMode: ExecutionMode;
-  catalogMode: CatalogMode;
-  selectedTools: string[];
-}
-
-/** Default minimal tools - defined as function to avoid initialization issues */
-export function getMinimalTools(): string[] {
-  return [
-    'read_neo4j_cypher',
-    'write_neo4j_cypher',
-    'get_neo4j_schema',
-    'search',
-    'fetch_content'
-  ];
-}
-
-/** Default minimal tools constant (for client-side use) */
-export const MINIMAL_TOOLS = getMinimalTools();
-
-// ============================================================================
-// Server Functions
-// ============================================================================
-
-// Server-side state - lazily initialized to avoid SSR issues
-let _currentConfig: ToolConfig | null = null;
-
-function getCurrentConfig(): ToolConfig {
-  if (!_currentConfig) {
-    _currentConfig = {
-      executionMode: 'static',
-      catalogMode: 'minimal',
-      selectedTools: getMinimalTools()
-    };
+async function requireUser(): Promise<{ id: string }> {
+  if (import.meta.env.VITE_DEV_BYPASS_AUTH === "true") {
+    return { id: "dev-bypass-user" };
   }
-  return _currentConfig;
+  const u = await getAuthenticatedUser();
+  return { id: u.id };
 }
 
-/**
- * Get the current tool configuration
- */
-export async function getToolConfig(): Promise<ToolConfig> {
-  "use server";
-  const config = getCurrentConfig();
-  return { ...config };
-}
+// ============================================================================
+// Per-conversation allowlist
+// ============================================================================
 
 /**
- * Set the execution mode (static or code)
+ * Read the user's code-mode tool selection for a conversation, plus the live
+ * gateway tool list and the locked-on meta-tools.
+ *
+ * When the conversation has no persisted selection yet (new chat, never
+ * touched the Tools panel), `allowed` is the meta-tools default.
  */
-export async function setExecutionMode(mode: ExecutionMode): Promise<ToolConfig> {
-  "use server";
-  const config = getCurrentConfig();
-  config.executionMode = mode;
-  return { ...config };
-}
+export async function getCodeModeAllowedTools(
+  sessionId: string,
+): Promise<CodeModeToolsState> {
+  const user = await requireUser();
 
-/**
- * Set the catalog mode and update available tools
- * This triggers hot-swap via MCP Gateway
- */
-export async function setCatalogMode(mode: CatalogMode): Promise<ToolConfig> {
-  "use server";
-  const config = getCurrentConfig();
-  config.catalogMode = mode;
+  const [loaded, gateway] = await Promise.all([
+    loadSession(sessionId, user.id),
+    listTools(),
+  ]);
 
-  // When switching to minimal, reset to default minimal tools
-  if (mode === 'minimal') {
-    config.selectedTools = getMinimalTools();
+  const available = gateway.map((t) => t.name).sort();
+  const defaults = [...CODE_MODE_DEFAULTS];
+
+  let persisted: string[] | undefined;
+  if (loaded) {
+    try {
+      const ctx = deserializeContext<SessionData>(loaded.serializedContext);
+      persisted = ctx.data?.codeModeAllowedTools;
+    } catch {
+      // Corrupt blob — fall through to defaults.
+    }
   }
 
-  // Note: Actual MCP Gateway hot-swap would happen here
-  // For now, we just update the local state
-  // await hotSwapCatalog(mode);
-
-  return { ...config };
+  const allowed = persisted && persisted.length > 0 ? persisted : defaults;
+  return { allowed, available, defaults };
 }
 
 /**
- * Update selected tools
+ * Persist the user's code-mode tool selection for this conversation. Stores
+ * the array as-is on `ctx.data.codeModeAllowedTools`; the agent's runtime
+ * unions it with `CODE_MODE_DEFAULTS` so meta-tools are always reachable
+ * regardless of UI state.
+ *
+ * Throws when the conversation row doesn't exist yet (the user must send at
+ * least one message before configuring tools — the row is created by the
+ * first turn).
  */
-export async function setSelectedTools(tools: string[]): Promise<ToolConfig> {
-  "use server";
-  const config = getCurrentConfig();
-  config.selectedTools = [...tools];
-  return { ...config };
-}
-
-/**
- * Toggle a specific tool on/off
- */
-export async function toggleTool(toolName: string): Promise<ToolConfig> {
-  "use server";
-  const config = getCurrentConfig();
-
-  const index = config.selectedTools.indexOf(toolName);
-  if (index === -1) {
-    config.selectedTools.push(toolName);
-  } else {
-    config.selectedTools.splice(index, 1);
+export async function setCodeModeAllowedTools(
+  sessionId: string,
+  tools: string[],
+): Promise<void> {
+  const user = await requireUser();
+  const loaded = await loadSession(sessionId, user.id);
+  if (!loaded) {
+    throw new Error(
+      `Cannot set tool allowlist for unknown session ${sessionId}. Send a message first.`,
+    );
   }
 
-  return { ...config };
+  const ctx = deserializeContext<SessionData>(loaded.serializedContext) as UnifiedContext<SessionData>;
+  ctx.data = { ...(ctx.data ?? {}), codeModeAllowedTools: [...tools] };
+
+  await saveSession(sessionId, user.id, loaded.agentId, serializeContext(ctx));
 }
 
 /**
- * Reset to default configuration
- */
-export async function resetToolConfig(): Promise<ToolConfig> {
-  "use server";
-
-  _currentConfig = {
-    executionMode: 'static',
-    catalogMode: 'minimal',
-    selectedTools: getMinimalTools()
-  };
-
-  return { ..._currentConfig };
-}
-
-// ============================================================================
-// MCP Gateway Hot-Swap (placeholder)
-// ============================================================================
-
-/**
- * Hot-swap catalog via MCP Gateway
- * Uses mcp-add and mcp-remove to enable/disable servers without restart
- */
-export async function hotSwapCatalog(mode: CatalogMode): Promise<void> {
-  "use server";
-
-  // TODO: Implement actual MCP Gateway hot-swap
-  // This would call the MCP Gateway API to:
-  // 1. For 'global': enable all servers from catalog.yaml
-  // 2. For 'minimal': remove all except MINIMAL_TOOLS servers
-
-  console.log(`[ToolConfig] Hot-swap catalog to: ${mode}`);
-}
-
-/**
- * Get available tools from MCP Gateway
- * Returns tool names that can be selected in the UI
+ * Live list of tools the gateway exposes. Replaces the earlier hardcoded
+ * stub. Returns just the tool names; the Tools panel queries this resource
+ * directly when sessionId isn't known yet.
  */
 export async function getAvailableTools(): Promise<string[]> {
-  "use server";
-  const config = getCurrentConfig();
-
-  // TODO: Query MCP Gateway for actual available tools
-  // For now, return static list based on catalog mode
-
-  if (config.catalogMode === 'minimal') {
-    return getMinimalTools();
-  }
-
-  // Global mode - return expanded list
-  // In production, this would query the MCP Gateway
-  return [
-    ...getMinimalTools(),
-    // Additional tools would be fetched from catalog.yaml
-    'brave_search',
-    'firecrawl',
-    'github',
-    'linear',
-    'slack',
-    'notion'
-    // ... more from catalog
-  ];
+  const tools = await listTools();
+  return tools.map((t) => t.name).sort();
 }

--- a/ui/src/lib/tool-config/constants.ts
+++ b/ui/src/lib/tool-config/constants.ts
@@ -1,0 +1,49 @@
+/**
+ * Tool-config constants and types — client-safe (no "use server").
+ *
+ * These live outside `config.server.ts` because the SolidStart server-action
+ * transform rewrites every export from a `"use server"` module into an RPC
+ * stub on the client. Non-function exports (constants, types) come through
+ * as `undefined`-like proxies, which broke `MINIMAL_TOOLS.includes(...)` in
+ * `ToolsPanel.tsx`. Putting pure data here keeps the import path stable
+ * (`~/lib/tool-config` still re-exports everything) while letting the
+ * client see real arrays.
+ */
+
+/** Execution mode determines which planning flow to use. Reserved for a
+ *  future planner-switch UX; currently the mode Switch is disabled. */
+export type ExecutionMode = "static" | "code";
+
+/** Catalog mode determines which tools are available. Reserved; the
+ *  toggle is disabled since the kg-agent gateway eagerly loads all servers. */
+export type CatalogMode = "minimal" | "global";
+
+/** Snapshot returned to the Tools panel by `getCodeModeAllowedTools`. */
+export interface CodeModeToolsState {
+  /** User's current per-conversation selection. Falls back to `defaults`
+   *  when the conversation has no entry yet (e.g. first turn). */
+  allowed: string[];
+  /** Live list of every tool the gateway exposes. */
+  available: string[];
+  /** Meta-tools the actor always needs (`mcp-find`, `mcp-add`, `code-mode`,
+   *  `mcp-exec`). UI should render them pre-checked and locked-on. */
+  defaults: string[];
+}
+
+/** Default "starter set" highlighted with a `Core` badge in the UI. */
+export function getMinimalTools(): string[] {
+  return [
+    "read_neo4j_cypher",
+    "write_neo4j_cypher",
+    "get_neo4j_schema",
+    "search",
+    "fetch_content",
+  ];
+}
+
+export const MINIMAL_TOOLS = getMinimalTools();
+
+/** The four meta-tools the code-mode actor cannot function without. Mirrors
+ *  CODE_MODE_TOOLS in `harness-client/examples/code-mode.server.ts` — keep
+ *  in sync. */
+export const CODE_MODE_DEFAULTS = ["mcp-find", "mcp-add", "code-mode", "mcp-exec"];

--- a/ui/src/lib/tool-config/index.ts
+++ b/ui/src/lib/tool-config/index.ts
@@ -1,25 +1,28 @@
 /**
  * Tool Configuration Module
  *
- * Manages tool configuration and repository for the ToolsPanel UI.
+ * Per-conversation tool allowlist for the code-mode agent, plus the Neo4j-
+ * backed CodedTool repository.
  */
 
-// Config exports
+// Server-only RPC functions (each rewritten to a fetch by SolidStart)
 export {
-  getToolConfig,
-  setExecutionMode,
-  setCatalogMode,
-  setSelectedTools,
-  toggleTool,
-  resetToolConfig,
-  hotSwapCatalog,
+  getCodeModeAllowedTools,
+  setCodeModeAllowedTools,
   getAvailableTools,
+} from "./config.server";
+
+// Pure data + types — must come from a non-"use server" module so the
+// client sees real arrays and not RPC stubs (see ToolsPanel hallucination
+// log on this branch's PR thread).
+export {
   getMinimalTools,
   MINIMAL_TOOLS,
+  CODE_MODE_DEFAULTS,
   type ExecutionMode,
   type CatalogMode,
-  type ToolConfig
-} from './config.server'
+  type CodeModeToolsState,
+} from "./constants";
 
 // Repository exports
 export {
@@ -29,5 +32,5 @@ export {
   deleteCodedToolServer,
   type CodedTool,
   type CodedToolReference,
-  type SaveCodedToolInput
-} from './repository.server'
+  type SaveCodedToolInput,
+} from "./repository.server";


### PR DESCRIPTION
## Summary

Replaces the broken `code_mode` route on the default agent with a dedicated **code-mode agent** that drives the kg-agent gateway's `code-mode` factory tool. Engineering an actorCritic loop to actually converge on this workflow surfaced a number of framework bugs and an MCP transport issue; they're bundled here because the agent doesn't ship safely without them.

Closes #12 (unblocks #28 row 1.3 — the default agent's `code_mode` route is the entry point that becomes testable once the underlying agent works). Adds follow-ups #64 (execution environment) and #65 (ResultDescribe factory short-circuit).

## What's in here

**Agent (`ui/src/lib/harness-client/examples/code-mode.server.ts`):**
- actorCritic loop with engineered actor prompt — context prelude (factory protocol, batching, discovery economy, return discipline), 4 shipped few-shots, attempt-budget hints
- `maxRetries: 8` (previous default of 3 wasn't enough for the factory + exec workflow)
- Per-conversation tool allowlist via the Tools tab; persisted on the session blob and resolved fresh per actor turn so user selections surface live
- Fresh `defaultCodeTools` per turn (was a stale snapshot from agent construction)
- AsyncLocalStorage-scoped userId so the per-conversation provider can reach the session store

**Framework fixes surfaced during bring-up:**
- `chain` / `guardrail` / `hook` now create a fresh child scope per sub-pattern. Sub-events were being tagged with the composition's auto-generated id, silently breaking `view.fromLastPattern()` and the default `ViewConfig.fromLast: true` filter (synth saw empty turns and hallucinated). Mirrors the existing correct pattern in `withApproval` / `parallel` / `router` / `withReferences`.
- `actorCritic`: `return scope` instead of `break` on completion (the fall-through was emitting a spurious "Max retries exceeded" error event on clean exits).
- `actorCritic`: `view.fromAll().ofType('user_message').last(1)` instead of `view.messages().last(1)`. The router's intermediate `assistant_message` ("Looking into that…") was bumping the real user input out of the actor's prompt.
- `ActorController` BAML adapter: manual `BamlValidationError` fallback chain (GroqGPT120B → GroqFast), mirroring `createLoopControllerAdapter`. A single Groq structured-output failure no longer kills the loop with no retry. Non-validation failures still propagate through `wrapAsLLMCallError` (from #59) so the observability panel keeps the rich prompt/variables capture.
- `ScriptExecutionEvent`: tracks `toolName` per attempt so rejected attempts render with the actor's real tool name (e.g. `mcp-exec`) instead of a placeholder `code-mode`. Rejection pushes also preserve `action.tool_args` so the bad JSON is visible to the next actor turn.
- Synthesizer: `viewConfig.eventTypes` includes `'error'` so `view.hasErrors()` / `view.lastError()` surface loop exhaustion to the BAML prompt and unblock its anti-hallucination guidance.

**MCP client:**
- `withReconnect` wraps `callTool` / `listTools` — transport-level errors (gateway restart) reset the singleton and retry once. Tool-level failures still propagate unchanged.
- `invalidateToolDescriptions()` called after a successful `code-mode` factory create so the next actor turn sees the newly-registered `code-mode-<name>` runner.

**UI:**
- ToolsPanel: per-tool checklist scoped to the active conversation, wired to a server-side getter/setter pair backed by the session JSONB blob.
- `tool-config/constants.ts` split out so the constants aren't rewritten as RPC stubs by SolidStart's `"use server"` transform.

**Tests + docs:**
- `__tests__/agents/code-mode.test.ts`: factory workflow, direct-response branch, retry-budget regression (>3 turns), per-conversation allowlist passthrough, chain() scope-reuse regression (sub-events tagged with `code-mode-loop`, not the chain's auto-id).
- All `createPatterns()` call sites updated for the new `sessionId` arg.
- `code_mode_actor_critic.md`: design choices + all 7 few-shot scenarios (shipped/alternate).
- `docs/ROADMAP.md`: Skill support (deferred), code-mode execution environment #64, ResultDescribe factory short-circuit #65.

## Test plan

- [x] `pnpm test:run` — 631/631 passing (post-rebase onto #52 / #42 / #31)
- [x] `pnpm exec tsc --noEmit` — no new errors (pre-existing `BamlValidationError` mock constructor issues in `baml-adapters.test.ts` only)
- [x] Live manual run: code-mode agent against a real query ("find top-2 most-connected nodes + web-search related tech") — `.harness-logs/nodes-websearch.json`
  - Actor receives the actual user intent (not the router's "Looking into that…" status)
  - Loop converges in 6/8 attempts with valid factory create + script exec
  - Synth grounds in real data — no hallucinated nodes/connections
  - Critic correctly accepts partial result given sparse graph
- [ ] Re-test after this PR lands with a fresh MCP gateway to verify `withReconnect` rebuilds after restart
- [x] Re-test the per-conversation Tools tab toggle in two sessions in parallel (verify scope isolation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)