### PR TITLE
Compute sandbox v0: withSandbox + DockerBackend (#79)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,7 +120,7 @@ view.fromPatterns(['neo4j-query']).serialize()        // → XML for LLM
 | `ControllerAnthropic` | Tool loop controllers (simpleLoop + actor) | AnthropicSonnet46 → AnthropicHaiku45 |
 | `CriticAnthropic` | Evaluation/critique | AnthropicHaiku45 → AnthropicSonnet46 |
 | `SynthesizerAnthropic` | Response synthesis | AnthropicSonnet46 → AnthropicHaiku45 |
-| `DescribeAnthropic` | Lightweight tool result summarization | AnthropicHaiku45 |
+| `DescribeAnthropic` | Lightweight tool result summarization, titles, intent compaction (`compactIntent`) | AnthropicHaiku45 |
 
 **Mixed-provider chains** (gated by `USE_MIXED_CHAINS=1`, see top of file) — declared in `baml_src/clients.baml`:
 

--- a/docs/harness-patterns/README.md
+++ b/docs/harness-patterns/README.md
@@ -34,6 +34,7 @@ MCP Tools ───────┘
 | `actorCritic` | Generate-evaluate with retry | Code generation, file editing |
 | `router` | Intent-based dispatch | Multi-capability agents |
 | `synthesizer` | Response generation | Human-readable output |
+| `compactIntent` | Rewrite latest message → self-contained `data.intent` | Router-less multi-turn agents ([#83](https://github.com/mknw/harness-playground/issues/83)) |
 | `withApproval` | User approval gate | Write operations |
 | `withReferences` | LLM-curated prior-result attachment at pattern ingress | Cross-pattern data flow ([#30](with-references.md)) |
 | `parallel` | Concurrent execution | Multi-source search |
@@ -105,4 +106,4 @@ See [examples.md](./examples.md) for details.
 
 ---
 
-**Last Updated:** 2026-02-05
+**Last Updated:** 2026-06-15

--- a/docs/harness-patterns/api.md
+++ b/docs/harness-patterns/api.md
@@ -43,6 +43,7 @@ type EventType =
   | 'pattern_enter' | 'pattern_exit'
   | 'approval_request' | 'approval_response'
   | 'error'
+  | 'reference_attached' | 'intent_compacted'  // observability events emitted by withReferences / compactIntent
 ```
 
 ### PatternScope
@@ -236,6 +237,35 @@ interface SynthesizerConfig extends PatternConfig {
   skipIfHasResponse?: boolean
 }
 ```
+
+### compactIntent
+
+Rewrite the latest user message into a self-contained `data.intent` brief
+before a router-less actor runs, resolving bare back-references (*"try again"*,
+*"I can't find the file"*) against recent message history. The chain-based
+counterpart to `router` (which sets `data.intent` as a side-effect of
+classification). Writes the carrier `actorCritic`/`simpleLoop` already read, so
+no controller-prompt change.
+
+```typescript
+function compactIntent<T>(config?: CompactIntentConfig): ConfiguredPattern<T>
+
+type CompactIntentConfig = PatternConfig
+// Default viewConfig: { fromLast: false, fromLastNTurns: 5,
+//   eventTypes: ['user_message', 'assistant_message'] }
+```
+
+**Behavior:**
+- Calls BAML `CompactIntent` (cheap `DescribeAnthropic` client) and writes the
+  result to `scope.data.intent`.
+- **Turn 1 (no history):** skips the LLM call and passes the message through
+  unchanged.
+- **Backward-safe:** on any failure it leaves `intent` unset, so the actor falls
+  back to the raw user message — never fatal.
+- Emits an `intent_compacted` observability event (carrying the LLM call),
+  mirroring `withReferences`' `reference_attached`.
+
+Adopted by the Sandbox · Session agent ([#83](https://github.com/mknw/harness-playground/issues/83) Part A). Part E (the `compact*` naming unification) is a deferred follow-up.
 
 ### router
 
@@ -571,6 +601,7 @@ interface ViewConfig {
 | simpleLoop | `'tool_result'` | `'on-success'` |
 | actorCritic | `'tool_result'` | `'on-success'` |
 | synthesizer | `'assistant_message'` | `'always'` |
+| compactIntent | `'intent_compacted'` | `'always'` |
 | router | `false` | `'always'` |
 | chain | `false` | `'always'` |
 | withApproval | `false` | `'on-success'` |
@@ -620,4 +651,4 @@ const DEFAULT_COMMIT_STRATEGY: Record<string, CommitStrategy>
 
 ---
 
-**Last Updated:** 2026-02-05
+**Last Updated:** 2026-06-15

--- a/docs/sandbox-plan.md
+++ b/docs/sandbox-plan.md
@@ -119,10 +119,11 @@ const sandbox = await acquireOrAttach(cfg)
 return sandboxScope.run(sandbox, () => inner.fn(scope, view))
 ```
 
-The two controllers are changed **once** to consult that scope:
+The two controllers, the `callTool` dispatch layer, and the BAML adapters are changed **once** to consult that scope:
 
-- **Allowlist** — `dynamicToolAllowlist` resolves to the active sandbox's tool names, so they pass the `tools.includes(...)` guard and appear in the actor's prompt.
-- **Dispatch** — the `callTool` step checks: a tool name owned by the active sandbox routes to its in-VM transport (`connectMcp`); everything else goes to the gateway, exactly as today.
+- **Allowlist (controllers)** — both controllers extend their `tools.includes(...)` guard with `sandbox.ownsTool(...)`, so sandbox-owned tool names are accepted without the caller listing them in `tools` / `availableTools`.
+- **Dispatch (`mcp-client.callTool`)** — checks the active scope first: a tool name owned by the sandbox routes to its in-VM transport (`connectMcp`); everything else goes to the host gateway, exactly as today.
+- **Prompt (adapters in `baml-adapters.server.ts`)** — `createLoopControllerAdapter` and `createActorControllerAdapter` append the active sandbox's `listTools()` descriptions to the gateway-derived tool list, so sandbox tools appear in the actor's first-turn prompt without being threaded through the wrapped pattern's config. The allowlist change alone wouldn't accomplish this — the prompt is built at adapter time from the gateway's tool list, separately from the runtime guard.
 
 **What this buys composition:**
 
@@ -391,7 +392,7 @@ Each step de-risks the next.
 
 1. `rootfs/` Dockerfile that bundles `rust-mcp-filesystem` + JS shell-MCP + Python on `debian-slim`. Build manually; verify both MCP servers come up on stdio.
 2. `ui/src/lib/sandbox/` — `ComputeBackend` interface + `DockerBackend` implementation. `boot` / `destroy` / `connectMcp` only; no warm pool yet, no reset.
-3. `withSandbox` wrapper **+ transport-aware dispatch**: run the wrapped pattern inside an ALS sandbox scope; change `simpleLoop` + `actorCritic` (and the `callTool` layer) **once** to route sandbox-owned tool names to the in-VM transport and default `dynamicToolAllowlist` to the active sandbox. Auto-attachment only (no ID, no `fresh`) for the first cut. This step is what makes multi-controller chains share one sandbox for free (see [How tools reach the controller](#how-tools-reach-the-controller)).
+3. `withSandbox` wrapper **+ transport-aware dispatch**: run the wrapped pattern inside an ALS sandbox scope; change `simpleLoop` + `actorCritic` (allowlist guard), `mcp-client.callTool` (dispatch), and `baml-adapters.server.ts` (prompt-side tool descriptions) **once** so sandbox-owned tool names route to the in-VM transport, pass the allowlist guard, and appear in the actor's first-turn prompt — all from the ALS scope, with no per-pattern wiring. Auto-attachment only (no ID, no `fresh`) for the first cut. This step is what makes multi-controller chains share one sandbox for free (see [How tools reach the controller](#how-tools-reach-the-controller)).
 4. End-to-end integration test: `actorCritic` wrapped in `withSandbox`, agent receives "write a Python script in /work that counts words in this string and run it," reports the count back. Single Docker container, no warm pool.
 5. Warm pool (small `warmCaps`), idle eviction, scheduler caps.
 6. ID-addressable attachment + `fresh: true`.

--- a/docs/sandbox/README.md
+++ b/docs/sandbox/README.md
@@ -1,0 +1,142 @@
+# Sandbox debugging
+
+Quick reference for observing what's happening inside the compute sandbox
+([#79](https://github.com/mknw/harness-playground/issues/79)) at runtime:
+what containers exist, what's running inside them, how to peek, and how to
+clean up. Pairs with the design spec at [`docs/sandbox-plan.md`](../sandbox-plan.md).
+
+## How to identify sandbox containers
+
+Every sandbox container carries two labels (set in
+[`ui/src/lib/sandbox/docker-backend.server.ts`](../../ui/src/lib/sandbox/docker-backend.server.ts)):
+
+| Label                    | Value                       | Purpose                                          |
+|--------------------------|-----------------------------|--------------------------------------------------|
+| `kg-sandbox=1`           | always `1`                  | The family label — use for filters and reaping.  |
+| `kg-sandbox-id=<sbx-…>`  | the harness's sandbox id    | Same string as the Docker container name.        |
+
+The container name (`sbx-XXXXXXXX`) is the harness's stable id. For id-keyed
+attachments (`withSandbox({ id: sessionId })`), this id stays the same across
+the conversation's turns — the container *underneath* may change after a
+warm-pool `reset`, but the id you see in the UI's terminal prompt is stable.
+
+## See what's running
+
+```sh
+# Snapshot: name, status, age
+docker ps --filter label=kg-sandbox=1 --format 'table {{.Names}}\t{{.Status}}\t{{.RunningFor}}'
+
+# Live-updating (refreshes every 2s; Ctrl-C to exit)
+watch -n 2 'docker ps --filter label=kg-sandbox=1 --format "table {{.Names}}\t{{.Status}}"'
+
+# Resource usage (CPU, memory, I/O) — live
+docker stats --filter label=kg-sandbox=1
+
+# Include stopped ones too (useful when debugging crashes; --rm normally
+# cleans up on stop, but a fast-crashing one may still be listed briefly)
+docker ps -a --filter label=kg-sandbox=1
+```
+
+## Peek inside one
+
+```sh
+# Replace sbx-xxxx with a name from `docker ps` above.
+docker exec -it sbx-xxxx bash      # interactive shell — same thing the UI's
+                                    # Terminal tab → Shell gives you, just from
+                                    # the host CLI.
+docker exec sbx-xxxx ls -la /work  # inspect the agent's workspace
+docker exec sbx-xxxx ps -ef        # processes inside the VM
+docker logs sbx-xxxx               # mostly empty (idle host); useful only if
+                                    # mcp-shell or init.sh wrote to stderr.
+```
+
+The `/work` directory is the agent's workspace — files written via
+`sandbox_write` / `sandbox_edit` land here, the shell's `cwd` defaults here.
+Inspecting it is the fastest way to confirm "did the agent actually write
+what it claimed to write?".
+
+## Reap leftovers
+
+The harness calls `--rm` so a stop auto-removes, and on graceful shutdown the
+warm pool destroys everything. **Crashes or kill -9 can leave orphans.**
+
+```sh
+# Nuke every sandbox container (running or stopped):
+docker ps -a --filter label=kg-sandbox=1 -q | xargs -r docker rm -f
+```
+
+Safe by construction — only touches `kg-sandbox=1`-labelled containers, never
+anything else. Same command is in
+[`ui/src/lib/sandbox/scripts/README.md`](../../ui/src/lib/sandbox/scripts/README.md).
+
+## What you'll see in practice
+
+| Pattern                           | Container shape                                                       |
+|-----------------------------------|-----------------------------------------------------------------------|
+| `withSandbox({})` (anonymous)     | Boots a VM for the turn, releases back to the warm pool (cap `base:1`). |
+| `withSandbox({ id })` (session)   | Boots a VM for the chat, parked under the id between turns.           |
+| Interactive Shell (Terminal tab)  | No extra container — attaches to the *session's* VM via `docker exec -it`. |
+| `withSandbox({ fresh: true })`    | One-shot private VM, destroyed on exit (skips pool).                  |
+
+After light use you'll typically see **0 or 1 anonymous warm-pool VM** plus
+**one VM per active session id**. The lazy idle sweep destroys parked entries
+~5 min after last use, but only fires on the next sandbox action — see issue
+[#82](https://github.com/mknw/harness-playground/issues/82) for the
+timer-driven follow-up if dormant accumulation becomes an issue.
+
+## Inspecting an agent run after the fact
+
+Per-conversation context logs land under `.harness-logs/`:
+
+```
+.harness-logs/context-<sessionId>-<date>.json
+```
+
+Each is the full `UnifiedContext` for one turn — `events[]` is the timeline
+(user_message, controller_action, tool_call, tool_result, critic_result,
+pattern_enter/exit, error, assistant_message). Replay it with `jq` for a
+compact trace:
+
+```sh
+LOG=.harness-logs/context-XXXX.json
+jq -r '.events[] | [.ts, .type, .patternId, (.data.action.tool_name // .data.tool // "")] | @tsv' "$LOG"
+```
+
+Useful follow-up filters:
+
+```sh
+# Just the tool calls and what was sent / returned
+jq -r '.events[] | select(.type=="tool_call" or .type=="tool_result")' "$LOG"
+
+# Critic feedback (why the loop didn't accept)
+jq -r '.events[] | select(.type=="critic_result") | .data.result.explanation' "$LOG"
+
+# Errors only
+jq -r '.events[] | select(.type=="error") | .data.error' "$LOG"
+```
+
+## What's *not* observable today
+
+- **No in-UI fleet view.** The Terminal tab shows the *current session's*
+  activity and shell — there's no harness-wide "which sandboxes are running"
+  panel. Use the `docker ps` snippets above.
+- **No per-VM stdout history outside the agent's view.** The interactive
+  Shell has a 64KB scrollback while it's open; once disposed, the bytes are
+  gone. The agent's `tool_result` events are persisted in the conversation log
+  and survive process restart.
+- **`docker logs <sbx-…>` is usually empty.** Sandboxes are idle hosts; the
+  in-VM MCP servers and the shell stream their stdio over `docker exec`, not
+  over the container's main stdout.
+
+## Related docs
+
+- [`docs/sandbox-plan.md`](../sandbox-plan.md) — full design spec (process
+  topology, attachment model, MCP-in-VM architecture, ALS dispatch, backend
+  interface, build order).
+- [`rootfs/README.md`](../../rootfs/README.md) — how the `kg-sandbox:base`
+  image is built and what's inside.
+- [`ui/src/lib/sandbox/scripts/README.md`](../../ui/src/lib/sandbox/scripts/README.md)
+  — LLM-free and real-LLM live-container smoke scripts (`smoke-scripted.ts`,
+  `smoke-llm.ts`).
+- [`ui/src/lib/harness-patterns/README.md`](../../ui/src/lib/harness-patterns/README.md)
+  — harness patterns overview (event types, EventView, trackEvent).

--- a/flake.nix
+++ b/flake.nix
@@ -53,6 +53,15 @@
           # Keep docker config local to the repo (optional, but nice)
           export DOCKER_CONFIG="$PWD/.docker"
           mkdir -p "$DOCKER_CONFIG/cli-plugins"
+          # Bridge the system docker contexts dir into the worktree-local
+          # DOCKER_CONFIG so the active context (e.g. colima) can resolve its
+          # endpoint metadata. Without this, `docker build` / `docker run`
+          # fail from inside the nix shell with
+          # `context "colima": context not found: open .docker/contexts/meta/...`
+          # because DOCKER_CONFIG redirects context lookup to the (empty)
+          # worktree-local dir. The symlink keeps the rest of DOCKER_CONFIG
+          # worktree-local (for the nix-store-backed CLI plugins below).
+          [ -d "$HOME/.docker/contexts" ] && ln -sfn "$HOME/.docker/contexts" "$DOCKER_CONFIG/contexts"
 
           # Store-backed Docker CLI plugins
           ln -sf "${docker-mcp}/bin/docker-mcp" \

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -1,0 +1,63 @@
+# Sandbox rootfs (v0, flavor: base)
+#
+# See docs/sandbox-plan.md → "Rootfs composition (v0)". Bundles the two in-VM
+# MCP servers + a Python runtime on debian-slim:
+#
+#   /opt/mcp/rust-mcp-filesystem   filesystem MCP (read/write/edit/list/search)
+#   /opt/mcp/mcp-shell/            JS shell-exec MCP (one `bash` tool; covers Python)
+#   python3                         invoked through mcp-shell in v0
+#
+# Architecture note (MCP-in-VM): the container is a long-lived, idle host. It
+# does NOT run the MCP servers as foreground processes. Instead the harness's
+# DockerBackend.connectMcp opens one stdio transport per server by running
+# `docker exec <container> <server-cmd>` — the server's lifetime is the
+# transport's lifetime. So the container's job at boot is only to (a) prepare
+# /work and (b) stay alive. init.sh does exactly that. Stdout/stderr of the
+# server processes flow over the docker-exec stdio pipe straight to the harness.
+
+# ---- stage 1: lift the rust-mcp-filesystem binary from the pinned image ----
+# Same digest the project already trusts (configs/custom-catalog.yaml). The
+# binary is a statically-linked ELF, so it runs unmodified on debian/glibc.
+FROM mcp/rust-mcp-filesystem@sha256:77a7f6f7a477bdec2c58696c76afda8e1f88d189f7c8b935d8dd9a00ee5780c5 AS fs-mcp
+
+# ---- stage 2: the sandbox image ----
+FROM node:22-bookworm-slim AS base
+
+# Python 3 + a minimal toolchain. python3-venv/pip so the actor can install
+# packages via `sandbox_bash`. curl/ca-certificates for file ingestion
+# (curl/wget into /work) per the plan's "File ingestion in v0".
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        python3 \
+        python3-pip \
+        python3-venv \
+        ca-certificates \
+        curl \
+        bash \
+    && rm -rf /var/lib/apt/lists/*
+
+# In-VM MCP servers live under /opt/mcp.
+RUN mkdir -p /opt/mcp /work
+
+# rust-mcp-filesystem (filesystem MCP).
+COPY --from=fs-mcp /rust-mcp-filesystem /opt/mcp/rust-mcp-filesystem
+RUN chmod +x /opt/mcp/rust-mcp-filesystem
+
+# mcp-shell (JS shell-exec MCP). Install its prod deps in-image so it runs
+# offline at exec time (no network needed once built).
+COPY mcp-shell/package.json /opt/mcp/mcp-shell/package.json
+WORKDIR /opt/mcp/mcp-shell
+RUN npm install --omit=dev --no-audit --no-fund
+COPY mcp-shell/server.mjs /opt/mcp/mcp-shell/server.mjs
+RUN chmod +x /opt/mcp/mcp-shell/server.mjs
+
+# init.sh keeps the container alive and prepares /work.
+COPY init.sh /opt/mcp/init.sh
+RUN chmod +x /opt/mcp/init.sh
+
+ENV WORK_DIR=/work
+WORKDIR /work
+
+# Idle host: prepare /work, then block forever. MCP servers are spawned
+# per-connection via `docker exec` (see connectMcp).
+ENTRYPOINT ["/opt/mcp/init.sh"]

--- a/rootfs/README.md
+++ b/rootfs/README.md
@@ -39,6 +39,30 @@ The build is a two-stage Dockerfile:
 1. lift the `rust-mcp-filesystem` binary from its pinned image, then
 2. assemble `node:22-bookworm-slim` + python3 + the two MCP servers.
 
+### Inside the nix shell
+
+The repo's `flake.nix` shellHook sets `DOCKER_CONFIG=$PWD/.docker` so the
+nix-store-backed CLI plugins (`docker-mcp`, eventually `docker-model`) are
+picked up. Naively that breaks `docker build` / `docker run`, because the
+worktree-local `.docker/contexts/` is empty and the active context (typically
+`colima` on macOS) can't resolve its endpoint metadata:
+
+```
+context "colima": context not found: open .docker/contexts/meta/<hash>/meta.json
+```
+
+The shellHook bridges this by symlinking `~/.docker/contexts` into
+`$DOCKER_CONFIG/contexts`. Re-enter the nix shell after pulling this change.
+If you ever see the error above and the symlink is missing, run:
+
+```sh
+ln -sfn "$HOME/.docker/contexts" "$DOCKER_CONFIG/contexts"
+```
+
+…or as a one-off, drop the env entirely: `env -u DOCKER_CONFIG docker build ...`.
+The same applies at runtime — `DockerBackend` shells out to `docker run`, so
+`pnpm dev:exposed` from inside the nix shell relies on the same bridge.
+
 ## Verify both MCP servers come up on stdio
 
 Start an idle container:

--- a/rootfs/README.md
+++ b/rootfs/README.md
@@ -96,6 +96,16 @@ printf '%s\n' \
 docker stop "$CID"
 ```
 
+## Verifying the full chain
+
+The handshake check above exercises only the in-VM MCP layer. To verify the
+whole stack against a live container — wrapper, ALS dispatch, controller +
+adapter changes, and `DockerBackend.boot/connectMcp/destroy` — see the smoke
+scripts under [`ui/src/lib/sandbox/scripts/`](../ui/src/lib/sandbox/scripts/README.md).
+Two scripts: one with a hand-scripted actor (no LLM cost, ~340ms) and one
+driven by real Anthropic via the BAML adapters (a few cents, ~4–5s). Both
+boot a real `kg-sandbox:base` container and exit cleanly.
+
 ## Tool surface exposed to the actor
 
 The harness applies a `sandbox_` prefix when registering these (see plan

--- a/rootfs/README.md
+++ b/rootfs/README.md
@@ -1,0 +1,86 @@
+# Sandbox rootfs (`base` flavor, v0)
+
+The image definition for sandbox VMs. See [`docs/sandbox-plan.md`](../docs/sandbox-plan.md)
+→ "Rootfs composition (v0)" for the design. This is the only "code at the
+project root" the sandbox needs — there is no separate pool-manager daemon.
+
+## Contents
+
+| Path (in image) | What | Notes |
+|-----------------|------|-------|
+| `/opt/mcp/rust-mcp-filesystem` | Filesystem MCP server | Lifted from the pinned `mcp/rust-mcp-filesystem` image (same digest as `configs/custom-catalog.yaml`); statically linked, runs on debian. |
+| `/opt/mcp/mcp-shell/` | JS shell-exec MCP server (one `bash` tool) | Authored here (`mcp-shell/`); deps installed in-image. Covers Python via `python3 -c …`. |
+| `python3`, `pip`, `venv` | Python runtime | Invoked through `mcp-shell` in v0. |
+| `/work` | Agent working directory | The filesystem MCP is scoped to this; shell `cwd` defaults here. |
+| `/opt/mcp/init.sh` | Entry/launcher | Idle-host entrypoint + `serve <name>` launch path for `docker exec`. |
+
+## Architecture: MCP-in-VM (Docker model)
+
+The container is a **long-lived idle host**. It does *not* run the MCP servers
+as foreground services. The harness's `DockerBackend.connectMcp` opens one
+stdio transport per server by running:
+
+```
+docker exec -i <container> /opt/mcp/init.sh serve filesystem
+docker exec -i <container> /opt/mcp/init.sh serve shell
+```
+
+Each server's lifetime is the transport's lifetime. Stdout/stderr flow over the
+docker-exec stdio pipe straight to the harness. No port mapping, no host
+gateway involvement.
+
+## Build
+
+```sh
+docker build -t kg-sandbox:base rootfs/
+```
+
+The build is a two-stage Dockerfile:
+1. lift the `rust-mcp-filesystem` binary from its pinned image, then
+2. assemble `node:22-bookworm-slim` + python3 + the two MCP servers.
+
+## Verify both MCP servers come up on stdio
+
+Start an idle container:
+
+```sh
+CID=$(docker run -d --rm kg-sandbox:base)
+```
+
+Filesystem MCP — `initialize` + `tools/list`:
+
+```sh
+printf '%s\n' \
+  '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"probe","version":"0"}}}' \
+  '{"jsonrpc":"2.0","method":"notifications/initialized"}' \
+  '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}' \
+| docker exec -i "$CID" /opt/mcp/init.sh serve filesystem
+# → serverInfo rust-mcp-filesystem; tools/list includes read_text_file, write_file, …
+```
+
+Shell MCP — handshake + a `bash` call (also exercises Python word-count):
+
+```sh
+printf '%s\n' \
+  '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"probe","version":"0"}}}' \
+  '{"jsonrpc":"2.0","method":"notifications/initialized"}' \
+  '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}' \
+  '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"bash","arguments":{"command":"python3 -c \"print(len('one two three'.split()))\""}}}' \
+| docker exec -i "$CID" /opt/mcp/init.sh serve shell
+# → serverInfo mcp-shell; bash returns {"stdout":"3\n","exit_code":0,...}
+
+docker stop "$CID"
+```
+
+## Tool surface exposed to the actor
+
+The harness applies a `sandbox_` prefix when registering these (see plan
+→ "Tools available in v0"): `sandbox_read`, `sandbox_write`, `sandbox_edit`,
+`sandbox_list`, `sandbox_search` (filesystem) and `sandbox_bash` (shell).
+
+## Not in v0
+
+- Publishing to a registry (built locally for dev; image-publish is an ops step).
+- Heavier flavors (Polars / PyPDF / spaCy / sentence-transformers) — the v1
+  rootfs catalog ([#78](https://github.com/mknw/harness-playground/issues/78)).
+- A Rust shell-exec server (swaps in for `mcp-shell` only if cold-start is felt).

--- a/rootfs/init.sh
+++ b/rootfs/init.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Sandbox init / launcher.
+#
+# Two roles, selected by the first argument:
+#
+#   (no args)            ENTRYPOINT mode. Prepare /work and block forever so the
+#                        container is a long-lived idle host. The harness then
+#                        spawns MCP servers on demand via:
+#                            docker exec <ctr> /opt/mcp/init.sh serve <name>
+#
+#   serve filesystem     Run rust-mcp-filesystem on stdio, scoped to /work,
+#                        write enabled. Used as the docker-exec target by
+#                        DockerBackend.connectMcp.
+#
+#   serve shell          Run mcp-shell on stdio. Same purpose.
+#
+# Keeping both behind one script means connectMcp targets a single, stable
+# launch path per server (see docs/sandbox-plan.md → "How tools reach the
+# controller" / the DockerBackend exec model).
+
+set -euo pipefail
+
+WORK_DIR="${WORK_DIR:-/work}"
+mkdir -p "$WORK_DIR"
+
+cmd="${1:-}"
+
+case "$cmd" in
+  serve)
+    server="${2:-}"
+    case "$server" in
+      filesystem)
+        # Write-enabled, scoped to /work only. Stdio is the MCP transport;
+        # do NOT emit anything else to stdout.
+        exec /opt/mcp/rust-mcp-filesystem --allow-write "$WORK_DIR"
+        ;;
+      shell)
+        exec node /opt/mcp/mcp-shell/server.mjs
+        ;;
+      *)
+        echo "init.sh: unknown server '$server' (want: filesystem|shell)" >&2
+        exit 64
+        ;;
+    esac
+    ;;
+  "")
+    # Entrypoint mode: idle host. Block forever; servers come up via docker exec.
+    echo "[sandbox] init ready; /work prepared; idling (servers spawn on exec)" >&2
+    exec tail -f /dev/null
+    ;;
+  *)
+    echo "init.sh: unknown command '$cmd' (want: serve <name> | <none>)" >&2
+    exit 64
+    ;;
+esac

--- a/rootfs/mcp-shell/package.json
+++ b/rootfs/mcp-shell/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "mcp-shell",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Minimal stdio MCP server exposing a single `bash` tool for in-sandbox shell execution.",
+  "bin": {
+    "mcp-shell": "./server.mjs"
+  },
+  "scripts": {
+    "start": "node server.mjs"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "1.29.0",
+    "zod": "^3.25.0"
+  }
+}

--- a/rootfs/mcp-shell/server.mjs
+++ b/rootfs/mcp-shell/server.mjs
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+/**
+ * mcp-shell — minimal stdio MCP server exposing a single `bash` tool.
+ *
+ * Part of the sandbox rootfs (see docs/sandbox-plan.md → "Rootfs composition").
+ * Runs *inside* the sandbox VM/container; the harness reaches it over the
+ * tunneled stdio transport that `DockerBackend.connectMcp` opens. This is the
+ * v0 shell surface — it covers Python too, via `python3 -c "..."` or scripts
+ * written to /work and then executed.
+ *
+ * Deliberately tiny and dependency-light (just the MCP SDK + zod). A Rust
+ * shell-exec server is a v1 swap if cold-start ever becomes felt; until then
+ * JS is fine because cold-start is amortized per-VM-boot by the warm pool,
+ * not paid per tool call.
+ *
+ * Tool surface:
+ *   bash(command, cwd?, timeout_ms?) ->
+ *     { stdout, stderr, exit_code, timed_out }
+ *
+ * Defaults: cwd = WORK_DIR env (or /work), timeout = SHELL_TIMEOUT_MS env
+ * (or 60_000ms). The command runs through `/bin/bash -lc` so shell builtins,
+ * pipes, and `&&` work as the actor expects.
+ */
+
+import { spawn } from 'node:child_process'
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
+import { z } from 'zod'
+
+const DEFAULT_CWD = process.env.WORK_DIR || '/work'
+const DEFAULT_TIMEOUT_MS = Number(process.env.SHELL_TIMEOUT_MS || 60_000)
+const MAX_OUTPUT_BYTES = Number(process.env.SHELL_MAX_OUTPUT_BYTES || 1_000_000)
+
+/**
+ * Run a shell command, capturing stdout/stderr with a wall-clock timeout.
+ * Never throws for command-level failure — a non-zero exit is reported as
+ * data (exit_code), matching the failure-mode table in the sandbox plan
+ * ("Script bug → tool_result with non-zero exit + stderr").
+ */
+function runBash(command, cwd, timeoutMs) {
+  return new Promise((resolve) => {
+    const child = spawn('/bin/bash', ['-lc', command], {
+      cwd,
+      env: process.env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+
+    let stdout = ''
+    let stderr = ''
+    let stdoutTruncated = false
+    let stderrTruncated = false
+    let timedOut = false
+    let settled = false
+
+    const append = (buf, which) => {
+      const text = buf.toString('utf8')
+      if (which === 'out') {
+        if (stdout.length + text.length > MAX_OUTPUT_BYTES) {
+          stdout += text.slice(0, Math.max(0, MAX_OUTPUT_BYTES - stdout.length))
+          stdoutTruncated = true
+        } else {
+          stdout += text
+        }
+      } else {
+        if (stderr.length + text.length > MAX_OUTPUT_BYTES) {
+          stderr += text.slice(0, Math.max(0, MAX_OUTPUT_BYTES - stderr.length))
+          stderrTruncated = true
+        } else {
+          stderr += text
+        }
+      }
+    }
+
+    child.stdout.on('data', (b) => append(b, 'out'))
+    child.stderr.on('data', (b) => append(b, 'err'))
+
+    const timer = setTimeout(() => {
+      timedOut = true
+      child.kill('SIGKILL')
+    }, timeoutMs)
+
+    const finish = (exitCode) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      if (stdoutTruncated) stdout += '\n…[stdout truncated]'
+      if (stderrTruncated) stderr += '\n…[stderr truncated]'
+      resolve({
+        stdout,
+        stderr,
+        exit_code: exitCode,
+        timed_out: timedOut,
+      })
+    }
+
+    child.on('error', (err) => {
+      stderr += `\n[mcp-shell] spawn error: ${err instanceof Error ? err.message : String(err)}`
+      finish(-1)
+    })
+    child.on('close', (code, signal) => {
+      // SIGKILL from our timeout surfaces as null code + signal; report 124
+      // (the conventional timeout exit code) so the actor reads it cleanly.
+      finish(timedOut ? 124 : code ?? (signal ? 137 : 0))
+    })
+  })
+}
+
+const server = new McpServer({ name: 'mcp-shell', version: '0.1.0' })
+
+server.registerTool(
+  'bash',
+  {
+    description:
+      'Run a shell command inside the sandbox via `bash -lc`. Use for Python ' +
+      '(`python3 -c "..."` or run a script written to /work), package installs, ' +
+      'file inspection, and any other shell work. Returns stdout, stderr, the ' +
+      'exit code, and whether it timed out. Working directory defaults to /work.',
+    inputSchema: {
+      command: z.string().describe('The shell command to execute (passed to bash -lc).'),
+      cwd: z
+        .string()
+        .optional()
+        .describe(`Working directory. Defaults to ${DEFAULT_CWD}.`),
+      timeout_ms: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .describe(`Wall-clock timeout in milliseconds. Defaults to ${DEFAULT_TIMEOUT_MS}.`),
+    },
+  },
+  async ({ command, cwd, timeout_ms }) => {
+    const result = await runBash(
+      command,
+      cwd || DEFAULT_CWD,
+      timeout_ms || DEFAULT_TIMEOUT_MS,
+    )
+    return {
+      content: [{ type: 'text', text: JSON.stringify(result) }],
+      structuredContent: result,
+      isError: result.exit_code !== 0,
+    }
+  },
+)
+
+const transport = new StdioServerTransport()
+await server.connect(transport)
+// Keep the process alive on stdio; the transport closes it when the client
+// disconnects. A boot-time log line on stderr lets init.sh / health checks
+// confirm the server actually came up (stdout is reserved for the protocol).
+process.stderr.write('[mcp-shell] ready on stdio\n')

--- a/ui/baml_src/compact-intent.baml
+++ b/ui/baml_src/compact-intent.baml
@@ -1,0 +1,44 @@
+// CompactIntent — rewrite a user's latest message into a self-contained brief.
+//
+// Used by the `compactIntent` chain primitive (harness-patterns) upstream of a
+// router-less actor. Chain-based agents (e.g. Sandbox · Session) have no router
+// to resolve bare back-references ("try again", "I can't find the file", "now
+// in TypeScript") into a standalone instruction, so the downstream actor — which
+// only sees `scope.data.intent` plus the current turn — would otherwise act blind.
+//
+// Uses the lightweight DescribeAnthropic client (same cheap chain as the
+// background summarizer / title generator) — one call per chain invocation.
+
+function CompactIntent(
+  history: Message[],
+  latest: string
+) -> string {
+  client DescribeAnthropic
+  prompt #"
+    {{ _.role("system") }}
+    You rewrite a user's latest message into a single self-contained instruction
+    for a downstream agent that CANNOT see the conversation history.
+
+    RULES:
+    - Resolve every back-reference ("it", "that file", "the script", "try again",
+      "now in TypeScript") into concrete nouns drawn from the history.
+    - Preserve the user's actual request exactly. Do NOT answer it, add steps,
+      or widen the scope.
+    - If the latest message is already self-contained, return it essentially
+      unchanged.
+    - Output ONE imperative instruction. No preamble, no explanation, no quotes.
+
+    {% if history|length > 0 %}
+    CONVERSATION SO FAR (most recent last):
+    {% for m in history %}
+    {{ m.role|upper }}: {{ m.content }}
+
+    {% endfor %}
+    {% endif %}
+
+    {{ _.role("user") }}
+    Latest message: {{ latest }}
+
+    {{ ctx.output_format }}
+  "#
+}

--- a/ui/package.json
+++ b/ui/package.json
@@ -27,6 +27,8 @@
     "@utcp/mcp": "^1.1.1",
     "@utcp/sdk": "^1.1.0",
     "@utcp/text": "^1.1.0",
+    "@xterm/addon-fit": "^0.11.0",
+    "@xterm/xterm": "^6.0.0",
     "cytoscape": "^3.33.2",
     "marked": "^17.0.6",
     "neo4j-driver": "^6.0.1",
@@ -41,7 +43,9 @@
     "node": ">=22"
   },
   "pnpm": {
-    "onlyBuiltDependencies": ["node-pty"]
+    "onlyBuiltDependencies": [
+      "node-pty"
+    ]
   },
   "devDependencies": {
     "@boundaryml/baml": "0.219.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "baml-test": "baml-cli test",
     "baml-generate": "baml-cli generate",
+    "postinstall": "find node_modules -path '*/node-pty/prebuilds/*/spawn-helper' -exec chmod +x {} + 2>/dev/null || true",
     "dev": "vinxi dev --port 3444",
     "dev:exposed": "vinxi dev --port 3444 --host 0.0.0.0",
     "build": "pnpm baml-generate & vinxi build",
@@ -29,6 +30,7 @@
     "cytoscape": "^3.33.2",
     "marked": "^17.0.6",
     "neo4j-driver": "^6.0.1",
+    "node-pty": "^1.1.0",
     "pg": "^8.20.0",
     "solid-js": "^1.9.12",
     "unocss": "^66.6.8",
@@ -37,6 +39,9 @@
   },
   "engines": {
     "node": ">=22"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": ["node-pty"]
   },
   "devDependencies": {
     "@boundaryml/baml": "0.219.0",

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -47,6 +47,12 @@ importers:
       '@utcp/text':
         specifier: ^1.1.0
         version: 1.1.0
+      '@xterm/addon-fit':
+        specifier: ^0.11.0
+        version: 0.11.0
+      '@xterm/xterm':
+        specifier: ^6.0.0
+        version: 6.0.0
       cytoscape:
         specifier: ^3.33.2
         version: 3.33.2
@@ -2112,6 +2118,12 @@ packages:
 
   '@xstate/fsm@1.6.5':
     resolution: {integrity: sha512-b5o1I6aLNeYlU/3CPlj/Z91ybk1gUsKT+5NAJI+2W4UjvS5KLG28K9v5UvNoFVjHV8PajVZ00RH3vnjyQO7ZAw==}
+
+  '@xterm/addon-fit@0.11.0':
+    resolution: {integrity: sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==}
+
+  '@xterm/xterm@6.0.0':
+    resolution: {integrity: sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==}
 
   '@zag-js/accordion@1.40.0':
     resolution: {integrity: sha512-YDdyvZJ6fr92RZazyXQq+juT3ZA0ubjDISptb5YPgMoTPdnjKNiICPpMeCeVj1ncYRDkHXrOdChS/5CtuX/K6g==}
@@ -7687,6 +7699,10 @@ snapshots:
       tinyrainbow: 3.1.0
 
   '@xstate/fsm@1.6.5': {}
+
+  '@xterm/addon-fit@0.11.0': {}
+
+  '@xterm/xterm@6.0.0': {}
 
   '@zag-js/accordion@1.40.0':
     dependencies:

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       neo4j-driver:
         specifier: ^6.0.1
         version: 6.0.1
+      node-pty:
+        specifier: ^1.1.0
+        version: 1.1.0
       pg:
         specifier: ^8.20.0
         version: 8.20.0
@@ -3952,6 +3955,9 @@ packages:
 
   node-mock-http@1.0.4:
     resolution: {integrity: sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ==}
+
+  node-pty@1.1.0:
+    resolution: {integrity: sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==}
 
   node-releases@2.0.37:
     resolution: {integrity: sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==}
@@ -9945,6 +9951,10 @@ snapshots:
   node-gyp-build@4.8.4: {}
 
   node-mock-http@1.0.4: {}
+
+  node-pty@1.1.0:
+    dependencies:
+      node-addon-api: 7.1.1
 
   node-releases@2.0.37: {}
 

--- a/ui/src/__tests__/lib/harness-client/examples/agents.test.ts
+++ b/ui/src/__tests__/lib/harness-client/examples/agents.test.ts
@@ -240,6 +240,29 @@ describe('Agent Harnesses', () => {
     })
   })
 
+  describe('sandboxSessionAgent', () => {
+    it('should have valid config', async () => {
+      const { sandboxSessionAgent } = await import('../../../../lib/harness-client/examples/sandbox-session.server')
+      validateAgentConfig(sandboxSessionAgent)
+      expect(sandboxSessionAgent.id).toBe('sandbox-session')
+    })
+
+    it('should create patterns: compactIntent → withSandbox(actorCritic) → synthesizer', async () => {
+      const { sandboxSessionAgent } = await import('../../../../lib/harness-client/examples/sandbox-session.server')
+      const patterns = await validatePatterns(sandboxSessionAgent)
+
+      const names = patterns.map(p => p.name)
+      expect(patterns.length).toBe(3)
+      // #83: compactIntent runs first so the router-less actor gets a
+      // self-contained brief instead of a bare back-reference.
+      expect(names[0]).toBe('compactIntent')
+      expect(patterns[0].config.patternId).toBe('sandbox-session-intent')
+      expect(names[1]).toContain('withSandbox')
+      expect(names[1]).toContain('actorCritic')
+      expect(names[2]).toBe('synthesizer')
+    })
+  })
+
   describe('conversationalMemoryAgent', () => {
     it('should have valid config', async () => {
       const { conversationalMemoryAgent } = await import('../../../../lib/harness-client/examples/conversational-memory.server')

--- a/ui/src/__tests__/lib/harness-patterns/baml-adapters.test.ts
+++ b/ui/src/__tests__/lib/harness-patterns/baml-adapters.test.ts
@@ -1032,3 +1032,77 @@ describe('extractFailureLLMCallData', () => {
     expect(result.parsedOutput).toBeUndefined()
   })
 })
+
+// Build-order step 3: when a `withSandbox` wrapper is active, the adapters
+// prepend the sandbox's in-VM tool descriptions to the `tools` arg passed to
+// the BAML function, so the actor sees them in its first-turn prompt without
+// the caller threading them through `toolNames`. See docs/sandbox-plan.md →
+// "How tools reach the controller".
+describe('sandbox tool descriptions in prompt', () => {
+  function fakeTransport() {
+    return {
+      vmId: 'sbx-1',
+      toolNames: async () => ['sandbox_bash', 'sandbox_read'],
+      listTools: async () => [
+        { name: 'sandbox_bash', description: 'run a shell command', inputSchema: { type: 'object' } },
+        { name: 'sandbox_read', description: 'read a file', inputSchema: { type: 'object' } },
+      ],
+      ownsTool: (n: string) => n === 'sandbox_bash' || n === 'sandbox_read',
+      callTool: vi.fn(),
+      close: async () => {},
+    }
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockLoopController.mockResolvedValue(mockFinalAction())
+    mockActorController.mockResolvedValue(mockFinalAction())
+  })
+
+  it('prepends sandbox tools to LoopController prompt when scope is active', async () => {
+    const { createLoopControllerAdapter } = await import('../../../lib/harness-patterns/baml-adapters.server')
+    const { runWithSandbox } = await import('../../../lib/sandbox/scope.server')
+
+    const controller = createLoopControllerAdapter(['read_neo4j_cypher', 'Return'])
+
+    await runWithSandbox(fakeTransport(), () =>
+      controller('msg', 'intent', '[]', 0),
+    )
+
+    // 3rd arg of LoopController is the `tools` array.
+    const tools = mockLoopController.mock.calls[0][2] as Array<{ name: string }>
+    const names = tools.map((t) => t.name)
+    // Sandbox tools appear first (prepended).
+    expect(names.slice(0, 2)).toEqual(['sandbox_bash', 'sandbox_read'])
+    // Gateway-listed tools still present.
+    expect(names).toContain('read_neo4j_cypher')
+  })
+
+  it('does not include sandbox tools when no scope is active (LoopController)', async () => {
+    const { createLoopControllerAdapter } = await import('../../../lib/harness-patterns/baml-adapters.server')
+
+    const controller = createLoopControllerAdapter(['read_neo4j_cypher', 'Return'])
+    await controller('msg', 'intent', '[]', 0)
+
+    const tools = mockLoopController.mock.calls[0][2] as Array<{ name: string }>
+    const names = tools.map((t) => t.name)
+    expect(names).not.toContain('sandbox_bash')
+    expect(names).not.toContain('sandbox_read')
+  })
+
+  it('prepends sandbox tools to ActorController prompt when scope is active', async () => {
+    const { createActorControllerAdapter } = await import('../../../lib/harness-patterns/baml-adapters.server')
+    const { runWithSandbox } = await import('../../../lib/sandbox/scope.server')
+
+    const controller = createActorControllerAdapter(['code-mode', 'Return'])
+
+    await runWithSandbox(fakeTransport(), () =>
+      controller('msg', 'intent', [], []),
+    )
+
+    // 3rd arg of ActorController is the `tools` array.
+    const tools = mockActorController.mock.calls[0][2] as Array<{ name: string }>
+    const names = tools.map((t) => t.name)
+    expect(names.slice(0, 2)).toEqual(['sandbox_bash', 'sandbox_read'])
+  })
+})

--- a/ui/src/__tests__/lib/harness-patterns/mcp-client.test.ts
+++ b/ui/src/__tests__/lib/harness-patterns/mcp-client.test.ts
@@ -291,4 +291,66 @@ describe('mcp-client', () => {
       expect(isConnected()).toBe(true)
     })
   })
+
+  // Build-order step 3: callTool dispatches sandbox-owned tool names to the
+  // active `withSandbox` scope's in-VM transport, not the host gateway. See
+  // docs/sandbox-plan.md → "How tools reach the controller".
+  describe('callTool sandbox dispatch', () => {
+    it('routes sandbox-owned tool names to the in-VM transport, not the gateway', async () => {
+      const { callTool } = await import('../../../lib/harness-patterns/mcp-client.server')
+      const { runWithSandbox } = await import('../../../lib/sandbox/scope.server')
+
+      const sandboxCallTool = vi.fn().mockResolvedValue({ success: true, data: 'from-sandbox' })
+      const transport = {
+        vmId: 'sbx-1',
+        toolNames: async () => ['sandbox_bash'],
+        listTools: async () => [],
+        ownsTool: (n: string) => n === 'sandbox_bash',
+        callTool: sandboxCallTool,
+        close: async () => {},
+      }
+
+      const result = await runWithSandbox(transport, () =>
+        callTool('sandbox_bash', { cmd: 'echo hi' }),
+      )
+
+      expect(result).toEqual({ success: true, data: 'from-sandbox' })
+      expect(sandboxCallTool).toHaveBeenCalledWith('sandbox_bash', { cmd: 'echo hi' })
+      // Gateway path must not have been touched for a sandbox-owned tool.
+      expect(mockCallTool).not.toHaveBeenCalled()
+    })
+
+    it('falls through to the gateway for tools the sandbox does not own', async () => {
+      const { callTool } = await import('../../../lib/harness-patterns/mcp-client.server')
+      const { runWithSandbox } = await import('../../../lib/sandbox/scope.server')
+
+      const sandboxCallTool = vi.fn()
+      const transport = {
+        vmId: 'sbx-2',
+        toolNames: async () => ['sandbox_bash'],
+        listTools: async () => [],
+        ownsTool: (n: string) => n === 'sandbox_bash',
+        callTool: sandboxCallTool,
+        close: async () => {},
+      }
+
+      const result = await runWithSandbox(transport, () =>
+        callTool('neo4j_query', { cypher: 'MATCH (n) RETURN n' }),
+      )
+
+      // The gateway mock returned `{ result: 'success' }` per beforeEach.
+      expect(result.success).toBe(true)
+      expect(mockCallTool).toHaveBeenCalledOnce()
+      expect(sandboxCallTool).not.toHaveBeenCalled()
+    })
+
+    it('routes everything to the gateway outside any sandbox scope', async () => {
+      const { callTool } = await import('../../../lib/harness-patterns/mcp-client.server')
+
+      const result = await callTool('whatever', {})
+
+      expect(result.success).toBe(true)
+      expect(mockCallTool).toHaveBeenCalledOnce()
+    })
+  })
 })

--- a/ui/src/__tests__/lib/harness-patterns/patterns/compactIntent.test.ts
+++ b/ui/src/__tests__/lib/harness-patterns/patterns/compactIntent.test.ts
@@ -1,0 +1,170 @@
+/**
+ * compactIntent Pattern Tests
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { ContextEvent, EventType, UnifiedContext } from '../../../../lib/harness-patterns'
+
+// Mock server-only imports
+vi.mock('../../../../lib/harness-patterns/assert.server', () => ({
+  assertServerOnImport: vi.fn()
+}))
+
+// Mock BAML client
+vi.mock('../../../../../baml_client', () => ({
+  b: {
+    CompactIntent: vi.fn(async () => 'Locate the Fibonacci script you created earlier under /work.')
+  }
+}))
+
+// Mock Collector — must be a real class so `new Collector()` works
+vi.mock('@boundaryml/baml', () => {
+  class MockCollector {
+    last = {
+      rawLlmResponse: 'Raw response',
+      usage: { inputTokens: 40, outputTokens: 12 },
+      calls: [{ httpRequest: { body: { messages: [] } }, provider: 'anthropic', clientName: 'DescribeAnthropic' }]
+    }
+    constructor(_name?: string) {}
+  }
+  return { Collector: MockCollector }
+})
+
+type Ev = { type: EventType; ts: number; patternId: string; data: unknown }
+
+function ctxOf(events: Ev[]): UnifiedContext<Record<string, unknown>> {
+  const lastUser = events.filter(e => e.type === 'user_message').slice(-1)[0]
+  return {
+    sessionId: 'test',
+    createdAt: Date.now(),
+    events: events as ContextEvent[],
+    status: 'running',
+    data: {},
+    input: lastUser ? (lastUser.data as { content: string }).content : ''
+  }
+}
+
+const PATTERN_ID = 'compact-intent-test'
+
+async function load() {
+  const { compactIntent } = await import('../../../../lib/harness-patterns/patterns/compactIntent.server')
+  const { createScope } = await import('../../../../lib/harness-patterns/context.server')
+  const { createEventView } = await import('../../../../lib/harness-patterns/patterns')
+  const { b } = await import('../../../../../baml_client')
+  return { compactIntent, createScope, createEventView, b }
+}
+
+describe('compactIntent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('exports a factory that returns a ConfiguredPattern', async () => {
+    const { compactIntent } = await load()
+    const pattern = compactIntent({ patternId: PATTERN_ID })
+    expect(pattern.name).toBe('compactIntent')
+    expect(pattern.config.patternId).toBe(PATTERN_ID)
+    expect(typeof pattern.fn).toBe('function')
+  })
+
+  it('skips the LLM call on turn 1 (no history) and passes the message through', async () => {
+    const { compactIntent, createScope, createEventView, b } = await load()
+    const now = Date.now()
+    const ctx = ctxOf([
+      { type: 'user_message', ts: now, patternId: 'harness', data: { content: 'Write a Fibonacci script' } }
+    ])
+    const pattern = compactIntent({ patternId: PATTERN_ID })
+    const scope = createScope(PATTERN_ID, {})
+    const view = createEventView(ctx, pattern.config.viewConfig, PATTERN_ID)
+
+    const result = await pattern.fn(scope, view)
+
+    expect(b.CompactIntent).not.toHaveBeenCalled()
+    expect((result.data as { intent?: string }).intent).toBe('Write a Fibonacci script')
+    const ic = result.events.filter(e => e.type === 'intent_compacted')
+    expect(ic).toHaveLength(1)
+    expect((ic[0].data as { skipped?: string }).skipped).toBe('no-history')
+    expect((ic[0].data as { historyLength: number }).historyLength).toBe(0)
+  })
+
+  it('rewrites a back-referencing follow-up into a self-contained brief', async () => {
+    const { compactIntent, createScope, createEventView, b } = await load()
+    const now = Date.now()
+    const ctx = ctxOf([
+      { type: 'user_message', ts: now, patternId: 'harness', data: { content: 'Write a Fibonacci script to /work' } },
+      { type: 'assistant_message', ts: now + 1, patternId: 'sandbox-session-synth', data: { content: 'Done, computed fib(10).', final: true } },
+      { type: 'user_message', ts: now + 2, patternId: 'harness', data: { content: "I can't find the file" } }
+    ])
+    const pattern = compactIntent({ patternId: PATTERN_ID })
+    const scope = createScope(PATTERN_ID, {})
+    const view = createEventView(ctx, pattern.config.viewConfig, PATTERN_ID)
+
+    const result = await pattern.fn(scope, view)
+
+    expect(b.CompactIntent).toHaveBeenCalledTimes(1)
+    // history (prior messages) is the first arg, latest the second
+    const [history, latest] = vi.mocked(b.CompactIntent).mock.calls[0]
+    expect(latest).toBe("I can't find the file")
+    expect(history.length).toBe(2)
+    expect((result.data as { intent?: string }).intent).toBe(
+      'Locate the Fibonacci script you created earlier under /work.'
+    )
+    const ic = result.events.filter(e => e.type === 'intent_compacted')
+    expect(ic).toHaveLength(1)
+    expect((ic[0].data as { skipped?: string }).skipped).toBeUndefined()
+    expect((ic[0].data as { historyLength: number }).historyLength).toBe(2)
+    // LLM call observability is attached to the event
+    expect(ic[0].llmCall?.functionName).toBe('CompactIntent')
+  })
+
+  it('falls back to the raw latest message when the model returns blank', async () => {
+    const { compactIntent, createScope, createEventView, b } = await load()
+    vi.mocked(b.CompactIntent).mockResolvedValueOnce('   ')
+    const now = Date.now()
+    const ctx = ctxOf([
+      { type: 'user_message', ts: now, patternId: 'harness', data: { content: 'first' } },
+      { type: 'user_message', ts: now + 1, patternId: 'harness', data: { content: 'do the thing' } }
+    ])
+    const pattern = compactIntent({ patternId: PATTERN_ID })
+    const scope = createScope(PATTERN_ID, {})
+    const view = createEventView(ctx, pattern.config.viewConfig, PATTERN_ID)
+
+    const result = await pattern.fn(scope, view)
+
+    expect((result.data as { intent?: string }).intent).toBe('do the thing')
+  })
+
+  it('is backward-safe: leaves intent unset and tracks an error if the BAML call throws', async () => {
+    const { compactIntent, createScope, createEventView, b } = await load()
+    vi.mocked(b.CompactIntent).mockRejectedValueOnce(new Error('describe model unavailable'))
+    const now = Date.now()
+    const ctx = ctxOf([
+      { type: 'user_message', ts: now, patternId: 'harness', data: { content: 'first' } },
+      { type: 'user_message', ts: now + 1, patternId: 'harness', data: { content: 'again please' } }
+    ])
+    const pattern = compactIntent({ patternId: PATTERN_ID })
+    const scope = createScope(PATTERN_ID, {})
+    const view = createEventView(ctx, pattern.config.viewConfig, PATTERN_ID)
+
+    const result = await pattern.fn(scope, view)
+
+    expect((result.data as { intent?: string }).intent).toBeUndefined()
+    const errors = result.events.filter(e => e.type === 'error')
+    expect(errors.length).toBeGreaterThan(0)
+    expect(JSON.stringify(errors[0].data)).toContain('describe model unavailable')
+  })
+
+  it('does nothing when there is no user message in view', async () => {
+    const { compactIntent, createScope, createEventView, b } = await load()
+    const ctx = ctxOf([])
+    const pattern = compactIntent({ patternId: PATTERN_ID })
+    const scope = createScope(PATTERN_ID, {})
+    const view = createEventView(ctx, pattern.config.viewConfig, PATTERN_ID)
+
+    const result = await pattern.fn(scope, view)
+
+    expect(b.CompactIntent).not.toHaveBeenCalled()
+    expect((result.data as { intent?: string }).intent).toBeUndefined()
+    expect(result.events).toHaveLength(0)
+  })
+})

--- a/ui/src/__tests__/lib/sandbox/attachment-table.test.ts
+++ b/ui/src/__tests__/lib/sandbox/attachment-table.test.ts
@@ -1,0 +1,264 @@
+/**
+ * AttachmentTable unit tests.
+ *
+ * Hermetic — vi.fn() backend, real WarmPool. No Docker / no MCP SDK.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('../../../lib/harness-patterns/assert.server', () => ({
+  assertServerOnImport: vi.fn(),
+}))
+
+import { AttachmentTable } from '../../../lib/sandbox/attachment-table.server'
+import { WarmPool } from '../../../lib/sandbox/warm-pool.server'
+import type {
+  ComputeBackend,
+  HealthStatus,
+  McpTransport,
+  RootfsId,
+  RuntimeConfig,
+  VMHandle,
+} from '../../../lib/sandbox/types'
+
+// ---- fakes ---------------------------------------------------------------
+
+let bootCount = 0
+function makeHandle(rootfs: RootfsId = 'base'): VMHandle {
+  bootCount += 1
+  return {
+    id: `sbx-${bootCount}`,
+    backend: 'docker',
+    rootfs,
+    bootedAt: Date.now(),
+    native: { containerId: `c-${bootCount}`, runtime: {} },
+  }
+}
+
+interface FakeTransport extends McpTransport {
+  closes: number
+}
+
+function makeTransport(vmId: string): FakeTransport {
+  const t = {
+    vmId,
+    closes: 0,
+    toolNames: async () => [],
+    listTools: async () => [],
+    ownsTool: () => false,
+    callTool: async () => ({ success: true, data: null }),
+    close: async function (this: FakeTransport) {
+      this.closes += 1
+    },
+  } as FakeTransport
+  return t
+}
+
+function makeBackend(overrides: Partial<ComputeBackend> = {}): ComputeBackend {
+  const backend: ComputeBackend = {
+    kind: 'docker',
+    boot: vi.fn(async (rootfs: RootfsId, _runtime: RuntimeConfig) => makeHandle(rootfs)),
+    destroy: vi.fn(async () => undefined),
+    reset: vi.fn(async (vm: VMHandle) => {
+      ;(vm as { bootedAt: number }).bootedAt = Date.now()
+    }),
+    connectMcp: vi.fn(async (vm: VMHandle) => makeTransport(vm.id)),
+    health: vi.fn(async (): Promise<HealthStatus> => ({ state: 'healthy' })),
+    ...overrides,
+  }
+  return backend
+}
+
+beforeEach(() => {
+  bootCount = 0
+})
+
+// ---- tests ---------------------------------------------------------------
+
+describe('AttachmentTable.acquire', () => {
+  it('boots through the pool on the first acquire and stores under the id', async () => {
+    const backend = makeBackend()
+    const pool = new WarmPool(backend, { caps: { base: 1 }, idleEvictMs: 60_000 })
+    const table = new AttachmentTable(backend, pool, { idleMs: 60_000 })
+
+    const att = await table.acquire('alpha', 'base', {})
+    expect(att.id).toBe('alpha')
+    expect(att.refCount).toBe(1)
+    expect(backend.boot).toHaveBeenCalledTimes(1)
+    expect(backend.connectMcp).toHaveBeenCalledTimes(1)
+    expect(table.has('alpha')).toBe(true)
+  })
+
+  it('returns the same attachment on subsequent acquires (refCount bumped)', async () => {
+    const backend = makeBackend()
+    const pool = new WarmPool(backend, { caps: { base: 1 }, idleEvictMs: 60_000 })
+    const table = new AttachmentTable(backend, pool, { idleMs: 60_000 })
+
+    const first = await table.acquire('alpha', 'base', {})
+    const second = await table.acquire('alpha', 'base', {})
+    expect(second).toBe(first)
+    expect(first.refCount).toBe(2)
+    expect(backend.boot).toHaveBeenCalledTimes(1)
+    expect(backend.connectMcp).toHaveBeenCalledTimes(1)
+  })
+
+  it('shares the boot promise between concurrent acquires of the same id', async () => {
+    let resolveBoot: (vm: VMHandle) => void = () => {}
+    const backend = makeBackend({
+      boot: vi.fn(async () => {
+        return await new Promise<VMHandle>((resolve) => {
+          resolveBoot = resolve
+        })
+      }),
+    })
+    const pool = new WarmPool(backend, { caps: { base: 1 }, idleEvictMs: 60_000 })
+    const table = new AttachmentTable(backend, pool, { idleMs: 60_000 })
+
+    const p1 = table.acquire('alpha', 'base', {})
+    const p2 = table.acquire('alpha', 'base', {})
+    await new Promise((r) => setImmediate(r))
+    expect(backend.boot).toHaveBeenCalledTimes(1)
+
+    resolveBoot(makeHandle('base'))
+    const [a, b] = await Promise.all([p1, p2])
+    expect(a).toBe(b)
+    expect(a.refCount).toBe(2)
+  })
+
+  it('isolates attachments under different ids', async () => {
+    const backend = makeBackend()
+    const pool = new WarmPool(backend, { caps: { base: 2 }, idleEvictMs: 60_000 })
+    const table = new AttachmentTable(backend, pool, { idleMs: 60_000 })
+
+    const a = await table.acquire('alpha', 'base', {})
+    const b = await table.acquire('beta', 'base', {})
+    expect(a).not.toBe(b)
+    expect(backend.boot).toHaveBeenCalledTimes(2)
+    expect(table.size()).toBe(2)
+  })
+})
+
+describe('AttachmentTable.release', () => {
+  it('decrements refCount but leaves the entry parked when count hits zero', async () => {
+    const backend = makeBackend()
+    const pool = new WarmPool(backend, { caps: { base: 1 }, idleEvictMs: 60_000 })
+    const table = new AttachmentTable(backend, pool, { idleMs: 60_000 })
+
+    const att = await table.acquire('alpha', 'base', {})
+    table.release(att)
+    expect(att.refCount).toBe(0)
+    expect(table.has('alpha')).toBe(true)
+    // VM still alive — neither destroy nor reset called yet.
+    expect(backend.destroy).not.toHaveBeenCalled()
+    expect(backend.reset).not.toHaveBeenCalled()
+  })
+
+  it('survives an over-release (refCount floored at 0)', async () => {
+    const backend = makeBackend()
+    const pool = new WarmPool(backend, { caps: { base: 1 }, idleEvictMs: 60_000 })
+    const table = new AttachmentTable(backend, pool, { idleMs: 60_000 })
+
+    const att = await table.acquire('alpha', 'base', {})
+    table.release(att)
+    table.release(att)
+    table.release(att)
+    expect(att.refCount).toBe(0)
+  })
+
+  it('reacquire after release-to-zero bumps refCount back to 1', async () => {
+    const backend = makeBackend()
+    const pool = new WarmPool(backend, { caps: { base: 1 }, idleEvictMs: 60_000 })
+    const table = new AttachmentTable(backend, pool, { idleMs: 60_000 })
+
+    const a = await table.acquire('alpha', 'base', {})
+    table.release(a)
+    const b = await table.acquire('alpha', 'base', {})
+    expect(b).toBe(a)
+    expect(b.refCount).toBe(1)
+    expect(backend.boot).toHaveBeenCalledTimes(1) // still only the one boot
+  })
+})
+
+describe('AttachmentTable.sweepIdle', () => {
+  it('destroys refCount=0 attachments past idleMs and cascades to pool.evictIdle', async () => {
+    vi.useFakeTimers()
+    try {
+      const backend = makeBackend()
+      const pool = new WarmPool(backend, { caps: { base: 2 }, idleEvictMs: 10_000 })
+      const evictSpy = vi.spyOn(pool, 'evictIdle')
+      const table = new AttachmentTable(backend, pool, { idleMs: 10_000 })
+
+      const t0 = 1_000_000
+      vi.setSystemTime(t0)
+      const att = await table.acquire('alpha', 'base', {})
+      table.release(att)
+      expect(att.refCount).toBe(0)
+
+      // Still fresh at t0 + 5s — no eviction.
+      await table.sweepIdle(t0 + 5_000)
+      expect(table.has('alpha')).toBe(true)
+
+      // Past idleMs at t0 + 11s — evicted.
+      await table.sweepIdle(t0 + 11_000)
+      expect(table.has('alpha')).toBe(false)
+      expect(evictSpy).toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not destroy attachments still in use (refCount > 0)', async () => {
+    vi.useFakeTimers()
+    try {
+      const backend = makeBackend()
+      const pool = new WarmPool(backend, { caps: { base: 1 }, idleEvictMs: 60_000 })
+      const table = new AttachmentTable(backend, pool, { idleMs: 10_000 })
+
+      const t0 = 1_000_000
+      vi.setSystemTime(t0)
+      const att = await table.acquire('alpha', 'base', {})
+      // refCount = 1; even past idleMs, must not be evicted.
+      await table.sweepIdle(t0 + 100_000)
+      expect(table.has('alpha')).toBe(true)
+      expect(att.refCount).toBe(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
+describe('AttachmentTable.destroyById', () => {
+  it('removes the attachment regardless of refCount', async () => {
+    const backend = makeBackend()
+    const pool = new WarmPool(backend, { caps: { base: 1 }, idleEvictMs: 60_000 })
+    const table = new AttachmentTable(backend, pool, { idleMs: 60_000 })
+
+    const att = await table.acquire('alpha', 'base', {})
+    expect(att.refCount).toBe(1) // still in use
+    await table.destroyById('alpha')
+    expect(table.has('alpha')).toBe(false)
+  })
+
+  it('is a no-op on unknown id', async () => {
+    const backend = makeBackend()
+    const pool = new WarmPool(backend, { caps: { base: 1 }, idleEvictMs: 60_000 })
+    const table = new AttachmentTable(backend, pool, { idleMs: 60_000 })
+    await expect(table.destroyById('nope')).resolves.toBeUndefined()
+  })
+})
+
+describe('AttachmentTable.shutdown', () => {
+  it('destroys every attachment and empties the table', async () => {
+    const backend = makeBackend()
+    const pool = new WarmPool(backend, { caps: { base: 3 }, idleEvictMs: 60_000 })
+    const table = new AttachmentTable(backend, pool, { idleMs: 60_000 })
+
+    await table.acquire('a', 'base', {})
+    await table.acquire('b', 'base', {})
+    await table.acquire('c', 'base', {})
+    expect(table.size()).toBe(3)
+
+    await table.shutdown()
+    expect(table.size()).toBe(0)
+  })
+})

--- a/ui/src/__tests__/lib/sandbox/docker-backend.test.ts
+++ b/ui/src/__tests__/lib/sandbox/docker-backend.test.ts
@@ -4,7 +4,8 @@
  * Hermetic — `node:child_process` spawn and the MCP SDK client/transport are
  * mocked so no real Docker engine is required. Covers boot arg construction,
  * destroy idempotency, health states, connectMcp tool routing/prefixing, and
- * the reset-not-implemented contract (build-order step 2 scope).
+ * the warm-pool recycle contract (destroy + boot fresh, handle mutated in
+ * place with stable vm.id and preserved RuntimeConfig).
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
@@ -248,10 +249,102 @@ describe('DockerBackend.connectMcp', () => {
 })
 
 describe('DockerBackend.reset', () => {
-  it('throws — warm-pool recycle is build-order step 5', async () => {
+  it('destroys the old container and boots a fresh one (warm-pool recycle)', async () => {
+    let bootCount = 0
+    spawnPlan = (cmd, args) => {
+      if (args[0] === 'run') {
+        bootCount += 1
+        return { stdout: `container-${bootCount}`, code: 0 }
+      }
+      return { stdout: 'ok', code: 0 }
+    }
+    const backend = await makeBackend()
+    const handle = await backend.boot('base', {})
+    expect((handle.native as { containerId: string }).containerId).toBe('container-1')
+    const originalId = handle.id
+
+    spawnCalls.length = 0
+    await backend.reset(handle)
+
+    // Two docker calls: rm old, then run new.
+    const rm = spawnCalls.find((c) => c.args[0] === 'rm')!
+    expect(rm.args).toEqual(['rm', '-f', 'container-1'])
+    const run = spawnCalls.find((c) => c.args[0] === 'run')!
+    expect(run.args).toContain('-d')
+    expect(run.args).toContain('--rm')
+
+    // Handle mutated in place: sandbox id stable, container id swapped.
+    expect(handle.id).toBe(originalId)
+    expect((handle.native as { containerId: string }).containerId).toBe('container-2')
+  })
+
+  it('preserves the runtime config across the recycle', async () => {
+    let bootCount = 0
+    spawnPlan = (cmd, args) => {
+      if (args[0] === 'run') {
+        bootCount += 1
+        return { stdout: `container-${bootCount}`, code: 0 }
+      }
+      return { stdout: 'ok', code: 0 }
+    }
+    const backend = await makeBackend()
+    const handle = await backend.boot('base', { cpus: 2, memoryMB: 512, egress: 'open' })
+
+    spawnCalls.length = 0
+    await backend.reset(handle)
+
+    const run = spawnCalls.find((c) => c.args[0] === 'run')!
+    expect(run.args).toContain('--cpus')
+    expect(run.args).toContain('2')
+    expect(run.args).toContain('--memory')
+    expect(run.args).toContain('512m')
+    // egress: 'open' ⇒ no --network none
+    expect(run.args).not.toContain('none')
+    // Container is renamed to the same sandbox id so the slot is stable.
+    const nameIdx = run.args.indexOf('--name')
+    expect(run.args[nameIdx + 1]).toBe(handle.id)
+  })
+
+  it('updates bootedAt to the recycle time', async () => {
     spawnPlan = () => ({ stdout: 'cid', code: 0 })
     const backend = await makeBackend()
     const handle = await backend.boot('base', {})
-    await expect(backend.reset(handle)).rejects.toThrow(/step 5/)
+    const firstBootedAt = handle.bootedAt
+    // Sleep a tick so Date.now() advances past firstBootedAt; vitest's clock
+    // resolution is enough that this is reliable.
+    await new Promise((r) => setTimeout(r, 2))
+    await backend.reset(handle)
+    expect(handle.bootedAt).toBeGreaterThan(firstBootedAt)
+  })
+
+  it('proceeds when the old container is already gone (rm failure is swallowed)', async () => {
+    let runCount = 0
+    spawnPlan = (cmd, args) => {
+      if (args[0] === 'rm') return { stderr: 'No such container', code: 1 }
+      if (args[0] === 'run') {
+        runCount += 1
+        return { stdout: `container-${runCount}`, code: 0 }
+      }
+      return { stdout: '', code: 0 }
+    }
+    const backend = await makeBackend()
+    const handle = await backend.boot('base', {})
+    await expect(backend.reset(handle)).resolves.toBeUndefined()
+    expect((handle.native as { containerId: string }).containerId).toBe('container-2')
+  })
+
+  it('throws SandboxBootError when the reboot fails', async () => {
+    let runCount = 0
+    spawnPlan = (cmd, args) => {
+      if (args[0] === 'run') {
+        runCount += 1
+        if (runCount === 2) return { stderr: 'image missing', code: 1 }
+        return { stdout: 'container-1', code: 0 }
+      }
+      return { stdout: 'ok', code: 0 }
+    }
+    const backend = await makeBackend()
+    const handle = await backend.boot('base', {})
+    await expect(backend.reset(handle)).rejects.toThrow(/boot failed/)
   })
 })

--- a/ui/src/__tests__/lib/sandbox/docker-backend.test.ts
+++ b/ui/src/__tests__/lib/sandbox/docker-backend.test.ts
@@ -1,0 +1,257 @@
+/**
+ * DockerBackend unit tests.
+ *
+ * Hermetic — `node:child_process` spawn and the MCP SDK client/transport are
+ * mocked so no real Docker engine is required. Covers boot arg construction,
+ * destroy idempotency, health states, connectMcp tool routing/prefixing, and
+ * the reset-not-implemented contract (build-order step 2 scope).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { EventEmitter } from 'node:events'
+
+// server-only guard is a no-op in tests
+vi.mock('../../../lib/harness-patterns/assert.server', () => ({
+  assertServerOnImport: vi.fn(),
+}))
+
+// ---- mock node:child_process.spawn ---------------------------------------
+// Each spawn returns a fake child whose behavior is programmed per-test via
+// `spawnScript`. The script receives the argv and returns { stdout, code }.
+type SpawnPlan = (cmd: string, args: string[]) => { stdout?: string; stderr?: string; code?: number }
+let spawnPlan: SpawnPlan = () => ({ stdout: '', code: 0 })
+const spawnCalls: Array<{ cmd: string; args: string[] }> = []
+
+function mockSpawn(cmd: string, args: string[]) {
+  spawnCalls.push({ cmd, args })
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter
+    stderr: EventEmitter
+    kill: () => void
+  }
+  child.stdout = new EventEmitter()
+  child.stderr = new EventEmitter()
+  child.kill = () => {}
+  const plan = spawnPlan(cmd, args)
+  // Emit asynchronously so listeners are attached first.
+  queueMicrotask(() => {
+    if (plan.stdout) child.stdout.emit('data', Buffer.from(plan.stdout))
+    if (plan.stderr) child.stderr.emit('data', Buffer.from(plan.stderr))
+    child.emit('close', plan.code ?? 0)
+  })
+  return child
+}
+
+vi.mock('node:child_process', () => ({
+  spawn: mockSpawn,
+  default: { spawn: mockSpawn },
+}))
+
+// ---- mock the MCP SDK client + stdio transport ---------------------------
+// connectMcp opens one client per in-VM server; we give each a fixed
+// listTools result keyed by the launch argv, and record callTool dispatch.
+const callToolCalls: Array<{ server: string; name: string; args: unknown }> = []
+let lastTransportArgs: string[][] = []
+
+vi.mock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
+  StdioClientTransport: class {
+    args: string[]
+    constructor(opts: { args: string[] }) {
+      this.args = opts.args
+      lastTransportArgs.push(opts.args)
+    }
+  },
+}))
+
+vi.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
+  Client: class {
+    private serverKey = 'unknown'
+    async connect(transport: { args: string[] }) {
+      // launch argv is [..., 'serve', '<key>']
+      this.serverKey = transport.args[transport.args.length - 1]
+    }
+    async listTools() {
+      if (this.serverKey === 'filesystem') {
+        return {
+          tools: [
+            { name: 'read_text_file', description: 'read', inputSchema: { type: 'object' } },
+            { name: 'write_file', description: 'write', inputSchema: { type: 'object' } },
+            { name: 'edit_file', description: 'edit', inputSchema: { type: 'object' } },
+            { name: 'list_directory', description: 'list', inputSchema: { type: 'object' } },
+            { name: 'search_files_content', description: 'search', inputSchema: { type: 'object' } },
+            { name: 'directory_tree', description: 'not exposed', inputSchema: {} },
+          ],
+        }
+      }
+      if (this.serverKey === 'shell') {
+        return { tools: [{ name: 'bash', description: 'shell', inputSchema: { type: 'object' } }] }
+      }
+      return { tools: [] }
+    }
+    async callTool({ name, arguments: args }: { name: string; arguments: unknown }) {
+      callToolCalls.push({ server: this.serverKey, name, args })
+      if (name === 'bash') {
+        return {
+          content: [{ type: 'text', text: JSON.stringify({ stdout: '3\n', exit_code: 0 }) }],
+          structuredContent: { stdout: '3\n', exit_code: 0 },
+          isError: false,
+        }
+      }
+      return { content: [{ type: 'text', text: 'ok' }], isError: false }
+    }
+    async close() {}
+  },
+}))
+
+beforeEach(() => {
+  spawnCalls.length = 0
+  callToolCalls.length = 0
+  lastTransportArgs = []
+  spawnPlan = () => ({ stdout: '', code: 0 })
+})
+
+async function makeBackend() {
+  const mod = await import('../../../lib/sandbox/docker-backend.server')
+  return new mod.DockerBackend()
+}
+
+describe('DockerBackend.boot', () => {
+  it('runs a detached, auto-removed, network-none container by default (mcp-only egress)', async () => {
+    spawnPlan = () => ({ stdout: 'container-abc123', code: 0 })
+    const backend = await makeBackend()
+    const handle = await backend.boot('base', {})
+
+    expect(handle.backend).toBe('docker')
+    expect(handle.rootfs).toBe('base')
+    expect(handle.id).toMatch(/^sbx-/)
+    expect((handle.native as { containerId: string }).containerId).toBe('container-abc123')
+
+    const run = spawnCalls.find((c) => c.args[0] === 'run')!
+    expect(run.args).toContain('-d')
+    expect(run.args).toContain('--rm')
+    // mcp-only ⇒ no network
+    expect(run.args).toContain('--network')
+    expect(run.args).toContain('none')
+    // labels for reaping
+    expect(run.args).toContain('--label')
+    expect(run.args).toContain('kg-sandbox=1')
+    // image last
+    expect(run.args[run.args.length - 1]).toBe('kg-sandbox:base')
+  })
+
+  it('applies cpu/memory caps and leaves network in place for open egress', async () => {
+    spawnPlan = () => ({ stdout: 'cid', code: 0 })
+    const backend = await makeBackend()
+    await backend.boot('base', { cpus: 2, memoryMB: 512, egress: 'open' })
+
+    const run = spawnCalls.find((c) => c.args[0] === 'run')!
+    expect(run.args).toContain('--cpus')
+    expect(run.args).toContain('2')
+    expect(run.args).toContain('--memory')
+    expect(run.args).toContain('512m')
+    expect(run.args).not.toContain('none')
+  })
+
+  it('throws SandboxBootError when docker run fails', async () => {
+    spawnPlan = () => ({ stderr: 'no such image', code: 1 })
+    const backend = await makeBackend()
+    await expect(backend.boot('base', {})).rejects.toThrow(/boot failed/)
+  })
+})
+
+describe('DockerBackend.destroy', () => {
+  it('force-removes the container', async () => {
+    spawnPlan = () => ({ stdout: 'ok', code: 0 })
+    const backend = await makeBackend()
+    const handle = await backend.boot('base', {})
+    spawnCalls.length = 0
+    await backend.destroy(handle)
+    const rm = spawnCalls.find((c) => c.args[0] === 'rm')!
+    expect(rm.args).toEqual(['rm', '-f', expect.any(String)])
+  })
+
+  it('is idempotent — swallows errors when the container is already gone', async () => {
+    // boot succeeds (returns a cid); the later `rm` fails (already gone).
+    spawnPlan = (cmd, args) => (args[0] === 'rm' ? { stderr: 'No such container', code: 1 } : { stdout: 'cid', code: 0 })
+    const backend = await makeBackend()
+    const handle = await backend.boot('base', {})
+    await expect(backend.destroy(handle)).resolves.toBeUndefined()
+  })
+})
+
+describe('DockerBackend.health', () => {
+  it('reports healthy when running', async () => {
+    spawnPlan = (cmd, args) => (args[0] === 'inspect' ? { stdout: 'running', code: 0 } : { stdout: 'cid', code: 0 })
+    const backend = await makeBackend()
+    const handle = await backend.boot('base', {})
+    expect(await backend.health(handle)).toEqual({ state: 'healthy', detail: 'running' })
+  })
+
+  it('reports gone when inspect fails', async () => {
+    spawnPlan = (cmd, args) => (args[0] === 'inspect' ? { code: 1, stderr: 'no such container' } : { stdout: 'cid', code: 0 })
+    const backend = await makeBackend()
+    const handle = await backend.boot('base', {})
+    expect(await backend.health(handle)).toEqual({ state: 'gone' })
+  })
+})
+
+describe('DockerBackend.connectMcp', () => {
+  it('exposes the six v0 sandbox_* tools across both in-VM servers', async () => {
+    spawnPlan = () => ({ stdout: 'cid', code: 0 })
+    const backend = await makeBackend()
+    const handle = await backend.boot('base', {})
+    const transport = await backend.connectMcp(handle)
+
+    const names = await transport.toolNames()
+    expect(names.sort()).toEqual(
+      ['sandbox_bash', 'sandbox_edit', 'sandbox_list', 'sandbox_read', 'sandbox_search', 'sandbox_write'].sort(),
+    )
+    // non-curated filesystem tools (directory_tree) are NOT exposed
+    expect(names).not.toContain('sandbox_directory_tree')
+
+    // connectMcp launched both servers via docker exec -i
+    const serveKeys = lastTransportArgs.map((a) => a[a.length - 1]).sort()
+    expect(serveKeys).toEqual(['filesystem', 'shell'])
+    expect(lastTransportArgs.every((a) => a.slice(0, 3).join(' ') === 'exec -i cid')).toBe(true)
+
+    await transport.close()
+  })
+
+  it('routes sandbox_bash to the shell server with the native name and parses structured output', async () => {
+    spawnPlan = () => ({ stdout: 'cid', code: 0 })
+    const backend = await makeBackend()
+    const handle = await backend.boot('base', {})
+    const transport = await backend.connectMcp(handle)
+
+    const res = await transport.callTool('sandbox_bash', { command: "python3 -c 'print(len(\"a b c\".split()))'" })
+    expect(res.success).toBe(true)
+    expect(res.data).toEqual({ stdout: '3\n', exit_code: 0 })
+
+    const dispatched = callToolCalls.find((c) => c.name === 'bash')!
+    expect(dispatched.server).toBe('shell')
+
+    expect(transport.ownsTool('sandbox_bash')).toBe(true)
+    expect(transport.ownsTool('read_neo4j_cypher')).toBe(false)
+    await transport.close()
+  })
+
+  it('returns a structured error for an unknown sandbox tool', async () => {
+    spawnPlan = () => ({ stdout: 'cid', code: 0 })
+    const backend = await makeBackend()
+    const handle = await backend.boot('base', {})
+    const transport = await backend.connectMcp(handle)
+    const res = await transport.callTool('sandbox_nonexistent', {})
+    expect(res.success).toBe(false)
+    expect(res.error).toMatch(/not found/)
+    await transport.close()
+  })
+})
+
+describe('DockerBackend.reset', () => {
+  it('throws — warm-pool recycle is build-order step 5', async () => {
+    spawnPlan = () => ({ stdout: 'cid', code: 0 })
+    const backend = await makeBackend()
+    const handle = await backend.boot('base', {})
+    await expect(backend.reset(handle)).rejects.toThrow(/step 5/)
+  })
+})

--- a/ui/src/__tests__/lib/sandbox/end-to-end.test.ts
+++ b/ui/src/__tests__/lib/sandbox/end-to-end.test.ts
@@ -1,0 +1,299 @@
+/**
+ * End-to-end integration test — `withSandbox(actorCritic(...))`.
+ *
+ * Build-order step 4 (see docs/sandbox-plan.md → "v0 build order"). Proves the
+ * full chain composes: a real `actorCritic` driven by the real BAML adapters,
+ * wrapped in `withSandbox`, dispatching through real `callTool` and the real
+ * ALS scope, to a real `DockerBackend` whose Docker engine and MCP SDK have
+ * been mocked at their lowest seam.
+ *
+ * Concretely — a scripted "count the words in this string" task. The mocked
+ * BAML actor proposes:
+ *   turn 1 → `sandbox_write` to `/work/count.py`
+ *   turn 2 → `sandbox_bash` running `python3 /work/count.py`
+ * The mocked critic accepts after the second turn; the mocked in-VM shell
+ * MCP simulates the python execution and returns the word count. The chain
+ * terminates with the count on `scope.data.result`.
+ *
+ * What this test rules in (over step 3's unit tests):
+ *   - actorCritic loop integrates with the adapter's sandbox-aware prompt
+ *     enrichment (the BAML actor sees `sandbox_*` in its `tools` arg).
+ *   - The real `callTool` routes sandbox-owned names to the in-VM transport.
+ *   - DockerBackend.boot + connectMcp + destroy sequence end-to-end.
+ *   - The host gateway client is never reached for sandbox-owned calls.
+ *   - On critic acceptance, the chain returns with `result.data.result`
+ *     equal to the last sandbox_bash output.
+ *
+ * Like docker-backend.test.ts, the docker CLI (`node:child_process.spawn`)
+ * and the MCP SDK (Stdio + Streamable HTTP transports + Client) are mocked,
+ * so no real Docker engine is required.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { EventEmitter } from 'node:events'
+import { mockAction, mockCriticResult } from '../../mocks/baml'
+
+vi.mock('../../../lib/harness-patterns/assert.server', () => ({
+  assertServerOnImport: vi.fn(),
+}))
+
+// ---- Mock `node:child_process.spawn` -------------------------------------
+// `DockerBackend` shells out to `docker run` / `rm` / `inspect`. Each spawn
+// returns a fake child whose behavior is `spawnPlan`-driven (set per test
+// when needed; otherwise returns stdout = a stable container id).
+type SpawnPlan = (cmd: string, args: string[]) => { stdout?: string; stderr?: string; code?: number }
+let spawnPlan: SpawnPlan = (_cmd, args) =>
+  args[0] === 'run' ? { stdout: 'cid-integration', code: 0 } : { stdout: '', code: 0 }
+const spawnCalls: Array<{ cmd: string; args: string[] }> = []
+
+function mockSpawn(cmd: string, args: string[]) {
+  spawnCalls.push({ cmd, args })
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter
+    stderr: EventEmitter
+    kill: () => void
+  }
+  child.stdout = new EventEmitter()
+  child.stderr = new EventEmitter()
+  child.kill = () => {}
+  const plan = spawnPlan(cmd, args)
+  queueMicrotask(() => {
+    if (plan.stdout) child.stdout.emit('data', Buffer.from(plan.stdout))
+    if (plan.stderr) child.stderr.emit('data', Buffer.from(plan.stderr))
+    child.emit('close', plan.code ?? 0)
+  })
+  return child
+}
+
+vi.mock('node:child_process', () => ({
+  spawn: mockSpawn,
+  default: { spawn: mockSpawn },
+}))
+
+// ---- Mock the in-VM MCP SDK clients --------------------------------------
+// `connectMcp` opens one client per in-VM server via `docker exec -i <cid>
+// init.sh serve <key>`. We simulate that here: filesystem keeps an in-memory
+// file map; shell "executes" python3 against the stored script. The
+// simulator parses one specific contract — a `text = "..."` assignment and a
+// `print(len(text.split()))` — which is exactly what our actor writes.
+const sandboxFiles = new Map<string, string>()
+const inVmCalls: Array<{ server: string; name: string; args: unknown }> = []
+
+function simulatePython3(scriptPath: string): string {
+  const src = sandboxFiles.get(scriptPath) ?? ''
+  const m = src.match(/text\s*=\s*"([^"]*)"/)
+  if (!m) return '0'
+  const wordCount = m[1].split(/\s+/).filter(Boolean).length
+  return String(wordCount)
+}
+
+vi.mock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
+  StdioClientTransport: class {
+    args: string[]
+    constructor(opts: { args: string[] }) {
+      this.args = opts.args
+    }
+  },
+}))
+
+vi.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
+  Client: class {
+    private serverKey = 'unknown'
+    async connect(transport: { args: string[] }) {
+      // launch argv ends with `serve <key>`
+      this.serverKey = transport.args[transport.args.length - 1]
+    }
+    async listTools() {
+      if (this.serverKey === 'filesystem') {
+        return {
+          tools: [
+            { name: 'read_text_file', description: 'read', inputSchema: { type: 'object' } },
+            { name: 'write_file', description: 'write', inputSchema: { type: 'object' } },
+            { name: 'edit_file', description: 'edit', inputSchema: { type: 'object' } },
+            { name: 'list_directory', description: 'list', inputSchema: { type: 'object' } },
+            { name: 'search_files_content', description: 'search', inputSchema: { type: 'object' } },
+          ],
+        }
+      }
+      if (this.serverKey === 'shell') {
+        return { tools: [{ name: 'bash', description: 'shell', inputSchema: { type: 'object' } }] }
+      }
+      return { tools: [] }
+    }
+    async callTool({ name, arguments: args }: { name: string; arguments: Record<string, unknown> }) {
+      inVmCalls.push({ server: this.serverKey, name, args })
+      if (name === 'write_file' && typeof args.path === 'string' && typeof args.content === 'string') {
+        sandboxFiles.set(args.path, args.content)
+        return { content: [{ type: 'text', text: JSON.stringify({ ok: true }) }], isError: false }
+      }
+      if (name === 'bash' && typeof args.command === 'string') {
+        // very narrow simulator: `python3 <path>` runs the stored script.
+        const m = args.command.match(/python3\s+(\S+)/)
+        if (m) {
+          const stdout = simulatePython3(m[1])
+          return { content: [{ type: 'text', text: stdout }], isError: false }
+        }
+        return { content: [{ type: 'text', text: '' }], isError: false }
+      }
+      return { content: [{ type: 'text', text: 'ok' }], isError: false }
+    }
+    async close() {}
+  },
+}))
+
+// The host gateway client must never be reached for a sandbox-owned tool.
+// If construction is ever attempted, count it so we can fail loudly.
+let gatewayConstructed = 0
+vi.mock('@modelcontextprotocol/sdk/client/streamableHttp.js', () => ({
+  StreamableHTTPClientTransport: class {
+    constructor() {
+      gatewayConstructed += 1
+    }
+  },
+}))
+
+// ---- Mock BAML -----------------------------------------------------------
+// The adapter dynamically imports `../../../baml_client`; vi.mock matches by
+// resolved path, so we replace the whole module. `inlinedbaml` is also
+// pulled in by the adapter's template-extraction code — mock it to noop so
+// the test doesn't depend on a generated client.
+const mockActorController = vi.fn()
+const mockCritic = vi.fn()
+
+vi.mock('../../../../baml_client', () => ({
+  b: {
+    ActorController: mockActorController,
+    Critic: mockCritic,
+    // The adapter doesn't call these here, but the import would fail at the
+    // destructuring site otherwise.
+    LoopController: vi.fn(),
+    Router: vi.fn(),
+    Synthesize: vi.fn(),
+    ResultDescribe: vi.fn(),
+  },
+}))
+
+vi.mock('../../../../baml_client/inlinedbaml', () => ({
+  getBamlFiles: () => ({}),
+}))
+
+// ---- Mock host-gateway listTools ----------------------------------------
+// The adapter's gateway-side `filterToolDescriptions` calls `mcpListTools()`.
+// In a sandbox-only test the gateway returns nothing (no host tools needed).
+vi.mock('../../../lib/harness-patterns/mcp-client.server', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../lib/harness-patterns/mcp-client.server')>()
+  return {
+    ...actual,
+    listTools: vi.fn().mockResolvedValue([]),
+  }
+})
+
+beforeEach(() => {
+  spawnCalls.length = 0
+  inVmCalls.length = 0
+  sandboxFiles.clear()
+  gatewayConstructed = 0
+  mockActorController.mockReset()
+  mockCritic.mockReset()
+  spawnPlan = (_cmd, args) =>
+    args[0] === 'run' ? { stdout: 'cid-integration', code: 0 } : { stdout: '', code: 0 }
+})
+
+describe('withSandbox(actorCritic) end-to-end — word count', () => {
+  it('writes a script, runs it, and returns the count via the critic-accepted result', async () => {
+    const { actorCritic } = await import('../../../lib/harness-patterns/patterns/actorCritic.server')
+    const { createScope } = await import('../../../lib/harness-patterns/context.server')
+    const { createEventView } = await import('../../../lib/harness-patterns/patterns')
+    const {
+      createActorControllerAdapter,
+      createCriticAdapter,
+    } = await import('../../../lib/harness-patterns/baml-adapters.server')
+    const { withSandbox } = await import('../../../lib/sandbox/with-sandbox.server')
+
+    const script =
+      'text = "the quick brown fox jumps over the lazy dog"\nprint(len(text.split()))\n'
+
+    mockActorController
+      .mockResolvedValueOnce(
+        mockAction({
+          tool_name: 'sandbox_write',
+          tool_args: JSON.stringify({ path: '/work/count.py', content: script }),
+        }),
+      )
+      .mockResolvedValueOnce(
+        mockAction({
+          tool_name: 'sandbox_bash',
+          tool_args: JSON.stringify({ command: 'python3 /work/count.py' }),
+        }),
+      )
+
+    mockCritic
+      .mockResolvedValueOnce(
+        mockCriticResult({ is_sufficient: false, suggested_approach: 'now run it' }),
+      )
+      .mockResolvedValueOnce(mockCriticResult({ is_sufficient: true }))
+
+    const actor = createActorControllerAdapter([])
+    const critic = createCriticAdapter()
+    const pattern = withSandbox({ rootfs: 'base' })(
+      actorCritic(actor, critic, [], { availableTools: [], maxRetries: 3, patternId: 'e2e' }),
+    )
+
+    const scope = createScope('e2e', { intent: 'count words in the string' })
+    const view = createEventView({
+      sessionId: 'e2e',
+      createdAt: Date.now(),
+      events: [
+        {
+          type: 'user_message' as const,
+          ts: Date.now(),
+          patternId: 'harness',
+          data: { content: 'count words in this sentence' },
+        },
+      ],
+      status: 'running' as const,
+      data: {},
+      input: 'count words in this sentence',
+    })
+
+    const result = await pattern.fn(scope, view)
+
+    // 1. Critic-accepted result is the bash stdout (9 words in the sentence).
+    expect(result.data.result).toBe(9)
+
+    // 2. Actor was driven exactly twice (write → bash), critic exactly twice.
+    expect(mockActorController).toHaveBeenCalledTimes(2)
+    expect(mockCritic).toHaveBeenCalledTimes(2)
+
+    // 3. The adapter prepended sandbox tools to the actor's prompt — proves
+    //    the ALS scope reached `baml-adapters.server.ts` from inside the
+    //    wrapper. (3rd arg of ActorController is the `tools` array.)
+    const firstCallTools = mockActorController.mock.calls[0][2] as Array<{ name: string }>
+    const firstCallNames = firstCallTools.map((t) => t.name)
+    expect(firstCallNames).toEqual(
+      expect.arrayContaining([
+        'sandbox_bash',
+        'sandbox_write',
+        'sandbox_edit',
+        'sandbox_list',
+        'sandbox_read',
+        'sandbox_search',
+      ]),
+    )
+
+    // 4. Dispatch routed both sandbox calls to the in-VM transport (one
+    //    write_file on filesystem, one bash on shell). Neither hit the
+    //    gateway.
+    const writes = inVmCalls.filter((c) => c.name === 'write_file')
+    const bashes = inVmCalls.filter((c) => c.name === 'bash')
+    expect(writes).toHaveLength(1)
+    expect(bashes).toHaveLength(1)
+    expect(writes[0].server).toBe('filesystem')
+    expect(bashes[0].server).toBe('shell')
+    expect(gatewayConstructed).toBe(0)
+
+    // 5. Backend lifecycle: docker run once, docker rm once on exit.
+    expect(spawnCalls.some((s) => s.args[0] === 'run')).toBe(true)
+    expect(spawnCalls.some((s) => s.args[0] === 'rm')).toBe(true)
+  })
+})

--- a/ui/src/__tests__/lib/sandbox/scheduler.test.ts
+++ b/ui/src/__tests__/lib/sandbox/scheduler.test.ts
@@ -1,0 +1,207 @@
+/**
+ * SandboxScheduler unit tests.
+ *
+ * Pure logic, no I/O. Covers immediate-grant, queue-on-cap, per-session
+ * isolation, FIFO-with-skip drain order, idempotent release, and counters.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('../../../lib/harness-patterns/assert.server', () => ({
+  assertServerOnImport: vi.fn(),
+}))
+
+import { SandboxScheduler, type Slot } from '../../../lib/sandbox/scheduler.server'
+
+describe('SandboxScheduler.allocate', () => {
+  it('grants immediately when under both caps', async () => {
+    const s = new SandboxScheduler({ globalCap: 4, perSessionCap: 2 })
+    const slot = await s.allocate('s1')
+    expect(slot).toBeDefined()
+    expect(s.inflightCount()).toBe(1)
+    expect(s.inflightCount('s1')).toBe(1)
+  })
+
+  it('waits when global cap is reached, resolves after release', async () => {
+    const s = new SandboxScheduler({ globalCap: 1, perSessionCap: 4 })
+    const first = await s.allocate('s1')
+    let secondResolved = false
+    const secondP = s.allocate('s2').then((slot) => {
+      secondResolved = true
+      return slot
+    })
+    // Allow microtasks to settle.
+    await new Promise((r) => setImmediate(r))
+    expect(secondResolved).toBe(false)
+    expect(s.queueDepth()).toBe(1)
+
+    first.release()
+    const second = await secondP
+    expect(secondResolved).toBe(true)
+    expect(s.inflightCount()).toBe(1)
+    expect(s.queueDepth()).toBe(0)
+    second.release()
+  })
+
+  it('queues when per-session cap is reached even with global headroom', async () => {
+    const s = new SandboxScheduler({ globalCap: 8, perSessionCap: 1 })
+    const a = await s.allocate('s1')
+    let bResolved = false
+    const bP = s.allocate('s1').then((slot) => {
+      bResolved = true
+      return slot
+    })
+    await new Promise((r) => setImmediate(r))
+    expect(bResolved).toBe(false)
+    expect(s.inflightCount('s1')).toBe(1)
+    expect(s.queueDepth('s1')).toBe(1)
+
+    a.release()
+    const b = await bP
+    expect(bResolved).toBe(true)
+    expect(s.inflightCount('s1')).toBe(1)
+    b.release()
+  })
+
+  it('isolates per-session caps across different sessions', async () => {
+    const s = new SandboxScheduler({ globalCap: 8, perSessionCap: 1 })
+    const a = await s.allocate('s1')
+    // s1 is at per-session cap, but s2 has its own cap.
+    const c = await s.allocate('s2')
+    expect(s.inflightCount()).toBe(2)
+    expect(s.inflightCount('s1')).toBe(1)
+    expect(s.inflightCount('s2')).toBe(1)
+    a.release()
+    c.release()
+  })
+
+  it('drains queue in FIFO order, skipping waiters still over per-session cap', async () => {
+    // globalCap=2 with two slots filled forces both later allocates to queue.
+    const s = new SandboxScheduler({ globalCap: 2, perSessionCap: 1 })
+    const a1 = await s.allocate('s1') // s1: 1/1
+    const b1 = await s.allocate('s2') // s2: 1/1, global: 2/2
+    // Queue: another s1, then s3.
+    const order: string[] = []
+    const a2P = s.allocate('s1').then((slot) => {
+      order.push('a2')
+      return slot
+    })
+    const c1P = s.allocate('s3').then((slot) => {
+      order.push('c1')
+      return slot
+    })
+    await new Promise((r) => setImmediate(r))
+    expect(order).toEqual([])
+    expect(s.queueDepth()).toBe(2)
+
+    // Release b1 (s2). Doesn't unblock head (a2/s1 still at cap), but c1/s3
+    // can proceed since s3 has 0 inflight.
+    b1.release()
+    await new Promise((r) => setImmediate(r))
+    expect(order).toEqual(['c1'])
+    // a2 still waiting on s1.
+    expect(s.queueDepth()).toBe(1)
+
+    // Release a1 (s1). Now a2 can be admitted.
+    a1.release()
+    const [a2, c1] = await Promise.all([a2P, c1P])
+    expect(order).toEqual(['c1', 'a2'])
+    expect(s.queueDepth()).toBe(0)
+    a2.release()
+    c1.release()
+  })
+
+  it('wakes multiple waiters when a release frees enough global capacity', async () => {
+    const s = new SandboxScheduler({ globalCap: 2, perSessionCap: 4 })
+    const a = await s.allocate('s1')
+    const b = await s.allocate('s2') // global at cap
+    const cP = s.allocate('s3')
+    const dP = s.allocate('s4')
+    await new Promise((r) => setImmediate(r))
+    expect(s.queueDepth()).toBe(2)
+
+    a.release()
+    // Frees one global slot — exactly one waiter wakes (c, the head).
+    const c = await cP
+    expect(s.inflightCount()).toBe(2)
+    expect(s.queueDepth()).toBe(1)
+
+    b.release()
+    const d = await dP
+    expect(s.queueDepth()).toBe(0)
+    expect(s.inflightCount()).toBe(2)
+    c.release()
+    d.release()
+  })
+})
+
+describe('SandboxScheduler release', () => {
+  it('is idempotent — second release is a no-op', async () => {
+    const s = new SandboxScheduler({ globalCap: 1, perSessionCap: 1 })
+    const slot = await s.allocate('s1')
+    slot.release()
+    expect(s.inflightCount()).toBe(0)
+    slot.release()
+    expect(s.inflightCount()).toBe(0)
+  })
+
+  it('does not over-wake when called twice', async () => {
+    const s = new SandboxScheduler({ globalCap: 1, perSessionCap: 1 })
+    const a = await s.allocate('s1')
+    const bP = s.allocate('s2')
+    let cResolved = false
+    const cP = s.allocate('s3').then((slot) => {
+      cResolved = true
+      return slot
+    })
+    await new Promise((r) => setImmediate(r))
+
+    a.release()
+    a.release() // double-release: must not wake c
+    const b = await bP
+    await new Promise((r) => setImmediate(r))
+    expect(cResolved).toBe(false)
+    expect(s.queueDepth()).toBe(1)
+
+    b.release()
+    const c = await cP
+    expect(cResolved).toBe(true)
+    c.release()
+  })
+})
+
+describe('SandboxScheduler counters', () => {
+  it('inflightCount tracks global and per-session', async () => {
+    const s = new SandboxScheduler({ globalCap: 4, perSessionCap: 4 })
+    const slots: Slot[] = []
+    slots.push(await s.allocate('s1'))
+    slots.push(await s.allocate('s1'))
+    slots.push(await s.allocate('s2'))
+    expect(s.inflightCount()).toBe(3)
+    expect(s.inflightCount('s1')).toBe(2)
+    expect(s.inflightCount('s2')).toBe(1)
+    expect(s.inflightCount('s3')).toBe(0)
+    for (const slot of slots) slot.release()
+    expect(s.inflightCount()).toBe(0)
+    expect(s.inflightCount('s1')).toBe(0)
+  })
+
+  it('queueDepth tracks pending waiters', async () => {
+    const s = new SandboxScheduler({ globalCap: 1, perSessionCap: 1 })
+    const a = await s.allocate('s1')
+    const bP = s.allocate('s2')
+    const cP = s.allocate('s2')
+    await new Promise((r) => setImmediate(r))
+    expect(s.queueDepth()).toBe(2)
+    expect(s.queueDepth('s2')).toBe(2)
+    expect(s.queueDepth('s1')).toBe(0)
+
+    a.release()
+    const b = await bP
+    expect(s.queueDepth()).toBe(1)
+    b.release()
+    const c = await cP
+    expect(s.queueDepth()).toBe(0)
+    c.release()
+  })
+})

--- a/ui/src/__tests__/lib/sandbox/scope.test.ts
+++ b/ui/src/__tests__/lib/sandbox/scope.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Sandbox ALS scope unit tests.
+ *
+ * Covers `runWithSandbox` / `getActiveSandbox` propagation invariants — the
+ * load-bearing primitive for build-order step 3 (see docs/sandbox-plan.md →
+ * "How tools reach the controller").
+ */
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('../../../lib/harness-patterns/assert.server', () => ({
+  assertServerOnImport: vi.fn(),
+}))
+
+import { runWithSandbox, getActiveSandbox } from '../../../lib/sandbox/scope.server'
+import type { McpTransport } from '../../../lib/sandbox/types'
+
+function fakeTransport(vmId: string): McpTransport {
+  return {
+    vmId,
+    toolNames: async () => [],
+    listTools: async () => [],
+    ownsTool: () => false,
+    callTool: async () => ({ success: true, data: null }),
+    close: async () => {},
+  }
+}
+
+describe('sandbox scope', () => {
+  it('returns undefined outside any scope', () => {
+    expect(getActiveSandbox()).toBeUndefined()
+  })
+
+  it('makes the transport visible inside runWithSandbox', async () => {
+    const t = fakeTransport('vm-1')
+    let captured: McpTransport | undefined
+    await runWithSandbox(t, async () => {
+      captured = getActiveSandbox()
+    })
+    expect(captured?.vmId).toBe('vm-1')
+    // Outside the scope, the store is empty again.
+    expect(getActiveSandbox()).toBeUndefined()
+  })
+
+  it('overrides the outer scope inside a nested runWithSandbox', async () => {
+    const outer = fakeTransport('outer')
+    const inner = fakeTransport('inner')
+    let midVm: string | undefined
+    let afterInnerVm: string | undefined
+    await runWithSandbox(outer, async () => {
+      await runWithSandbox(inner, async () => {
+        midVm = getActiveSandbox()?.vmId
+      })
+      afterInnerVm = getActiveSandbox()?.vmId
+    })
+    expect(midVm).toBe('inner')
+    expect(afterInnerVm).toBe('outer')
+  })
+
+  it('propagates through async/await chains', async () => {
+    const t = fakeTransport('vm-async')
+    const seen: string[] = []
+    await runWithSandbox(t, async () => {
+      await Promise.resolve()
+      seen.push(getActiveSandbox()?.vmId ?? '<none>')
+      await new Promise<void>((r) => setTimeout(r, 0))
+      seen.push(getActiveSandbox()?.vmId ?? '<none>')
+    })
+    expect(seen).toEqual(['vm-async', 'vm-async'])
+  })
+})

--- a/ui/src/__tests__/lib/sandbox/warm-pool.test.ts
+++ b/ui/src/__tests__/lib/sandbox/warm-pool.test.ts
@@ -1,0 +1,270 @@
+/**
+ * WarmPool unit tests.
+ *
+ * Hermetic — the backend is a vi.fn() fake; no Docker or MCP SDK involved.
+ * Covers acquire (hit / miss), release (park / cap-full / reset-fail),
+ * evictIdle, shutdown, and prewarm.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('../../../lib/harness-patterns/assert.server', () => ({
+  assertServerOnImport: vi.fn(),
+}))
+
+import { WarmPool } from '../../../lib/sandbox/warm-pool.server'
+import type { ComputeBackend, RootfsId, RuntimeConfig, VMHandle, HealthStatus, McpTransport } from '../../../lib/sandbox/types'
+
+// ---- backend fake --------------------------------------------------------
+
+let bootCount = 0
+function makeHandle(rootfs: RootfsId = 'base', bootedAt = Date.now()): VMHandle {
+  bootCount += 1
+  return {
+    id: `sbx-${bootCount.toString().padStart(4, '0')}`,
+    backend: 'docker',
+    rootfs,
+    bootedAt,
+    native: { containerId: `c-${bootCount}`, runtime: {} },
+  }
+}
+
+function makeBackend(overrides: Partial<ComputeBackend> = {}): ComputeBackend {
+  const backend: ComputeBackend = {
+    kind: 'docker',
+    boot: vi.fn(async (rootfs: RootfsId, _runtime: RuntimeConfig) => makeHandle(rootfs)),
+    destroy: vi.fn(async (_vm: VMHandle) => undefined),
+    reset: vi.fn(async (vm: VMHandle) => {
+      // Mimic real reset: bootedAt advances.
+      ;(vm as { bootedAt: number }).bootedAt = Date.now()
+    }),
+    connectMcp: vi.fn(async (_vm: VMHandle): Promise<McpTransport> => {
+      throw new Error('not used in warm-pool tests')
+    }),
+    health: vi.fn(async (_vm: VMHandle): Promise<HealthStatus> => ({ state: 'healthy' })),
+    ...overrides,
+  }
+  return backend
+}
+
+beforeEach(() => {
+  bootCount = 0
+})
+
+// ---- tests ---------------------------------------------------------------
+
+describe('WarmPool.acquire', () => {
+  it('cold-boots when the pool is empty', async () => {
+    const backend = makeBackend()
+    const pool = new WarmPool(backend, { caps: { base: 2 }, idleEvictMs: 60_000 })
+
+    const vm = await pool.acquire('base', {})
+    expect(vm.rootfs).toBe('base')
+    expect(backend.boot).toHaveBeenCalledTimes(1)
+    expect(pool.size()).toBe(0)
+  })
+
+  it('returns a parked VM without calling boot', async () => {
+    const backend = makeBackend()
+    const pool = new WarmPool(backend, { caps: { base: 2 }, idleEvictMs: 60_000 })
+
+    const first = await pool.acquire('base', {})
+    await pool.release(first)
+    expect(pool.size('base')).toBe(1)
+
+    vi.mocked(backend.boot).mockClear()
+    const second = await pool.acquire('base', {})
+    expect(backend.boot).not.toHaveBeenCalled()
+    expect(second.id).toBe(first.id)
+    expect(pool.size('base')).toBe(0)
+  })
+
+  it('passes through cold-boot for unknown rootfs flavors', async () => {
+    const backend = makeBackend()
+    const pool = new WarmPool(backend, { caps: { base: 2 }, idleEvictMs: 60_000 })
+    const vm = await pool.acquire('python-heavy', {})
+    expect(vm.rootfs).toBe('python-heavy')
+    expect(backend.boot).toHaveBeenCalledWith('python-heavy', {})
+  })
+})
+
+describe('WarmPool.release', () => {
+  it('calls backend.reset then parks the VM', async () => {
+    const backend = makeBackend()
+    const pool = new WarmPool(backend, { caps: { base: 2 }, idleEvictMs: 60_000 })
+
+    const vm = await pool.acquire('base', {})
+    await pool.release(vm)
+
+    expect(backend.reset).toHaveBeenCalledWith(vm)
+    expect(backend.destroy).not.toHaveBeenCalled()
+    expect(pool.size('base')).toBe(1)
+  })
+
+  it('destroys instead of parking when the pool is at cap', async () => {
+    const backend = makeBackend()
+    const pool = new WarmPool(backend, { caps: { base: 1 }, idleEvictMs: 60_000 })
+
+    const a = await pool.acquire('base', {})
+    const b = await pool.acquire('base', {})
+    await pool.release(a)
+    expect(pool.size('base')).toBe(1)
+    await pool.release(b)
+    expect(pool.size('base')).toBe(1)
+    expect(backend.destroy).toHaveBeenCalledTimes(1)
+    expect(backend.destroy).toHaveBeenCalledWith(b)
+  })
+
+  it('destroys when caps is missing for the flavor (defaults to 0)', async () => {
+    const backend = makeBackend()
+    const pool = new WarmPool(backend, { caps: {}, idleEvictMs: 60_000 })
+
+    const vm = await pool.acquire('base', {})
+    await pool.release(vm)
+    expect(backend.reset).toHaveBeenCalledTimes(1)
+    expect(backend.destroy).toHaveBeenCalledWith(vm)
+    expect(pool.size()).toBe(0)
+  })
+
+  it('destroys (does not park) when reset throws', async () => {
+    const backend = makeBackend({
+      reset: vi.fn(async () => {
+        throw new Error('engine unreachable')
+      }),
+    })
+    const pool = new WarmPool(backend, { caps: { base: 2 }, idleEvictMs: 60_000 })
+
+    const vm = await pool.acquire('base', {})
+    await expect(pool.release(vm)).resolves.toBeUndefined()
+    expect(backend.destroy).toHaveBeenCalledWith(vm)
+    expect(pool.size()).toBe(0)
+  })
+})
+
+describe('WarmPool.evictIdle', () => {
+  it('destroys VMs parked past the threshold, leaves fresh ones', async () => {
+    vi.useFakeTimers()
+    try {
+      const backend = makeBackend()
+      const pool = new WarmPool(backend, { caps: { base: 4 }, idleEvictMs: 10_000 })
+      const t0 = 1_000_000
+      vi.setSystemTime(t0)
+      const v1 = await pool.acquire('base', {})
+      await pool.release(v1)
+      vi.setSystemTime(t0 + 20_000)
+      // Bypass acquire (which would return v1) and cold-boot v2 directly,
+      // then park it via release at this later timestamp.
+      const v2 = await backend.boot('base', {})
+      await pool.release(v2)
+      expect(pool.size('base')).toBe(2)
+
+      // At t0 + 25_000: v1 is 25s old (evicted), v2 is 5s old (kept).
+      await pool.evictIdle(t0 + 25_000)
+      expect(pool.size('base')).toBe(1)
+      expect(backend.destroy).toHaveBeenCalledTimes(1)
+      expect(backend.destroy).toHaveBeenCalledWith(v1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('is a no-op when nothing is idle', async () => {
+    const backend = makeBackend()
+    const pool = new WarmPool(backend, { caps: { base: 2 }, idleEvictMs: 60_000 })
+    const vm = await pool.acquire('base', {})
+    await pool.release(vm)
+
+    await pool.evictIdle(Date.now())
+    expect(backend.destroy).not.toHaveBeenCalled()
+    expect(pool.size('base')).toBe(1)
+  })
+})
+
+describe('WarmPool.prewarm', () => {
+  it('boots N VMs into the pool, capped by caps[rootfs]', async () => {
+    const backend = makeBackend()
+    const pool = new WarmPool(backend, { caps: { base: 2 }, idleEvictMs: 60_000 })
+
+    await pool.prewarm('base', 5, {})
+    // Capped at 2.
+    expect(backend.boot).toHaveBeenCalledTimes(2)
+    expect(pool.size('base')).toBe(2)
+  })
+
+  it('does nothing when the pool is already at cap', async () => {
+    const backend = makeBackend()
+    const pool = new WarmPool(backend, { caps: { base: 1 }, idleEvictMs: 60_000 })
+
+    const vm = await pool.acquire('base', {})
+    await pool.release(vm)
+    expect(pool.size('base')).toBe(1)
+
+    vi.mocked(backend.boot).mockClear()
+    await pool.prewarm('base', 5, {})
+    expect(backend.boot).not.toHaveBeenCalled()
+    expect(pool.size('base')).toBe(1)
+  })
+
+  it('tolerates boot failures (parks the survivors)', async () => {
+    let n = 0
+    const backend = makeBackend({
+      boot: vi.fn(async (rootfs: RootfsId) => {
+        n += 1
+        if (n === 2) throw new Error('boot failed')
+        return makeHandle(rootfs)
+      }),
+    })
+    const pool = new WarmPool(backend, { caps: { base: 3 }, idleEvictMs: 60_000 })
+    await pool.prewarm('base', 3, {})
+    expect(backend.boot).toHaveBeenCalledTimes(3)
+    expect(pool.size('base')).toBe(2)
+  })
+})
+
+describe('WarmPool.shutdown', () => {
+  it('destroys every parked VM across all flavors', async () => {
+    const backend = makeBackend()
+    const pool = new WarmPool(backend, { caps: { base: 2, other: 1 }, idleEvictMs: 60_000 })
+
+    const a = await pool.acquire('base', {})
+    const b = await pool.acquire('base', {})
+    const c = await pool.acquire('other', {})
+    await pool.release(a)
+    await pool.release(b)
+    await pool.release(c)
+    expect(pool.size()).toBe(3)
+
+    await pool.shutdown()
+    expect(backend.destroy).toHaveBeenCalledTimes(3)
+    expect(pool.size()).toBe(0)
+  })
+
+  it('handles destroy failures during shutdown without throwing', async () => {
+    const backend = makeBackend({
+      destroy: vi.fn(async () => {
+        throw new Error('engine gone')
+      }),
+    })
+    const pool = new WarmPool(backend, { caps: { base: 1 }, idleEvictMs: 60_000 })
+    const vm = await pool.acquire('base', {})
+    await pool.release(vm)
+    await expect(pool.shutdown()).resolves.toBeUndefined()
+    expect(pool.size()).toBe(0)
+  })
+})
+
+describe('WarmPool.size', () => {
+  it('reports per-flavor and total depth', async () => {
+    const backend = makeBackend()
+    const pool = new WarmPool(backend, { caps: { base: 2, other: 1 }, idleEvictMs: 60_000 })
+
+    const a = await pool.acquire('base', {})
+    const b = await pool.acquire('other', {})
+    await pool.release(a)
+    await pool.release(b)
+    expect(pool.size('base')).toBe(1)
+    expect(pool.size('other')).toBe(1)
+    expect(pool.size()).toBe(2)
+    expect(pool.size('missing')).toBe(0)
+  })
+})

--- a/ui/src/__tests__/lib/sandbox/with-sandbox.test.ts
+++ b/ui/src/__tests__/lib/sandbox/with-sandbox.test.ts
@@ -14,6 +14,8 @@ vi.mock('../../../lib/harness-patterns/assert.server', () => ({
 
 import { withSandbox } from '../../../lib/sandbox/with-sandbox.server'
 import { getActiveSandbox } from '../../../lib/sandbox/scope.server'
+import { WarmPool } from '../../../lib/sandbox/warm-pool.server'
+import { SandboxScheduler } from '../../../lib/sandbox/scheduler.server'
 import type {
   ComputeBackend,
   HealthStatus,
@@ -166,7 +168,7 @@ describe('withSandbox', () => {
     expect(backend.calls.destroy).toHaveLength(1)
   })
 
-  it('forwards rootfs, resources, and egress to backend.boot', async () => {
+  it('forwards rootfs and caller-supplied resources/egress to backend.boot', async () => {
     const backend = fakeBackend()
     const inner = fakePattern(async (scope) => scope)
 
@@ -177,9 +179,26 @@ describe('withSandbox', () => {
       egress: 'open',
     })(inner).fn(fakeScope({}), fakeView)
 
-    expect(backend.calls.boot[0]).toEqual({
-      rootfs: 'base',
-      runtime: { cpus: 2, memoryMB: 1024, egress: 'open' },
+    // Caller-supplied wins; timeoutSec gets the settings default.
+    expect(backend.calls.boot[0].rootfs).toBe('base')
+    expect(backend.calls.boot[0].runtime).toMatchObject({
+      cpus: 2,
+      memoryMB: 1024,
+      egress: 'open',
+      timeoutSec: 60, // DEFAULT_SETTINGS.sandbox.defaultTimeoutSec
+    })
+  })
+
+  it('fills missing resources/egress from settings.sandbox defaults', async () => {
+    const backend = fakeBackend()
+    const inner = fakePattern(async (scope) => scope)
+
+    await withSandbox({ backend })(inner).fn(fakeScope({}), fakeView)
+
+    expect(backend.calls.boot[0].runtime).toMatchObject({
+      memoryMB: 512, // defaultMemoryMB
+      timeoutSec: 60, // defaultTimeoutSec
+      egress: 'mcp-only', // defaultEgress
     })
   })
 
@@ -191,5 +210,124 @@ describe('withSandbox', () => {
     expect(wrapped.name).toBe('withSandbox(inner)')
     expect(wrapped.config).toEqual(inner.config)
     expect(wrapped.estimateTurns?.({ maxToolTurns: 10, maxRetries: 3 })).toBe(3)
+  })
+})
+
+describe('withSandbox scheduler + pool wiring', () => {
+  it('routes acquire/release through the injected pool', async () => {
+    const backend = fakeBackend()
+    // Spy on a real WarmPool's methods so we see the wrapper's call sequence.
+    const pool = new WarmPool(backend, { caps: { base: 2 }, idleEvictMs: 60_000 })
+    const acquireSpy = vi.spyOn(pool, 'acquire')
+    const releaseSpy = vi.spyOn(pool, 'release')
+
+    const inner = fakePattern(async (scope) => scope)
+    await withSandbox({ backend, pool, rootfs: 'base' })(inner).fn(
+      fakeScope({}),
+      fakeView,
+    )
+
+    expect(acquireSpy).toHaveBeenCalledWith('base', expect.any(Object))
+    expect(releaseSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('parks the VM in the pool when reset succeeds (subsequent acquire hits)', async () => {
+    const backend = fakeBackend()
+    // fakeBackend's default reset throws; install a working reset for this case.
+    backend.reset = vi.fn(async (vm) => {
+      ;(vm as { bootedAt: number }).bootedAt = Date.now()
+    })
+    const pool = new WarmPool(backend, { caps: { base: 1 }, idleEvictMs: 60_000 })
+    const inner = fakePattern(async (scope) => scope)
+    const wrap = withSandbox({ backend, pool, rootfs: 'base' })(inner)
+
+    await wrap.fn(fakeScope({}), fakeView)
+    expect(backend.calls.boot).toHaveLength(1)
+    expect(pool.size('base')).toBe(1) // parked
+    expect(backend.calls.destroy).toHaveLength(0)
+
+    // Second invocation: pool-hit, no new boot.
+    await wrap.fn(fakeScope({}), fakeView)
+    expect(backend.calls.boot).toHaveLength(1)
+    expect(pool.size('base')).toBe(1) // re-parked
+  })
+
+  it('allocates and releases scheduler slots with the provided sessionId', async () => {
+    const backend = fakeBackend()
+    backend.reset = vi.fn(async () => {})
+    const pool = new WarmPool(backend, { caps: { base: 1 }, idleEvictMs: 60_000 })
+    const scheduler = new SandboxScheduler({ globalCap: 4, perSessionCap: 2 })
+    const allocSpy = vi.spyOn(scheduler, 'allocate')
+
+    const inner = fakePattern(async (scope) => scope)
+    await withSandbox({ backend, pool, scheduler, sessionId: 'sess-99' })(inner).fn(
+      fakeScope({}),
+      fakeView,
+    )
+
+    expect(allocSpy).toHaveBeenCalledWith('sess-99')
+    expect(scheduler.inflightCount()).toBe(0) // slot released on cleanup
+  })
+
+  it('blocks a second invocation when the scheduler is at globalCap', async () => {
+    const backend = fakeBackend()
+    backend.reset = vi.fn(async () => {})
+    const pool = new WarmPool(backend, { caps: { base: 2 }, idleEvictMs: 60_000 })
+    const scheduler = new SandboxScheduler({ globalCap: 1, perSessionCap: 4 })
+
+    let gateOpen = false
+    const releaseGate = new Promise<void>((resolve) => {
+      const id = setInterval(() => {
+        if (gateOpen) {
+          clearInterval(id)
+          resolve()
+        }
+      }, 5)
+    })
+
+    const slow = fakePattern(async (scope) => {
+      await releaseGate
+      return scope
+    })
+    const fast = fakePattern(async (scope) => scope)
+
+    const slowP = withSandbox({ backend, pool, scheduler, sessionId: 's1' })(slow).fn(
+      fakeScope({}),
+      fakeView,
+    )
+    // Give slow a tick to claim the slot.
+    await new Promise((r) => setImmediate(r))
+    expect(scheduler.inflightCount()).toBe(1)
+    expect(scheduler.queueDepth()).toBe(0)
+
+    const fastP = withSandbox({ backend, pool, scheduler, sessionId: 's2' })(fast).fn(
+      fakeScope({}),
+      fakeView,
+    )
+    await new Promise((r) => setImmediate(r))
+    // fast is queued behind slow.
+    expect(scheduler.queueDepth()).toBe(1)
+
+    gateOpen = true
+    await Promise.all([slowP, fastP])
+    expect(scheduler.inflightCount()).toBe(0)
+  })
+
+  it('releases the scheduler slot even if the inner pattern throws', async () => {
+    const backend = fakeBackend()
+    backend.reset = vi.fn(async () => {})
+    const pool = new WarmPool(backend, { caps: { base: 1 }, idleEvictMs: 60_000 })
+    const scheduler = new SandboxScheduler({ globalCap: 1, perSessionCap: 1 })
+    const inner = fakePattern(async () => {
+      throw new Error('inner went pop')
+    })
+
+    await expect(
+      withSandbox({ backend, pool, scheduler, sessionId: 's1' })(inner).fn(
+        fakeScope({}),
+        fakeView,
+      ),
+    ).rejects.toThrow('inner went pop')
+    expect(scheduler.inflightCount()).toBe(0)
   })
 })

--- a/ui/src/__tests__/lib/sandbox/with-sandbox.test.ts
+++ b/ui/src/__tests__/lib/sandbox/with-sandbox.test.ts
@@ -16,6 +16,7 @@ import { withSandbox } from '../../../lib/sandbox/with-sandbox.server'
 import { getActiveSandbox } from '../../../lib/sandbox/scope.server'
 import { WarmPool } from '../../../lib/sandbox/warm-pool.server'
 import { SandboxScheduler } from '../../../lib/sandbox/scheduler.server'
+import { AttachmentTable } from '../../../lib/sandbox/attachment-table.server'
 import type {
   ComputeBackend,
   HealthStatus,
@@ -329,5 +330,114 @@ describe('withSandbox scheduler + pool wiring', () => {
       ),
     ).rejects.toThrow('inner went pop')
     expect(scheduler.inflightCount()).toBe(0)
+  })
+})
+
+describe('withSandbox id/fresh (step 6)', () => {
+  function buildKit() {
+    const backend = fakeBackend()
+    backend.reset = vi.fn(async () => {})
+    const pool = new WarmPool(backend, { caps: { base: 1 }, idleEvictMs: 60_000 })
+    const scheduler = new SandboxScheduler({ globalCap: 4, perSessionCap: 4 })
+    const attachments = new AttachmentTable(backend, pool, { idleMs: 60_000 })
+    return { backend, pool, scheduler, attachments }
+  }
+
+  it('{ id } reuses the same VM across consecutive invocations', async () => {
+    const kit = buildKit()
+    const inner = fakePattern(async (scope) => scope)
+    const wrap = withSandbox({ ...kit, id: 'session-42' })(inner)
+
+    await wrap.fn(fakeScope({}), fakeView)
+    await wrap.fn(fakeScope({}), fakeView)
+    await wrap.fn(fakeScope({}), fakeView)
+
+    // Only one boot — the attachment table reuses across calls.
+    expect(kit.backend.calls.boot).toHaveLength(1)
+    expect(kit.attachments.has('session-42')).toBe(true)
+    expect(kit.attachments.size()).toBe(1)
+  })
+
+  it('{ id } isolates separate ids (different VMs per id)', async () => {
+    const kit = buildKit()
+    // Need pool cap big enough for two attachments parked at refCount=0
+    // during overlap; but here we only have one in flight at a time, so
+    // pool sees one acquire then another. Cap 1 means second acquire boots
+    // since first hasn't been released to the pool. Bump cap to 2 to be safe.
+    const pool = new WarmPool(kit.backend, { caps: { base: 2 }, idleEvictMs: 60_000 })
+    const attachments = new AttachmentTable(kit.backend, pool, { idleMs: 60_000 })
+    const inner = fakePattern(async (scope) => scope)
+
+    await withSandbox({ backend: kit.backend, pool, scheduler: kit.scheduler, attachments, id: 'a' })(
+      inner,
+    ).fn(fakeScope({}), fakeView)
+    await withSandbox({ backend: kit.backend, pool, scheduler: kit.scheduler, attachments, id: 'b' })(
+      inner,
+    ).fn(fakeScope({}), fakeView)
+
+    expect(kit.backend.calls.boot).toHaveLength(2)
+    expect(attachments.has('a')).toBe(true)
+    expect(attachments.has('b')).toBe(true)
+  })
+
+  it('{ id, fresh: true } calls destroyById then reacquires under the same id', async () => {
+    const kit = buildKit()
+    const destroySpy = vi.spyOn(kit.attachments, 'destroyById')
+    const inner = fakePattern(async (scope) => scope)
+
+    await withSandbox({ ...kit, id: 'session-42' })(inner).fn(fakeScope({}), fakeView)
+    expect(destroySpy).not.toHaveBeenCalled()
+
+    await withSandbox({ ...kit, id: 'session-42', fresh: true })(inner).fn(
+      fakeScope({}),
+      fakeView,
+    )
+    expect(destroySpy).toHaveBeenCalledWith('session-42')
+    expect(kit.attachments.has('session-42')).toBe(true)
+    // Note: a pool-recycled VM may serve the re-acquire, so we don't assert
+    // boot was called twice — the user-visible semantic is "fresh state under
+    // this id", and pool.reset already guarantees a fresh container.
+  })
+
+  it('{ fresh: true } (no id) bypasses pool and attachment table', async () => {
+    const kit = buildKit()
+    const poolAcquireSpy = vi.spyOn(kit.pool, 'acquire')
+    const poolReleaseSpy = vi.spyOn(kit.pool, 'release')
+
+    const inner = fakePattern(async (scope) => scope)
+    await withSandbox({ ...kit, fresh: true })(inner).fn(fakeScope({}), fakeView)
+
+    expect(poolAcquireSpy).not.toHaveBeenCalled()
+    expect(poolReleaseSpy).not.toHaveBeenCalled()
+    expect(kit.backend.calls.boot).toHaveLength(1)
+    expect(kit.backend.calls.destroy).toHaveLength(1)
+    expect(kit.attachments.size()).toBe(0)
+    expect(kit.pool.size()).toBe(0)
+  })
+
+  it('{ fresh: true } (no id) destroys the VM even when the inner pattern throws', async () => {
+    const kit = buildKit()
+    const inner = fakePattern(async () => {
+      throw new Error('boom')
+    })
+
+    await expect(
+      withSandbox({ ...kit, fresh: true })(inner).fn(fakeScope({}), fakeView),
+    ).rejects.toThrow('boom')
+    expect(kit.backend.calls.destroy).toHaveLength(1)
+  })
+
+  it('{ id } refCount drops to 0 after release; reacquire reuses without booting', async () => {
+    const kit = buildKit()
+    const inner = fakePattern(async (scope) => scope)
+    const wrap = withSandbox({ ...kit, id: 'session-42' })(inner)
+
+    await wrap.fn(fakeScope({}), fakeView)
+    // After release, refCount=0 but entry stays. Sweeper hasn't run.
+    expect(kit.attachments.has('session-42')).toBe(true)
+    const before = kit.backend.calls.boot.length
+
+    await wrap.fn(fakeScope({}), fakeView)
+    expect(kit.backend.calls.boot.length).toBe(before) // no extra boot
   })
 })

--- a/ui/src/__tests__/lib/sandbox/with-sandbox.test.ts
+++ b/ui/src/__tests__/lib/sandbox/with-sandbox.test.ts
@@ -1,0 +1,195 @@
+/**
+ * `withSandbox` wrapper unit tests.
+ *
+ * Backend is mocked — these tests don't spawn containers. They verify the
+ * wrapper's sequencing (boot → connectMcp → runWithSandbox(inner.fn) →
+ * close + destroy), cleanup discipline on partial failure, and the
+ * visibility guarantee that the inner pattern sees the transport via ALS.
+ */
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('../../../lib/harness-patterns/assert.server', () => ({
+  assertServerOnImport: vi.fn(),
+}))
+
+import { withSandbox } from '../../../lib/sandbox/with-sandbox.server'
+import { getActiveSandbox } from '../../../lib/sandbox/scope.server'
+import type {
+  ComputeBackend,
+  HealthStatus,
+  McpTransport,
+  RootfsId,
+  RuntimeConfig,
+  VMHandle,
+} from '../../../lib/sandbox/types'
+import type {
+  ConfiguredPattern,
+  PatternScope,
+  EventView,
+} from '../../../lib/harness-patterns/types'
+
+type Calls = {
+  boot: Array<{ rootfs: RootfsId; runtime: RuntimeConfig }>
+  destroy: VMHandle[]
+  connectMcp: VMHandle[]
+  closes: number
+}
+
+function fakeBackend(opts?: {
+  connectMcpFails?: boolean
+}): ComputeBackend & { calls: Calls } {
+  const calls: Calls = { boot: [], destroy: [], connectMcp: [], closes: 0 }
+  const handle: VMHandle = {
+    id: 'sbx-test',
+    backend: 'docker',
+    rootfs: 'base',
+    bootedAt: Date.now(),
+    native: { containerId: 'cid-test' },
+  }
+  const transport: McpTransport = {
+    vmId: handle.id,
+    toolNames: async () => ['sandbox_bash'],
+    listTools: async () => [
+      { name: 'sandbox_bash', description: 'run a shell command', inputSchema: {} },
+    ],
+    ownsTool: (name: string) => name === 'sandbox_bash',
+    callTool: async () => ({ success: true, data: null }),
+    close: async () => {
+      calls.closes += 1
+    },
+  }
+  const backend: ComputeBackend & { calls: Calls } = {
+    kind: 'docker',
+    calls,
+    async boot(rootfs, runtime) {
+      calls.boot.push({ rootfs, runtime })
+      return handle
+    },
+    async destroy(vm) {
+      calls.destroy.push(vm)
+    },
+    async reset() {
+      throw new Error('not used')
+    },
+    async connectMcp(vm) {
+      calls.connectMcp.push(vm)
+      if (opts?.connectMcpFails) throw new Error('boom')
+      return transport
+    },
+    async health(): Promise<HealthStatus> {
+      return { state: 'healthy' }
+    },
+  }
+  return backend
+}
+
+function fakePattern<T extends Record<string, unknown>>(
+  fn: (scope: PatternScope<T>, view: EventView) => Promise<PatternScope<T>>,
+): ConfiguredPattern<T> {
+  return {
+    name: 'inner',
+    fn,
+    config: { patternId: 'inner', trackHistory: true, errorSeverity: 'irrecoverable' },
+    estimateTurns: () => 3,
+  }
+}
+
+function fakeScope<T>(data: T): PatternScope<T> {
+  return { id: 'inner', events: [], data, startTime: Date.now() }
+}
+
+const fakeView = {} as unknown as EventView
+
+describe('withSandbox', () => {
+  it('boots, runs the inner pattern, then closes and destroys', async () => {
+    const backend = fakeBackend()
+    let innerRan = false
+    const inner = fakePattern<{ ran?: boolean }>(async (scope) => {
+      innerRan = true
+      scope.data = { ...scope.data, ran: true }
+      return scope
+    })
+
+    const wrapped = withSandbox({ backend, rootfs: 'base' })(inner)
+    const out = await wrapped.fn(fakeScope({}), fakeView)
+
+    expect(innerRan).toBe(true)
+    expect(out.data.ran).toBe(true)
+    expect(backend.calls.boot).toHaveLength(1)
+    expect(backend.calls.boot[0].rootfs).toBe('base')
+    expect(backend.calls.connectMcp).toHaveLength(1)
+    expect(backend.calls.closes).toBe(1)
+    expect(backend.calls.destroy).toHaveLength(1)
+  })
+
+  it('exposes the transport to the inner pattern via getActiveSandbox', async () => {
+    const backend = fakeBackend()
+    let seenVmId: string | undefined
+    let seenOwns: boolean | undefined
+    const inner = fakePattern(async (scope) => {
+      const t = getActiveSandbox()
+      seenVmId = t?.vmId
+      seenOwns = t?.ownsTool('sandbox_bash')
+      return scope
+    })
+
+    await withSandbox({ backend })(inner).fn(fakeScope({}), fakeView)
+
+    expect(seenVmId).toBe('sbx-test')
+    expect(seenOwns).toBe(true)
+    expect(getActiveSandbox()).toBeUndefined()
+  })
+
+  it('destroys the VM if connectMcp fails (no leak)', async () => {
+    const backend = fakeBackend({ connectMcpFails: true })
+    const inner = fakePattern(async (scope) => scope)
+
+    const wrapped = withSandbox({ backend })(inner)
+    await expect(wrapped.fn(fakeScope({}), fakeView)).rejects.toThrow('boom')
+
+    expect(backend.calls.boot).toHaveLength(1)
+    expect(backend.calls.destroy).toHaveLength(1)
+    // transport never opened, so no close call
+    expect(backend.calls.closes).toBe(0)
+  })
+
+  it('runs cleanup even if the inner pattern throws', async () => {
+    const backend = fakeBackend()
+    const inner = fakePattern(async () => {
+      throw new Error('inner failure')
+    })
+
+    const wrapped = withSandbox({ backend })(inner)
+    await expect(wrapped.fn(fakeScope({}), fakeView)).rejects.toThrow('inner failure')
+
+    expect(backend.calls.closes).toBe(1)
+    expect(backend.calls.destroy).toHaveLength(1)
+  })
+
+  it('forwards rootfs, resources, and egress to backend.boot', async () => {
+    const backend = fakeBackend()
+    const inner = fakePattern(async (scope) => scope)
+
+    await withSandbox({
+      backend,
+      rootfs: 'base',
+      resources: { cpus: 2, memoryMB: 1024 },
+      egress: 'open',
+    })(inner).fn(fakeScope({}), fakeView)
+
+    expect(backend.calls.boot[0]).toEqual({
+      rootfs: 'base',
+      runtime: { cpus: 2, memoryMB: 1024, egress: 'open' },
+    })
+  })
+
+  it('prefixes the inner pattern name and preserves config / estimateTurns', () => {
+    const backend = fakeBackend()
+    const inner = fakePattern(async (scope) => scope)
+    const wrapped = withSandbox({ backend })(inner)
+
+    expect(wrapped.name).toBe('withSandbox(inner)')
+    expect(wrapped.config).toEqual(inner.config)
+    expect(wrapped.estimateTurns?.({ maxToolTurns: 10, maxRetries: 3 })).toBe(3)
+  })
+})

--- a/ui/src/components/ark-ui/InteractiveTerminal.tsx
+++ b/ui/src/components/ark-ui/InteractiveTerminal.tsx
@@ -1,0 +1,152 @@
+/**
+ * InteractiveTerminal — xterm.js bound to a session's sandbox PTY (#79).
+ *
+ * Client-only widget (xterm needs the DOM, so it's all built in onMount with
+ * dynamic imports to stay SSR-safe). Transport is SSE-down / POST-up:
+ *   - EventSource /api/sandbox/pty/stream?sessionId  -> term.write (JSON-decoded)
+ *   - term.onData -> POST /api/sandbox/pty/input { sessionId, data }
+ *   - fit + ResizeObserver -> POST /api/sandbox/pty/resize { sessionId, cols, rows }
+ *
+ * Mounting opens (or attaches to) the session's live sandbox shell; the
+ * backend keeps the PTY alive across unmounts (tab switches) and replays
+ * scrollback on reconnect, so the shell's cwd/env/processes persist.
+ */
+import { onMount, onCleanup, createSignal } from 'solid-js'
+
+export interface InteractiveTerminalProps {
+  sessionId: string
+}
+
+type ConnState = 'connecting' | 'connected' | 'closed'
+
+export const InteractiveTerminal = (props: InteractiveTerminalProps) => {
+  let containerRef: HTMLDivElement | undefined
+  const [state, setState] = createSignal<ConnState>('connecting')
+
+  // Register cleanup SYNCHRONOUSLY — onCleanup called after an `await` inside
+  // onMount loses the reactive owner and never runs (Solid warns). We stash
+  // the real disposer once async setup finishes; `disposed` covers the case
+  // where the component unmounts mid-boot (fast tab switch).
+  let disposed = false
+  let dispose: (() => void) | undefined
+  onCleanup(() => {
+    disposed = true
+    dispose?.()
+  })
+
+  onMount(async () => {
+    const [{ Terminal }, { FitAddon }] = await Promise.all([
+      import('@xterm/xterm'),
+      import('@xterm/addon-fit'),
+      import('@xterm/xterm/css/xterm.css'),
+    ])
+
+    const term = new Terminal({
+      cursorBlink: true,
+      fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace',
+      fontSize: 13,
+      theme: { background: '#0a0a0a', foreground: '#e4e4e7', cursor: '#10b981' },
+      scrollback: 5000,
+    })
+    const fit = new FitAddon()
+    term.loadAddon(fit)
+    if (!containerRef) return
+    term.open(containerRef)
+    try {
+      fit.fit()
+    } catch {
+      /* container not sized yet; ResizeObserver will refit */
+    }
+
+    const sessionId = props.sessionId
+
+    const postResize = () => {
+      try {
+        fit.fit()
+      } catch {
+        /* ignore */
+      }
+      fetch('/api/sandbox/pty/resize', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sessionId, cols: term.cols, rows: term.rows }),
+      }).catch(() => {})
+    }
+
+    // Keystrokes (and pasted control sequences) up.
+    const dataSub = term.onData((data) => {
+      fetch('/api/sandbox/pty/input', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sessionId, data }),
+      }).catch(() => {})
+    })
+
+    // PTY output down. Each frame is a JSON-encoded raw byte string.
+    const es = new EventSource(
+      `/api/sandbox/pty/stream?sessionId=${encodeURIComponent(sessionId)}`,
+    )
+    es.onopen = () => {
+      setState('connected')
+      postResize()
+    }
+    es.onmessage = (ev) => {
+      try {
+        term.write(JSON.parse(ev.data) as string)
+      } catch {
+        /* malformed frame; skip */
+      }
+    }
+    es.onerror = () => setState('closed')
+
+    const ro = new ResizeObserver(() => postResize())
+    ro.observe(containerRef)
+
+    term.focus()
+
+    const teardown = () => {
+      dataSub.dispose()
+      es.close()
+      ro.disconnect()
+      term.dispose()
+    }
+
+    // Unmounted while we were still booting/wiring — tear down now.
+    if (disposed) {
+      teardown()
+      return
+    }
+    dispose = teardown
+  })
+
+  return (
+    <div flex="~ col" h="full" bg="black" style={{ position: 'relative' }}>
+      <div
+        flex="~"
+        items="center"
+        gap="2"
+        p="1 3"
+        bg="dark-bg-tertiary"
+        border="b dark-border-primary"
+      >
+        <span
+          style={{
+            width: '8px',
+            height: '8px',
+            'border-radius': '9999px',
+            'background-color':
+              state() === 'connected' ? '#10b981' : state() === 'closed' ? '#ef4444' : '#f59e0b',
+          }}
+        />
+        <span text="2xs dark-text-secondary" font="mono">
+          {state() === 'connected'
+            ? 'sandbox shell · /work · mcp-only'
+            : state() === 'closed'
+              ? 'disconnected'
+              : 'connecting…'}
+        </span>
+      </div>
+      <div ref={containerRef} style={{ flex: '1', 'min-height': '0', padding: '4px' }} />
+    </div>
+  )
+}

--- a/ui/src/components/ark-ui/ObservabilityPanel.tsx
+++ b/ui/src/components/ark-ui/ObservabilityPanel.tsx
@@ -20,6 +20,7 @@ import type {
   AssistantMessageEventData,
   ApprovalRequestEventData,
   ErrorEventData,
+  IntentCompactedEventData,
   LLMCallData,
   UnifiedContext
 } from '~/lib/harness-patterns'
@@ -60,7 +61,8 @@ const eventIcons: Record<EventType, string> = {
   approval_request: '⏸️',
   approval_response: '✅',
   error: '❌',
-  reference_attached: '🔗'
+  reference_attached: '🔗',
+  intent_compacted: '🎯'
 }
 
 const eventColors: Record<EventType, string> = {
@@ -75,7 +77,8 @@ const eventColors: Record<EventType, string> = {
   approval_request: '#f97316',  // orange-500
   approval_response: '#10b981', // emerald-500
   error: '#ef4444',             // red-500
-  reference_attached: '#c084fc' // purple-400
+  reference_attached: '#c084fc', // purple-400
+  intent_compacted: '#fbbf24'   // amber-400 (an LLM reasoning step, like controller_action)
 }
 
 // ============================================================================
@@ -109,6 +112,11 @@ function getEventPreview(type: EventType, data: unknown): string {
     case 'error': {
       const d = data as ErrorEventData
       return d.error.slice(0, 50)
+    }
+    case 'intent_compacted': {
+      const d = data as IntentCompactedEventData
+      const brief = d.intent || ''
+      return brief.length > 50 ? brief.slice(0, 50) + '...' : brief
     }
     case 'pattern_enter':
     case 'pattern_exit':

--- a/ui/src/components/ark-ui/SupportPanel.tsx
+++ b/ui/src/components/ark-ui/SupportPanel.tsx
@@ -304,9 +304,9 @@ export const SupportPanel = (props: SupportPanelProps) => {
             <ToolsPanel sessionId={props.sessionId} />
           </Tabs.Content>
 
-          {/* Terminal Tab — read-only in-VM sandbox feed (#79) */}
+          {/* Terminal Tab — read-only feed + interactive shell (#79) */}
           <Tabs.Content value="terminal" h="full">
-            <TerminalPanel events={props.contextEvents ?? []} />
+            <TerminalPanel events={props.contextEvents ?? []} sessionId={props.sessionId} />
           </Tabs.Content>
 
           {/* Actions Tab (Future) */}

--- a/ui/src/components/ark-ui/SupportPanel.tsx
+++ b/ui/src/components/ark-ui/SupportPanel.tsx
@@ -11,6 +11,7 @@ import { GraphVisualization } from './GraphVisualization';
 import { ObservabilityPanel } from './ObservabilityPanel';
 import { DataStashPanel, type StashAction } from './DataStashPanel';
 import { ToolsPanel } from './ToolsPanel';
+import { TerminalPanel } from './TerminalPanel';
 import { AllGraphTabWrapper } from './AllGraphTab';
 import type { ElementDefinition, StylesheetJsonBlock } from 'cytoscape';
 import type { ContextEvent, UnifiedContext } from '~/lib/harness-patterns';
@@ -200,6 +201,23 @@ export const SupportPanel = (props: SupportPanelProps) => {
           </Tabs.Trigger>
 
           <Tabs.Trigger
+            value="terminal"
+            p="x-3 y-2"
+            text="sm dark-text-primary"
+            cursor="pointer"
+            border="b-2 transparent"
+            transition="all"
+            data-state={selectedTab() === 'terminal' ? 'active' : 'inactive'}
+            style={{
+              "border-bottom-color": selectedTab() === 'terminal' ? '#10b981' : 'transparent',
+              "color": selectedTab() === 'terminal' ? '#10b981' : '#a1a1aa'
+            }}
+          >
+            <span mr="1">🖥️</span>
+            Terminal
+          </Tabs.Trigger>
+
+          <Tabs.Trigger
             value="actions"
             p="x-3 y-2"
             text="sm dark-text-tertiary"
@@ -284,6 +302,11 @@ export const SupportPanel = (props: SupportPanelProps) => {
           {/* Tools Tab */}
           <Tabs.Content value="tools" h="full">
             <ToolsPanel sessionId={props.sessionId} />
+          </Tabs.Content>
+
+          {/* Terminal Tab — read-only in-VM sandbox feed (#79) */}
+          <Tabs.Content value="terminal" h="full">
+            <TerminalPanel events={props.contextEvents ?? []} />
           </Tabs.Content>
 
           {/* Actions Tab (Future) */}

--- a/ui/src/components/ark-ui/TerminalPanel.tsx
+++ b/ui/src/components/ark-ui/TerminalPanel.tsx
@@ -13,9 +13,10 @@
  * Pairing is by the `callId` that links a `tool_call` to its `tool_result`.
  */
 
-import { For, Show, createMemo } from 'solid-js'
+import { For, Show, createMemo, createSignal } from 'solid-js'
 import type { ContextEvent } from '~/lib/harness-patterns'
 import { SANDBOX_TOOL_PREFIX } from '~/lib/sandbox/types'
+import { InteractiveTerminal } from './InteractiveTerminal'
 
 // Local, defensive views of the event payloads (the panel never trusts shape).
 interface ToolCallData {
@@ -46,6 +47,8 @@ interface TerminalEntry {
 
 export interface TerminalPanelProps {
   events: ContextEvent[]
+  /** Active session id — required to open an interactive shell. */
+  sessionId?: string
 }
 
 function isSandboxTool(name: unknown): name is string {
@@ -153,94 +156,130 @@ export const TerminalPanel = (props: TerminalPanelProps) => {
     return order
   })
 
+  const [view, setView] = createSignal<'activity' | 'shell'>('activity')
+  const hasSession = () => typeof props.sessionId === 'string' && props.sessionId.length > 0
+
   return (
     <div flex="~ col" h="full" bg="dark-bg-primary" overflow="hidden">
+      {/* Header: count + Activity/Shell toggle */}
+      <div
+        flex="~"
+        items="center"
+        justify="between"
+        p="2 3"
+        bg="dark-bg-tertiary"
+        border="b dark-border-primary"
+      >
+        <div flex="~" items="center" gap="2">
+          <span class="i-mdi-console" style={{ width: '16px', height: '16px', color: '#10b981' }} />
+          <span text="xs dark-text-secondary">
+            {entries().length} sandbox {entries().length === 1 ? 'command' : 'commands'}
+          </span>
+        </div>
+        <div flex="~" items="center" gap="1">
+          <button
+            onClick={() => setView('activity')}
+            p="x-2 y-0.5"
+            text={view() === 'activity' ? 'xs emerald-400' : 'xs dark-text-tertiary'}
+            bg={view() === 'activity' ? 'emerald-600/15' : 'transparent hover:dark-bg-primary'}
+            border="1 transparent"
+            rounded="md"
+            cursor="pointer"
+            transition="all"
+          >
+            Activity
+          </button>
+          <button
+            onClick={() => hasSession() && setView('shell')}
+            disabled={!hasSession()}
+            title={hasSession() ? 'Open an interactive shell in this session sandbox' : 'No active session'}
+            p="x-2 y-0.5"
+            text={view() === 'shell' ? 'xs emerald-400' : 'xs dark-text-tertiary'}
+            bg={view() === 'shell' ? 'emerald-600/15' : 'transparent hover:dark-bg-primary'}
+            border="1 transparent"
+            rounded="md"
+            cursor={hasSession() ? 'pointer' : 'not-allowed'}
+            opacity={hasSession() ? '100' : '40'}
+            transition="all"
+          >
+            Shell
+          </button>
+        </div>
+      </div>
+
+      {/* Body */}
       <Show
-        when={entries().length > 0}
+        when={view() === 'shell' && hasSession()}
         fallback={
-          <div flex="~ col" items="center" justify="center" h="full" text="center" gap="3">
-            <span text="4xl">🖥️</span>
-            <span text="sm dark-text-secondary" max-w="xs">
-              No sandbox activity yet. Run the <strong>Sandbox Demo</strong> agent
-              (or any agent wrapped in <code>withSandbox</code>) and the in-VM
-              commands and their output will stream here.
-            </span>
-          </div>
+          <Show
+            when={entries().length > 0}
+            fallback={
+              <div flex="~ col" items="center" justify="center" h="full" text="center" gap="3">
+                <span text="4xl">🖥️</span>
+                <span text="sm dark-text-secondary" max-w="xs">
+                  No sandbox activity yet. Run the <strong>Sandbox Demo</strong> agent
+                  (or any agent wrapped in <code>withSandbox</code>) to see commands
+                  here — or hit <strong>Shell</strong> to open a live terminal in this
+                  session's sandbox.
+                </span>
+              </div>
+            }
+          >
+            {/* Read-only activity feed */}
+            <div flex="1" overflow="auto" p="3" font="mono" bg="black/40">
+              <For each={entries()}>
+                {(e) => (
+                  <div m="b-3">
+                    <div flex="~" items="start" gap="2">
+                      <span text="sm emerald-400" style={{ 'flex-shrink': '0' }}>$</span>
+                      <span
+                        text="xs emerald-300"
+                        style={{ 'white-space': 'pre-wrap', 'word-break': 'break-word' }}
+                      >
+                        {e.command}
+                      </span>
+                    </div>
+                    <Show when={e.pending}>
+                      <div text="2xs amber-400" m="t-1" pl="4">running…</div>
+                    </Show>
+                    <Show when={!e.pending && e.output}>
+                      <pre
+                        text="xs dark-text-primary"
+                        m="t-1 b-0"
+                        pl="4"
+                        style={{ 'white-space': 'pre-wrap', 'word-break': 'break-word' }}
+                      >
+                        {e.output}
+                      </pre>
+                    </Show>
+                    <Show when={e.stderr}>
+                      <pre
+                        text="xs amber-300"
+                        m="t-1 b-0"
+                        pl="4"
+                        style={{ 'white-space': 'pre-wrap', 'word-break': 'break-word' }}
+                      >
+                        {e.stderr}
+                      </pre>
+                    </Show>
+                    <Show when={!e.pending && (e.success === false || e.error)}>
+                      <div text="2xs red-400" m="t-1" pl="4">
+                        {e.error ?? 'command failed'}
+                      </div>
+                    </Show>
+                    <Show when={typeof e.exitCode === 'number' && e.exitCode !== 0}>
+                      <div text="2xs red-400" m="t-1" pl="4">exit {e.exitCode}</div>
+                    </Show>
+                  </div>
+                )}
+              </For>
+            </div>
+          </Show>
         }
       >
-        {/* Header */}
-        <div
-          flex="~"
-          items="center"
-          justify="between"
-          p="2 3"
-          bg="dark-bg-tertiary"
-          border="b dark-border-primary"
-        >
-          <div flex="~" items="center" gap="2">
-            <span class="i-mdi-console" style={{ width: '16px', height: '16px', color: '#10b981' }} />
-            <span text="xs dark-text-secondary">
-              {entries().length} sandbox {entries().length === 1 ? 'command' : 'commands'}
-            </span>
-          </div>
-          <span text="2xs dark-text-tertiary" font="mono">/work · mcp-only</span>
-        </div>
-
-        {/* Feed */}
-        <div flex="1" overflow="auto" p="3" font="mono" bg="black/40">
-          <For each={entries()}>
-            {(e) => (
-              <div m="b-3">
-                {/* Prompt line */}
-                <div flex="~" items="start" gap="2">
-                  <span text="sm emerald-400" style={{ 'flex-shrink': '0' }}>$</span>
-                  <span
-                    text="xs emerald-300"
-                    style={{ 'white-space': 'pre-wrap', 'word-break': 'break-word' }}
-                  >
-                    {e.command}
-                  </span>
-                </div>
-
-                {/* stdout / result */}
-                <Show when={e.pending}>
-                  <div text="2xs amber-400" m="t-1" pl="4">running…</div>
-                </Show>
-                <Show when={!e.pending && e.output}>
-                  <pre
-                    text="xs dark-text-primary"
-                    m="t-1 b-0"
-                    pl="4"
-                    style={{ 'white-space': 'pre-wrap', 'word-break': 'break-word' }}
-                  >
-                    {e.output}
-                  </pre>
-                </Show>
-
-                {/* stderr */}
-                <Show when={e.stderr}>
-                  <pre
-                    text="xs amber-300"
-                    m="t-1 b-0"
-                    pl="4"
-                    style={{ 'white-space': 'pre-wrap', 'word-break': 'break-word' }}
-                  >
-                    {e.stderr}
-                  </pre>
-                </Show>
-
-                {/* error / non-zero exit */}
-                <Show when={!e.pending && (e.success === false || e.error)}>
-                  <div text="2xs red-400" m="t-1" pl="4">
-                    {e.error ?? 'command failed'}
-                  </div>
-                </Show>
-                <Show when={typeof e.exitCode === 'number' && e.exitCode !== 0}>
-                  <div text="2xs red-400" m="t-1" pl="4">exit {e.exitCode}</div>
-                </Show>
-              </div>
-            )}
-          </For>
+        {/* Interactive shell — mounts the xterm bound to this session's PTY */}
+        <div flex="1" overflow="hidden">
+          <InteractiveTerminal sessionId={props.sessionId!} />
         </div>
       </Show>
     </div>

--- a/ui/src/components/ark-ui/TerminalPanel.tsx
+++ b/ui/src/components/ark-ui/TerminalPanel.tsx
@@ -1,0 +1,248 @@
+/**
+ * Terminal Panel
+ *
+ * Read-only feed of the agent's in-VM sandbox activity (#79, step 7).
+ *
+ * It derives entirely from the existing event stream — no new event type, no
+ * protocol changes. It filters `contextEvents` for `sandbox_*` tool calls
+ * (which the sandboxed actorCritic loop already emits with `liveEvents: true`)
+ * and renders each as a shell-style entry: a prompt line for the command and
+ * the command's stdout / result below it. Entries appear as each tool call
+ * completes — the same cadence the observability timeline shows.
+ *
+ * Pairing is by the `callId` that links a `tool_call` to its `tool_result`.
+ */
+
+import { For, Show, createMemo } from 'solid-js'
+import type { ContextEvent } from '~/lib/harness-patterns'
+import { SANDBOX_TOOL_PREFIX } from '~/lib/sandbox/types'
+
+// Local, defensive views of the event payloads (the panel never trusts shape).
+interface ToolCallData {
+  callId?: string
+  tool?: string
+  args?: unknown
+}
+interface ToolResultData {
+  callId?: string
+  tool?: string
+  result?: unknown
+  success?: boolean
+  error?: string
+}
+
+interface TerminalEntry {
+  key: string
+  tool: string
+  /** Shell-style command/op line, e.g. `python3 /work/count.py` or `write /work/x.py`. */
+  command: string
+  output?: string
+  stderr?: string
+  exitCode?: number
+  error?: string
+  success?: boolean
+  pending: boolean
+}
+
+export interface TerminalPanelProps {
+  events: ContextEvent[]
+}
+
+function isSandboxTool(name: unknown): name is string {
+  return typeof name === 'string' && name.startsWith(SANDBOX_TOOL_PREFIX)
+}
+
+/** Strip the `sandbox_` prefix for display. */
+function shortTool(tool: string): string {
+  return tool.startsWith(SANDBOX_TOOL_PREFIX) ? tool.slice(SANDBOX_TOOL_PREFIX.length) : tool
+}
+
+/** Human-readable command line for the prompt. */
+function formatCommand(tool: string, args: unknown): string {
+  const a = (args ?? {}) as Record<string, unknown>
+  const str = (v: unknown): string => (typeof v === 'string' ? v : JSON.stringify(v))
+  switch (tool) {
+    case 'sandbox_bash':
+      return typeof a.command === 'string' ? a.command : str(a)
+    case 'sandbox_write':
+      return `write ${str(a.path)}`
+    case 'sandbox_read':
+      return `read ${str(a.path)}`
+    case 'sandbox_edit':
+      return `edit ${str(a.path)}`
+    case 'sandbox_list':
+      return `ls ${typeof a.path === 'string' ? a.path : '/work'}`
+    case 'sandbox_search':
+      return `search ${str(a.pattern ?? a.query ?? '')}`
+    default:
+      return `${shortTool(tool)} ${str(a)}`
+  }
+}
+
+/** Pull stdout / stderr / exit code out of a tool result, falling back to JSON. */
+function formatResult(result: unknown): { output: string; stderr?: string; exitCode?: number } {
+  if (result == null) return { output: '' }
+  if (typeof result === 'string') return { output: result }
+  if (typeof result === 'object') {
+    const r = result as Record<string, unknown>
+    if ('stdout' in r || 'exit_code' in r || 'stderr' in r) {
+      return {
+        output: typeof r.stdout === 'string' ? r.stdout : '',
+        stderr: typeof r.stderr === 'string' && r.stderr.length > 0 ? r.stderr : undefined,
+        exitCode: typeof r.exit_code === 'number' ? r.exit_code : undefined,
+      }
+    }
+  }
+  try {
+    return { output: JSON.stringify(result, null, 2) }
+  } catch {
+    return { output: String(result) }
+  }
+}
+
+export const TerminalPanel = (props: TerminalPanelProps) => {
+  const entries = createMemo<TerminalEntry[]>(() => {
+    const order: TerminalEntry[] = []
+    const byKey = new Map<string, TerminalEntry>()
+    let anon = 0
+
+    for (const ev of props.events ?? []) {
+      if (ev.type === 'tool_call') {
+        const d = ev.data as ToolCallData
+        if (!isSandboxTool(d.tool)) continue
+        const key = d.callId ?? `call-${anon++}`
+        const entry: TerminalEntry = {
+          key,
+          tool: d.tool,
+          command: formatCommand(d.tool, d.args),
+          pending: true,
+        }
+        byKey.set(key, entry)
+        order.push(entry)
+      } else if (ev.type === 'tool_result') {
+        const d = ev.data as ToolResultData
+        if (!isSandboxTool(d.tool)) continue
+        const existing = d.callId ? byKey.get(d.callId) : undefined
+        const { output, stderr, exitCode } = formatResult(d.result)
+        if (existing) {
+          existing.pending = false
+          existing.success = d.success
+          existing.error = d.error
+          existing.output = output
+          existing.stderr = stderr
+          existing.exitCode = exitCode
+        } else {
+          // Result without a seen call (defensive) — render standalone.
+          const key = d.callId ?? `result-${anon++}`
+          const entry: TerminalEntry = {
+            key,
+            tool: d.tool ?? 'sandbox',
+            command: shortTool(d.tool ?? 'sandbox'),
+            pending: false,
+            success: d.success,
+            error: d.error,
+            output,
+            stderr,
+            exitCode,
+          }
+          byKey.set(key, entry)
+          order.push(entry)
+        }
+      }
+    }
+    return order
+  })
+
+  return (
+    <div flex="~ col" h="full" bg="dark-bg-primary" overflow="hidden">
+      <Show
+        when={entries().length > 0}
+        fallback={
+          <div flex="~ col" items="center" justify="center" h="full" text="center" gap="3">
+            <span text="4xl">🖥️</span>
+            <span text="sm dark-text-secondary" max-w="xs">
+              No sandbox activity yet. Run the <strong>Sandbox Demo</strong> agent
+              (or any agent wrapped in <code>withSandbox</code>) and the in-VM
+              commands and their output will stream here.
+            </span>
+          </div>
+        }
+      >
+        {/* Header */}
+        <div
+          flex="~"
+          items="center"
+          justify="between"
+          p="2 3"
+          bg="dark-bg-tertiary"
+          border="b dark-border-primary"
+        >
+          <div flex="~" items="center" gap="2">
+            <span class="i-mdi-console" style={{ width: '16px', height: '16px', color: '#10b981' }} />
+            <span text="xs dark-text-secondary">
+              {entries().length} sandbox {entries().length === 1 ? 'command' : 'commands'}
+            </span>
+          </div>
+          <span text="2xs dark-text-tertiary" font="mono">/work · mcp-only</span>
+        </div>
+
+        {/* Feed */}
+        <div flex="1" overflow="auto" p="3" font="mono" bg="black/40">
+          <For each={entries()}>
+            {(e) => (
+              <div m="b-3">
+                {/* Prompt line */}
+                <div flex="~" items="start" gap="2">
+                  <span text="sm emerald-400" style={{ 'flex-shrink': '0' }}>$</span>
+                  <span
+                    text="xs emerald-300"
+                    style={{ 'white-space': 'pre-wrap', 'word-break': 'break-word' }}
+                  >
+                    {e.command}
+                  </span>
+                </div>
+
+                {/* stdout / result */}
+                <Show when={e.pending}>
+                  <div text="2xs amber-400" m="t-1" pl="4">running…</div>
+                </Show>
+                <Show when={!e.pending && e.output}>
+                  <pre
+                    text="xs dark-text-primary"
+                    m="t-1 b-0"
+                    pl="4"
+                    style={{ 'white-space': 'pre-wrap', 'word-break': 'break-word' }}
+                  >
+                    {e.output}
+                  </pre>
+                </Show>
+
+                {/* stderr */}
+                <Show when={e.stderr}>
+                  <pre
+                    text="xs amber-300"
+                    m="t-1 b-0"
+                    pl="4"
+                    style={{ 'white-space': 'pre-wrap', 'word-break': 'break-word' }}
+                  >
+                    {e.stderr}
+                  </pre>
+                </Show>
+
+                {/* error / non-zero exit */}
+                <Show when={!e.pending && (e.success === false || e.error)}>
+                  <div text="2xs red-400" m="t-1" pl="4">
+                    {e.error ?? 'command failed'}
+                  </div>
+                </Show>
+                <Show when={typeof e.exitCode === 'number' && e.exitCode !== 0}>
+                  <div text="2xs red-400" m="t-1" pl="4">exit {e.exitCode}</div>
+                </Show>
+              </div>
+            )}
+          </For>
+        </div>
+      </Show>
+    </div>
+  )
+}

--- a/ui/src/lib/harness-client/examples/README.md
+++ b/ui/src/lib/harness-client/examples/README.md
@@ -28,6 +28,7 @@ compositions across all available MCP servers.
 | `withApproval` | `(pattern, predicate)` | Pause for user approval on matching actions |
 | `withReferences` | `(pattern, config?)` | LLM-curated prior-result attachment at pattern ingress (cross-pattern data flow, [#30](../../../../docs/harness-patterns/with-references.md)) |
 | `synthesizer` | `(config)` | Transform tool results into natural language |
+| `compactIntent` | `(config?)` | Rewrite the latest message into a self-contained `data.intent` for a router-less actor ([#83](https://github.com/mknw/harness-playground/issues/83)) |
 | `router` | `(routeDescriptions, config?)` | Intent classification → sets `data.route` |
 | `routes` | `(patternMap, config?)` | Dispatch to matched sub-pattern; pass-through on `'user'` route |
 | `chain` | `(ctx, patterns)` | Sequential composition |
@@ -1383,15 +1384,19 @@ time, no per-pattern wiring. See `sandbox-demo.server.ts`.
 ### 11. Sandbox · Session (`withSandbox({ id })` persistent + xterm)
 
 **Servers**: none (same as Sandbox Demo)
-**Patterns**: `chain(withSandbox({ id: sessionId })(actorCritic), synth)`
+**Patterns**: `[compactIntent, withSandbox({ id: sessionId })(actorCritic), synth]`
 **Use case**: A persistent workspace shared with the **interactive Shell
 terminal** in the Terminal panel. Agent writes a file → user can `cat` it in
 the Shell; same VM. The `id` keys the attachment to the conversation in
 `AttachmentTable`; the `PtyManager` keys on the same `sessionId`.
 
-Composes any actor-style pattern with id-addressable attachment. The current
-cross-turn-context gap (actor sees only the latest message) is tracked in
-[#83](https://github.com/mknw/harness-playground/issues/83) (`compactIntent`).
+Composes any actor-style pattern with id-addressable attachment. Because this
+agent is **router-less**, `compactIntent` runs first ([#83](https://github.com/mknw/harness-playground/issues/83)
+Part A) to rewrite bare follow-ups (*"I can't find the file"*) into a
+self-contained `data.intent` the actor can act on — turn 1 passes through
+unchanged. The actor also carries two `tool_args` few-shots
+([#85](https://github.com/mknw/harness-playground/issues/85)) so multi-line
+`sandbox_write` / quoted `sandbox_bash` calls emit valid JSON on the first try.
 
 See `sandbox-session.server.ts`. Debugging modalities for live sandboxes:
 [`docs/sandbox/README.md`](../../../../docs/sandbox/README.md).

--- a/ui/src/lib/harness-client/examples/README.md
+++ b/ui/src/lib/harness-client/examples/README.md
@@ -1358,6 +1358,44 @@ return [
 ];
 ```
 
+### 10. Sandbox Demo (`withSandbox` ephemeral)
+
+**Servers**: none (in-VM `sandbox_*` tools via the ALS scope, not the gateway)
+**Patterns**: `chain(withSandbox({})(actorCritic), synth)`
+**Use case**: Run untrusted code in an isolated Docker VM for a single turn.
+
+```typescript
+const actor = createActorControllerAdapter({ contextPrefix: SANDBOX_ACTOR_GUIDANCE })
+const critic = createCriticAdapter()
+const loop = actorCritic<SessionData>(actor, critic, [], {
+  patternId: 'sandbox-loop',
+  availableTools: [],
+  liveEvents: true,
+})
+const sandboxed = withSandbox({ rootfs: 'base' })(loop)
+return [sandboxed, synthesizer({ mode: 'thread' })]
+```
+
+Each turn gets a fresh VM (warm-pool amortized). Tools surface as `sandbox_*`
+through the ALS scope — actor's adapter prepends them to the prompt at call
+time, no per-pattern wiring. See `sandbox-demo.server.ts`.
+
+### 11. Sandbox · Session (`withSandbox({ id })` persistent + xterm)
+
+**Servers**: none (same as Sandbox Demo)
+**Patterns**: `chain(withSandbox({ id: sessionId })(actorCritic), synth)`
+**Use case**: A persistent workspace shared with the **interactive Shell
+terminal** in the Terminal panel. Agent writes a file → user can `cat` it in
+the Shell; same VM. The `id` keys the attachment to the conversation in
+`AttachmentTable`; the `PtyManager` keys on the same `sessionId`.
+
+Composes any actor-style pattern with id-addressable attachment. The current
+cross-turn-context gap (actor sees only the latest message) is tracked in
+[#83](https://github.com/mknw/harness-playground/issues/83) (`compactIntent`).
+
+See `sandbox-session.server.ts`. Debugging modalities for live sandboxes:
+[`docs/sandbox/README.md`](../../../../docs/sandbox/README.md).
+
 ---
 
 ## Pattern Composition Matrix

--- a/ui/src/lib/harness-client/examples/code-mode.server.ts
+++ b/ui/src/lib/harness-client/examples/code-mode.server.ts
@@ -76,9 +76,9 @@ The kg-agent gateway exposes a "code-mode" factory tool. Use it to:
 3. SKIP REDUNDANT DISCOVERY. Tools already present in AVAILABLE TOOLS
    (above) don't need mcp-find or mcp-add — they're loaded.
 
-4. RETURN WHEN DONE OR NEAR BUDGET. When the script produces a usable
-   answer (or BUDGET shows you're near the max), call Return with the
-   data + a short summary. Do NOT chain more tools past that point.
+4. LET THE CRITIC DECIDE COMPLETION. You don't need a Return tool — the
+   critic evaluates each result and ends the loop when sufficient. Focus
+   on producing the right tool call; don't try to short-circuit.
 `.trim();
 
 /**

--- a/ui/src/lib/harness-client/examples/sandbox-demo.server.ts
+++ b/ui/src/lib/harness-client/examples/sandbox-demo.server.ts
@@ -87,7 +87,11 @@ async function createPatterns(sessionId: string): Promise<ConfiguredPattern<Sess
     patternId: "sandbox-synth",
     liveEvents: true,
     viewConfig: {
-      eventTypes: ["controller_action", "tool_call", "tool_result", "error"],
+      // Include user_message so the synthesizer frames the answer against the
+      // original question — without it, it sees only the tool trace ("9") and
+      // can't say what was computed. controller_action carries the actor's
+      // reasoning; error surfaces loop-exhaustion to view.hasErrors().
+      eventTypes: ["user_message", "controller_action", "tool_call", "tool_result", "error"],
     },
   });
 

--- a/ui/src/lib/harness-client/examples/sandbox-demo.server.ts
+++ b/ui/src/lib/harness-client/examples/sandbox-demo.server.ts
@@ -1,0 +1,106 @@
+/**
+ * Sandbox Demo Agent
+ *
+ * The simplest end-to-end exercise of the compute sandbox (#79): an
+ * `actorCritic` loop wrapped in `withSandbox`, followed by a synthesizer.
+ *
+ * The actor sees no host-gateway tools — its entire toolset is the in-VM
+ * `sandbox_*` surface (filesystem + shell), surfaced into its prompt by the
+ * BAML adapter from the active AsyncLocalStorage sandbox scope. Every tool
+ * call routes to the isolated VM over `docker exec` stdio; nothing touches
+ * the host gateway. The critic steers the actor (write a script → run it →
+ * accept once the result is in hand); the synthesizer reads the tool_result
+ * trace and reports the answer.
+ *
+ * Because the loop runs with `liveEvents: true`, each `tool_call` /
+ * `tool_result` streams to the UI as it happens — the existing observability
+ * timeline shows the sandbox commands and their stdout live, and the
+ * Terminal panel filters that same stream down to the `sandbox_*` calls.
+ *
+ * Requires the `kg-sandbox:base` image (see rootfs/README.md) and a reachable
+ * Docker engine on the host running the dev server.
+ */
+"use server";
+
+import {
+  actorCritic,
+  synthesizer,
+  createActorControllerAdapter,
+  createCriticAdapter,
+  type ConfiguredPattern,
+} from "../../harness-patterns";
+import { withSandbox } from "../../sandbox/with-sandbox.server";
+import type { SessionData } from "../session.server";
+import type { AgentConfig } from "../registry.server";
+
+/**
+ * Actor guidance prepended to the prompt. Teaches the actor that it has a
+ * real Linux sandbox and should compute answers by running code, not by
+ * reasoning over them. Mirrors the `contextPrefix` mechanism the code-mode
+ * agent uses.
+ */
+const SANDBOX_ACTOR_GUIDANCE = `
+You have an isolated Linux sandbox. Use it to compute answers by running
+code rather than reasoning about them in your head.
+
+Available tools (all run inside the sandbox VM):
+- sandbox_bash: run a shell command. Python 3 is available — e.g.
+  sandbox_bash({ command: "python3 -c '...'" }) or run a script you wrote.
+- sandbox_write / sandbox_read / sandbox_edit: manage files under /work.
+- sandbox_list / sandbox_search: inspect the working directory.
+
+Guidance:
+1. For anything computational (counting, parsing, math, data wrangling),
+   write or run code in the sandbox — don't guess the result.
+2. Files live under /work; the shell's cwd defaults there.
+3. When you have the answer, call Return with the result and a short summary.
+   Don't keep calling tools past that point.
+`.trim();
+
+async function createPatterns(sessionId: string): Promise<ConfiguredPattern<SessionData>[]> {
+  // No host-gateway tools — the actor's toolset is the in-VM sandbox_* surface,
+  // injected into its prompt from the active sandbox scope by the adapter.
+  const actor = createActorControllerAdapter({
+    contextPrefix: SANDBOX_ACTOR_GUIDANCE,
+  });
+  const critic = createCriticAdapter();
+
+  const loop = actorCritic<SessionData>(actor, critic, [], {
+    patternId: "sandbox-loop",
+    availableTools: [],
+    liveEvents: true,
+    maxRetries: 6,
+  });
+
+  // The sandbox lives for the loop's duration: boot/pool-acquire on entry,
+  // reset-and-park (or destroy) on exit. The synthesizer that follows reads
+  // the recorded tool_result events — it doesn't need the VM, so it stays
+  // outside the wrapper.
+  const sandboxedLoop = withSandbox({
+    rootfs: "base",
+    sessionId,
+    egress: "mcp-only",
+  })(loop);
+
+  const synth = synthesizer<SessionData>({
+    mode: "thread",
+    patternId: "sandbox-synth",
+    liveEvents: true,
+    viewConfig: {
+      eventTypes: ["controller_action", "tool_call", "tool_result", "error"],
+    },
+  });
+
+  return [sandboxedLoop, synth];
+}
+
+export const sandboxDemoAgent: AgentConfig = {
+  id: "sandbox-demo",
+  name: "Sandbox Demo",
+  description:
+    "Runs an actor-critic loop inside an isolated Docker sandbox VM — Python via sandbox_bash, files under /work.",
+  icon: "🧪",
+  // No host MCP servers — tools come from the in-VM filesystem + shell servers.
+  servers: [],
+  createPatterns,
+};

--- a/ui/src/lib/harness-client/examples/sandbox-session.server.ts
+++ b/ui/src/lib/harness-client/examples/sandbox-session.server.ts
@@ -1,0 +1,90 @@
+/**
+ * Sandbox Session Agent (persistent)
+ *
+ * Like the Sandbox Demo agent, but the sandbox is **session-persistent**:
+ * `withSandbox({ id: sessionId })` keys the VM to the conversation via the
+ * shared AttachmentTable, so every turn reuses the same container with its
+ * /work files, installed packages, and env intact — and it's the *same*
+ * container the interactive Shell terminal attaches to (the PTY manager keys
+ * on sessionId too). Write a file with the agent, then `cat` it in the
+ * Terminal tab's Shell; both see one workspace.
+ *
+ * Contrast with `sandbox-demo` (ephemeral): there each turn gets a fresh,
+ * reset VM. Pick this agent when follow-ups should build on prior state.
+ */
+"use server";
+
+import {
+  actorCritic,
+  synthesizer,
+  createActorControllerAdapter,
+  createCriticAdapter,
+  type ConfiguredPattern,
+} from "../../harness-patterns";
+import { withSandbox } from "../../sandbox/with-sandbox.server";
+import type { SessionData } from "../session.server";
+import type { AgentConfig } from "../registry.server";
+
+const SANDBOX_SESSION_GUIDANCE = `
+You have a PERSISTENT Linux sandbox for this conversation. Files, installed
+packages, and shell state under /work survive across turns, and you share
+this workspace with the user's interactive terminal — they may inspect or
+edit files you create, and you can pick up where a previous turn left off.
+
+Available tools (all run inside the sandbox VM):
+- sandbox_bash: run a shell command. Python 3 is available.
+- sandbox_write / sandbox_read / sandbox_edit: manage files under /work.
+- sandbox_list / sandbox_search: inspect the working directory.
+
+Guidance:
+1. Build incrementally — reuse files and results from earlier turns instead
+   of recreating them. Check what's already in /work before starting fresh.
+2. For anything computational, run code in the sandbox rather than guessing.
+3. When you have the answer, call Return with the result and a short summary.
+`.trim();
+
+async function createPatterns(sessionId: string): Promise<ConfiguredPattern<SessionData>[]> {
+  const actor = createActorControllerAdapter({
+    contextPrefix: SANDBOX_SESSION_GUIDANCE,
+  });
+  const critic = createCriticAdapter();
+
+  const loop = actorCritic<SessionData>(actor, critic, [], {
+    patternId: "sandbox-session-loop",
+    availableTools: [],
+    liveEvents: true,
+    maxRetries: 6,
+  });
+
+  // id: sessionId → the attachment table keys this VM to the conversation, so
+  // it persists across turns AND is the same container the Shell terminal
+  // attaches to (PtyManager keys on sessionId). Release decrements refCount
+  // without resetting, so /work survives between turns.
+  const sandboxedLoop = withSandbox({
+    id: sessionId,
+    sessionId,
+    rootfs: "base",
+    egress: "mcp-only",
+  })(loop);
+
+  const synth = synthesizer<SessionData>({
+    mode: "thread",
+    patternId: "sandbox-session-synth",
+    liveEvents: true,
+    viewConfig: {
+      eventTypes: ["user_message", "controller_action", "tool_call", "tool_result", "error"],
+    },
+  });
+
+  return [sandboxedLoop, synth];
+}
+
+export const sandboxSessionAgent: AgentConfig = {
+  id: "sandbox-session",
+  name: "Sandbox · Session",
+  description:
+    "Persistent sandbox VM shared across turns and with the interactive Shell — build incrementally, inspect files live.",
+  icon: "🖥️",
+  servers: [],
+  createPatterns,
+};

--- a/ui/src/lib/harness-client/examples/sandbox-session.server.ts
+++ b/ui/src/lib/harness-client/examples/sandbox-session.server.ts
@@ -17,6 +17,7 @@
 import {
   actorCritic,
   synthesizer,
+  compactIntent,
   createActorControllerAdapter,
   createCriticAdapter,
   type ConfiguredPattern,
@@ -24,6 +25,7 @@ import {
 import { withSandbox } from "../../sandbox/with-sandbox.server";
 import type { SessionData } from "../session.server";
 import type { AgentConfig } from "../registry.server";
+import type { FewShot } from "../../../../baml_client/types";
 
 const SANDBOX_SESSION_GUIDANCE = `
 You have a PERSISTENT Linux sandbox for this conversation. Files, installed
@@ -40,12 +42,43 @@ Guidance:
 1. Build incrementally — reuse files and results from earlier turns instead
    of recreating them. Check what's already in /work before starting fresh.
 2. For anything computational, run code in the sandbox rather than guessing.
-3. When you have the answer, call Return with the result and a short summary.
+3. When a task asks for a FILE, actually write it with sandbox_write (don't
+   just compute the answer with a throwaway python3 -c). The user can inspect
+   /work in their terminal, so the file is the deliverable.
+4. Let the critic decide completion — you don't need a Return tool. Focus on
+   producing the right tool call; the critic ends the loop when the result is
+   sufficient.
 `.trim();
+
+/**
+ * Few-shot examples for the actor's `tool_args` JSON formatting (#85).
+ * Sonnet 4.6 intermittently emits JS-object-literal args (unquoted keys, raw
+ * newlines) that the dispatch guard rejects as "Invalid tool_args JSON",
+ * wasting retries. Two shots anchor the two tricky shapes: a multi-line file
+ * write (newlines escaped inside a double-quoted JSON string) and a bash
+ * command containing quotes. Mirrors `code-mode`'s `CODE_MODE_FEW_SHOTS`.
+ */
+const SANDBOX_SESSION_FEW_SHOTS: FewShot[] = [
+  {
+    user: "Write a hello-world Python script to /work/hi.py and run it.",
+    reasoning:
+      "Write the file first. Keys and string values are double-quoted; the newline inside the script is the escape sequence \\n, not a raw line break.",
+    tool: "sandbox_write",
+    args: JSON.stringify({ path: "/work/hi.py", content: 'print("hello")\n' }),
+  },
+  {
+    user: "What Python version is in the sandbox?",
+    reasoning:
+      "Single bash call. The command string is double-quoted; any inner quotes are escaped.",
+    tool: "sandbox_bash",
+    args: JSON.stringify({ command: "python3 --version" }),
+  },
+];
 
 async function createPatterns(sessionId: string): Promise<ConfiguredPattern<SessionData>[]> {
   const actor = createActorControllerAdapter({
     contextPrefix: SANDBOX_SESSION_GUIDANCE,
+    fewShots: SANDBOX_SESSION_FEW_SHOTS,
   });
   const critic = createCriticAdapter();
 
@@ -76,7 +109,16 @@ async function createPatterns(sessionId: string): Promise<ConfiguredPattern<Sess
     },
   });
 
-  return [sandboxedLoop, synth];
+  // Rewrite the latest message into a self-contained brief before the actor
+  // runs. This agent is router-less, so without it a follow-up like "I can't
+  // find the file" reaches the actor with zero context for which file (#83).
+  // On turn 1 (no history) it passes the message through and skips the LLM call.
+  const intent = compactIntent<SessionData>({
+    patternId: "sandbox-session-intent",
+    liveEvents: true,
+  });
+
+  return [intent, sandboxedLoop, synth];
 }
 
 export const sandboxSessionAgent: AgentConfig = {

--- a/ui/src/lib/harness-client/registry.server.ts
+++ b/ui/src/lib/harness-client/registry.server.ts
@@ -93,6 +93,7 @@ import { llmJudgeAgent } from "./examples/llm-judge.server";
 import { conversationalMemoryAgent } from "./examples/conversational-memory.server";
 import { ontologyBuilderAgent } from "./examples/ontology-builder.server";
 import { semanticCacheAgent } from "./examples/semantic-cache.server";
+import { sandboxDemoAgent } from "./examples/sandbox-demo.server";
 
 // Register all agents
 registerAgent(defaultAgent);
@@ -106,3 +107,4 @@ registerAgent(llmJudgeAgent);
 registerAgent(conversationalMemoryAgent);
 registerAgent(ontologyBuilderAgent);
 registerAgent(semanticCacheAgent);
+registerAgent(sandboxDemoAgent);

--- a/ui/src/lib/harness-client/registry.server.ts
+++ b/ui/src/lib/harness-client/registry.server.ts
@@ -94,6 +94,7 @@ import { conversationalMemoryAgent } from "./examples/conversational-memory.serv
 import { ontologyBuilderAgent } from "./examples/ontology-builder.server";
 import { semanticCacheAgent } from "./examples/semantic-cache.server";
 import { sandboxDemoAgent } from "./examples/sandbox-demo.server";
+import { sandboxSessionAgent } from "./examples/sandbox-session.server";
 
 // Register all agents
 registerAgent(defaultAgent);
@@ -108,3 +109,4 @@ registerAgent(conversationalMemoryAgent);
 registerAgent(ontologyBuilderAgent);
 registerAgent(semanticCacheAgent);
 registerAgent(sandboxDemoAgent);
+registerAgent(sandboxSessionAgent);

--- a/ui/src/lib/harness-patterns/README.md
+++ b/ui/src/lib/harness-patterns/README.md
@@ -36,6 +36,7 @@ Functional, composable framework for agentic tool execution.
   - [withApproval()](#withapprovalpattern-predicate)
   - [withReferences()](#withreferencespattern-config)
   - [synthesizer()](#synthesizerconfig)
+  - [compactIntent()](#compactintentconfig)
   - [router()](#routerroutedescriptions-config)
   - [routes()](#routespatternmap-config)
   - [chain()](#chainctx-patterns)
@@ -129,6 +130,8 @@ type EventType =
   | 'pattern_enter' | 'pattern_exit'
   | 'approval_request' | 'approval_response'
   | 'error'
+  | 'reference_attached'   // withReferences — selector decision (observability)
+  | 'intent_compacted'     // compactIntent — rewritten brief (observability)
 
 // Isolated workspace for each pattern
 interface PatternScope<T> {
@@ -494,6 +497,47 @@ synthesizer({
 })
 ```
 
+### `compactIntent(config?)`
+
+Rewrites the latest user message into a self-contained `scope.data.intent` brief
+before a router-less actor runs. The chain-based counterpart to `router` (which
+sets `data.intent` as a side-effect of classification) — `compactIntent` strips
+the classification, leaving only the rewrite. Writes the same carrier
+`actorCritic` / `simpleLoop` already read (`scope.data.intent ?? userContent`),
+so there is **no controller-prompt change**.
+
+```typescript
+chain(
+  compactIntent({ viewConfig: { fromLastNTurns: 5 } }),
+  withSandbox({ id: sessionId })(actorCritic(actor, critic, [], { … })),
+  synthesizer({ mode: 'thread' }),
+)
+
+type CompactIntentConfig = PatternConfig
+```
+
+**How it works:**
+1. Reads recent message history from its view (default `viewConfig`:
+   `{ fromLast: false, fromLastNTurns: 5, eventTypes: ['user_message', 'assistant_message'] }`,
+   think-blocks stripped — mirrors `router`).
+2. Splits into the latest user message + prior history, then calls BAML
+   `CompactIntent` on the cheap `DescribeAnthropic` client (one call per chain
+   invocation) to resolve back-references (*"try again"*, *"I can't find the
+   file"*) into a standalone instruction.
+3. Writes `scope.data.intent`; emits an `intent_compacted` event carrying the
+   LLM call for observability (mirrors `withReferences`' `reference_attached`).
+
+**Skip / safety:**
+- **Turn 1 (no history):** skips the LLM call, passes the message through
+  unchanged (`skipped: 'no-history'`).
+- **Backward-safe:** on any failure it leaves `intent` unset, so the actor falls
+  back to the raw user message — never fatal.
+
+> Use it upstream of a router-less actor (e.g. the Sandbox · Session agent).
+> Agents that already route don't need it — `router` fills `data.intent` itself.
+> Part E of [#83](https://github.com/mknw/harness-playground/issues/83) (the
+> `compact*` naming unification) is a deferred follow-up.
+
 ### `router(routeDescriptions, config?)`
 
 Classifies intent via BAML and sets `scope.data.route`. The first half of the router/routes pair.
@@ -734,6 +778,7 @@ router({ neo4j: 'Database queries' }, {
 - `simpleLoop`: `trackHistory: 'tool_result'`, `commitStrategy: 'on-success'`
 - `actorCritic`: `trackHistory: 'tool_result'`, `commitStrategy: 'on-success'`
 - `synthesizer`: `trackHistory: 'assistant_message'`, `commitStrategy: 'always'`
+- `compactIntent`: `trackHistory: 'intent_compacted'`, `commitStrategy: 'always'`, default `viewConfig` of last 5 message turns
 
 ## Event → BAML Type Mapping
 
@@ -756,6 +801,8 @@ transformed into prompt-friendly types. The table below shows which harness
 | `approval_request` | `ApprovalRequestEventData` | _(not sent to BAML)_ | withApproval only |
 | `approval_response` | `ApprovalResponseEventData` | _(not sent to BAML)_ | withApproval only |
 | `error` | `ErrorEventData` | _(read via `view.hasErrors()`)_ | synthesizer (error context), harness error handling |
+| `reference_attached` | `ReferenceAttachedEventData` | _(not sent to BAML)_ | withReferences only (observability) |
+| `intent_compacted` | `IntentCompactedEventData` | _(not sent to BAML)_ | compactIntent only (observability) |
 
 ### Per-Pattern: Events Read → BAML Inputs → BAML Return
 
@@ -831,6 +878,24 @@ BAML Return → string (assistant response text)
 > **Error scoping**: The synthesizer reads error state from EventView, not from the data stash.
 > This means errors are scoped by the synthesizer's `ViewConfig` (e.g. `fromLastNTurns: 1`) and
 > naturally expire — they don't persist across turns via serialization.
+
+#### compactIntent → `CompactIntent`
+
+```
+Events read (ViewConfig default: fromLastNTurns: 5, messages only)
+├── user_message       ──► latest (last user_message) + history (Message[])
+└── assistant_message  ──► history (Message[])
+
+BAML Inputs:
+  history : Message[]   ← prior turns' user/assistant messages
+  latest  : string      ← current user_message content
+
+BAML Return → string (the rewritten brief)
+  → written to scope.data.intent
+  → stored as an intent_compacted event (with the LLM call)
+
+Turn 1 (no history): LLM call skipped, latest passes through unchanged.
+```
 
 #### router() + routes()
 
@@ -1016,6 +1081,7 @@ harness-patterns/
     ├── hook.server.ts          # Lifecycle hook; wraps inner events with pattern_enter/exit
     ├── chain.server.ts         # Sequential composition; accepts onEvent? for SSE streaming
     ├── synthesizer.server.ts   # Final response synthesis; skips BAML for DIRECT_RESPONSE_ROUTE
+    ├── compactIntent.server.ts # Rewrites latest message → scope.data.intent for router-less actors; emits intent_compacted
     └── event-view.server.ts    # EventViewImpl (fluent query API, serializeCompact)
 ```
 

--- a/ui/src/lib/harness-patterns/baml-adapters.server.ts
+++ b/ui/src/lib/harness-patterns/baml-adapters.server.ts
@@ -21,6 +21,7 @@ import { assertServerOnImport } from './assert.server'
 import type { ControllerFn, CriticFn, CodeModeControllerFn, ControllerAction, CriticResult, ScriptExecutionEvent, LLMCallData } from './types'
 import type { ToolDescription, LoopTurn, Attempt, PriorResult, FewShot } from '../../../baml_client/types'
 import { listTools as mcpListTools } from './mcp-client.server'
+import { getActiveSandbox } from '../sandbox/scope.server'
 import { Collector, BamlValidationError } from '@boundaryml/baml'
 import { getBamlFiles } from '../../../baml_client/inlinedbaml'
 import { clientOverrideFor } from './clients.server'
@@ -294,6 +295,21 @@ async function filterToolDescriptions(
   return all.filter((t) => nameSet.has(t.name) || (pattern?.test(t.name) ?? false))
 }
 
+/** When a `withSandbox` wrapper is active, return its in-VM tool descriptions
+ *  in the adapter's `ToolDescription` shape. Outside any sandbox scope, returns
+ *  `[]`. See docs/sandbox-plan.md → "How tools reach the controller". The
+ *  transport caches its tool list internally, so this is cheap per call. */
+async function getActiveSandboxToolDescriptions(): Promise<ToolDescription[]> {
+  const sandbox = getActiveSandbox()
+  if (!sandbox) return []
+  const mcp = await sandbox.listTools()
+  return mcp.map((t) => ({
+    name: t.name,
+    description: t.description ?? '',
+    args_schema: t.inputSchema ? JSON.stringify(t.inputSchema) : undefined,
+  }))
+}
+
 // ============================================================================
 // Adapters for simpleLoop
 // ============================================================================
@@ -322,8 +338,12 @@ export function createLoopControllerAdapter(
     const { b } = await import('../../../baml_client')
     const startTime = Date.now()
 
-    // Get tool descriptions for available tools
-    const tools = await filterToolDescriptions(toolNames)
+    // Get tool descriptions for available tools. When a `withSandbox` wrapper
+    // is active, prepend its in-VM tool surface so the actor sees them in its
+    // first-turn prompt without the caller threading them through `toolNames`.
+    const sandboxTools = await getActiveSandboxToolDescriptions()
+    const gatewayTools = await filterToolDescriptions(toolNames)
+    const tools = [...sandboxTools, ...gatewayTools]
 
     // Parse previous results into LoopTurn format
     const turns: LoopTurn[] = parseResultsToTurns(previous_results, n_turn)
@@ -528,10 +548,15 @@ export function createActorControllerAdapter(
       : options.toolNames ?? []
 
     // Get tool descriptions — optionally refresh + include pattern matches.
-    const tools = await filterToolDescriptions(names, {
+    // When a `withSandbox` wrapper is active, prepend its in-VM tool surface
+    // so the actor sees them in its first-turn prompt without the caller
+    // threading them through `toolNames` / `toolNamesProvider`.
+    const sandboxTools = await getActiveSandboxToolDescriptions()
+    const gatewayTools = await filterToolDescriptions(names, {
       dynamicPattern: options.dynamicPattern,
       refresh: options.refreshOnCall,
     })
+    const tools = [...sandboxTools, ...gatewayTools]
 
     // Convert ScriptExecutionEvent to Attempt format. `toolName` records the
     // actor's actual tool_name per push — so a rejected `mcp-exec` attempt

--- a/ui/src/lib/harness-patterns/index.ts
+++ b/ui/src/lib/harness-patterns/index.ts
@@ -68,6 +68,7 @@ export type {
   ApprovalRequestEventData,
   ApprovalResponseEventData,
   ErrorEventData,
+  IntentCompactedEventData,
 
   // LLM Observability
   LLMCallData,
@@ -128,6 +129,7 @@ export {
   chain,
   runChain,
   synthesizer,
+  compactIntent,
   configurePattern,
   parallel,
   judge,
@@ -138,6 +140,8 @@ export {
   hook,
   type SimpleLoopData,
   type ActorCriticData,
+  type CompactIntentConfig,
+  type CompactIntentData,
   type ApprovalPredicate,
   type WithApprovalData,
   type JudgeConfig,

--- a/ui/src/lib/harness-patterns/mcp-client.server.ts
+++ b/ui/src/lib/harness-patterns/mcp-client.server.ts
@@ -6,6 +6,7 @@
  */
 
 import { assertServerOnImport } from './assert.server';
+import { getActiveSandbox } from '../sandbox/scope.server';
 import type { ToolCallResult, MCPToolDescription } from './types';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
@@ -100,6 +101,16 @@ export async function callTool(
   name: string,
   args: Record<string, unknown>
 ): Promise<ToolCallResult> {
+  // Sandbox dispatch (see docs/sandbox-plan.md → "How tools reach the
+  // controller"). When a `withSandbox` wrapper is active and the tool name
+  // is owned by its in-VM transport, route there instead of the host
+  // gateway. Tools not owned by the sandbox fall through to the gateway path
+  // — which is also what happens outside any sandbox scope.
+  const sandbox = getActiveSandbox();
+  if (sandbox?.ownsTool(name)) {
+    return sandbox.callTool(name, args);
+  }
+
   try {
     const result = await withReconnect((c) => c.callTool({ name, arguments: args }));
 

--- a/ui/src/lib/harness-patterns/patterns/actorCritic.server.ts
+++ b/ui/src/lib/harness-patterns/patterns/actorCritic.server.ts
@@ -27,6 +27,7 @@ import type { ErrorEventData } from '../types'
 import { getErrorHint } from '../error-hints'
 import { trackEvent, resolveConfig, generateId } from '../context.server'
 import { getRequestSettings } from '../../settings-context.server'
+import { getActiveSandbox } from '../../sandbox/scope.server'
 import type { CodeModeControllerFnWithLLMData, CriticFnWithLLMData } from '../baml-adapters.server'
 import { LLMCallError } from '../baml-adapters.server'
 
@@ -140,9 +141,16 @@ export function actorCritic<T extends ActorCriticData>(
         const dynamicAllowlist = config?.dynamicToolAllowlist
           ? await config.dynamicToolAllowlist()
           : []
+        // A third augmentation: an active `withSandbox` scope's tool surface.
+        // Sandbox-owned (`sandbox_*`) names pass without being listed in
+        // `tools` or `dynamicToolAllowlist` (see docs/sandbox-plan.md → "How
+        // tools reach the controller"). Outside any sandbox scope this is
+        // a no-op.
+        const sandbox = getActiveSandbox()
         const allowed =
           tools.includes(action.tool_name) ||
           dynamicAllowlist.includes(action.tool_name) ||
+          (sandbox?.ownsTool(action.tool_name) ?? false) ||
           (config?.dynamicToolPattern?.test(action.tool_name) ?? false)
         if (!allowed) {
           const errMsg = `Tool not allowed: ${action.tool_name}`

--- a/ui/src/lib/harness-patterns/patterns/compactIntent.server.ts
+++ b/ui/src/lib/harness-patterns/patterns/compactIntent.server.ts
@@ -1,0 +1,178 @@
+/**
+ * compactIntent Pattern
+ *
+ * Rewrites the user's latest message into a self-contained `intent` brief and
+ * writes it to `scope.data.intent`, so a downstream router-less actor (which
+ * only sees the current turn + `scope.data.intent`) can resolve bare
+ * back-references like "try again", "I can't find the file", or "now in
+ * TypeScript" without the conversation history.
+ *
+ * Placed upstream of an actor pattern in a chain:
+ *
+ *   chain(
+ *     compactIntent({ viewConfig: { fromLastNTurns: 5 } }),
+ *     withSandbox({ id })(actorCritic(actor, critic, [], { … })),
+ *     synthesizer({ mode: 'thread' }),
+ *   )
+ *
+ * This is the chain-based counterpart to `router`, which sets `data.intent` as
+ * a side-effect of classification (#53). compactIntent strips the
+ * classification — there is no routing decision, only the rewrite.
+ *
+ * Backward-compatible: agents that don't use it are unchanged. On any failure
+ * it leaves `scope.data.intent` unset so the actor falls back to the raw user
+ * message — never fatal.
+ */
+
+import { assertServerOnImport } from '../assert.server'
+import { Collector } from '@boundaryml/baml'
+import type {
+  PatternScope,
+  EventView,
+  ConfiguredPattern,
+  PatternConfig,
+  ViewConfig,
+  UserMessageEventData,
+  AssistantMessageEventData,
+  IntentCompactedEventData,
+  ErrorEventData,
+  LLMCallData,
+} from '../types'
+import { trackEvent, resolveConfig } from '../context.server'
+import { getErrorHint } from '../error-hints'
+import { stripThinkBlocks } from '../content-transforms'
+import { trimToFit, getContextWindow } from '../token-budget.server'
+import { extractLLMCallData, extractFailureLLMCallData } from '../baml-adapters.server'
+import { clientOverrideFor } from '../clients.server'
+
+assertServerOnImport()
+
+export type CompactIntentConfig = PatternConfig
+
+export interface CompactIntentData {
+  intent?: string
+}
+
+/**
+ * Create a compactIntent pattern.
+ *
+ * @param config - Optional pattern configuration. The default `viewConfig`
+ *   reads the last 5 user turns of message history (think-blocks stripped);
+ *   override it to widen/narrow the window.
+ * @returns ConfiguredPattern ready for chain
+ */
+export function compactIntent<T extends CompactIntentData>(
+  config?: CompactIntentConfig
+): ConfiguredPattern<T> {
+  // Default: cross-turn message history of the last 5 turns, messages only —
+  // mirrors the router's default view. Caller can override entirely.
+  const DEFAULT_VIEW: ViewConfig = {
+    fromLast: false,
+    fromLastNTurns: 5,
+    eventTypes: ['user_message', 'assistant_message'],
+    contentTransforms: [stripThinkBlocks],
+  }
+  const resolved = resolveConfig('compactIntent', {
+    viewConfig: DEFAULT_VIEW,
+    ...config,
+  })
+
+  const fn = async (
+    scope: PatternScope<T>,
+    view: EventView
+  ): Promise<PatternScope<T>> => {
+    let collector: Collector | undefined
+    let startTime: number | undefined
+    let variables: Record<string, unknown> | undefined
+    try {
+      // view is pre-configured by viewConfig (last N turns of messages).
+      const allMessages = view.get()
+
+      // Latest message = the last user_message in the window.
+      const currentMsg = [...allMessages].reverse().find(e => e.type === 'user_message')
+      const latest = currentMsg
+        ? (currentMsg.data as UserMessageEventData).content
+        : ''
+
+      // Nothing to rewrite — leave intent unset, actor falls back to raw input.
+      if (!latest) return scope
+
+      // History = every message except the current one, mapped to {role, content}.
+      const rawHistory = allMessages
+        .filter(e => e !== currentMsg)
+        .map(e => ({
+          role: e.type === 'user_message' ? 'user' : 'assistant',
+          content: (e.data as UserMessageEventData | AssistantMessageEventData).content,
+        }))
+
+      // Turn 1 (no prior history): no back-references to resolve. Pass the
+      // latest message through unchanged and skip the LLM call entirely.
+      if (rawHistory.length === 0) {
+        scope.data = { ...scope.data, intent: latest }
+        trackEvent(
+          scope,
+          'intent_compacted',
+          { intent: latest, latest, historyLength: 0, skipped: 'no-history' } as IntentCompactedEventData,
+          resolved.trackHistory
+        )
+        return scope
+      }
+
+      // Trim oldest history if it would overflow the describe-tier model.
+      const contextWindow = getContextWindow('DescribeFallback')
+      const history = trimToFit(rawHistory, h => JSON.stringify(h), 300, contextWindow)
+
+      const { b } = await import('../../../../baml_client')
+      collector = new Collector('compactIntent')
+      startTime = Date.now()
+      variables = { history, latest }
+
+      // Default (no override): routes to `DescribeAnthropic` (Haiku 4.5).
+      // `USE_MIXED_CHAINS=1`: swaps in `DescribeFallback` via clientOverrideFor.
+      const opts = { collector, ...clientOverrideFor('describe') }
+      const raw = await b.CompactIntent(history, latest, opts)
+      const intent = raw.trim() || latest
+
+      const llmCall: LLMCallData | undefined = extractLLMCallData(
+        collector,
+        'CompactIntent',
+        variables,
+        startTime,
+        intent
+      )
+
+      scope.data = { ...scope.data, intent }
+      trackEvent(
+        scope,
+        'intent_compacted',
+        { intent, latest, historyLength: history.length } as IntentCompactedEventData,
+        resolved.trackHistory,
+        llmCall
+      )
+
+      return scope
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error)
+      // Best-effort: surface the prompt/variables drill-down for the failed
+      // BAML call. Intent stays unset → actor falls back to the raw message.
+      const failedLlmCall =
+        collector !== undefined && variables !== undefined && startTime !== undefined
+          ? extractFailureLLMCallData(collector, 'CompactIntent', variables, startTime)
+          : undefined
+      trackEvent(scope, 'error', {
+        error: msg,
+        severity: resolved.errorSeverity,
+        hint: getErrorHint(msg),
+        ...(failedLlmCall ? { kind: 'llm_call' as const } : {}),
+      } as ErrorEventData, true, failedLlmCall)
+      return scope
+    }
+  }
+
+  return {
+    name: 'compactIntent',
+    fn,
+    config: resolved,
+    estimateTurns: () => 1,
+  }
+}

--- a/ui/src/lib/harness-patterns/patterns/index.ts
+++ b/ui/src/lib/harness-patterns/patterns/index.ts
@@ -9,6 +9,7 @@ export { actorCritic, type ActorCriticData } from './actorCritic.server'
 export { withApproval, approvalPredicates, type ApprovalPredicate, type WithApprovalData } from './withApproval.server'
 export { chain, runChain, configurePattern } from './chain.server'
 export { synthesizer } from './synthesizer.server'
+export { compactIntent, type CompactIntentConfig, type CompactIntentData } from './compactIntent.server'
 export { parallel } from './parallel.server'
 export { judge, type JudgeConfig, type JudgeData, type EvaluatorFn } from './judge.server'
 export { guardrail, piiScanRail, pathAllowlistRail, driftDetectorRail, type Rail, type RailResult, type RailContext, type GuardrailConfig, type CircuitBreakerConfig } from './guardrail.server'
@@ -45,5 +46,6 @@ export type {
   WithReferencesConfig,
   SelectorFn,
   ReferenceCandidate,
-  ReferenceAttachedEventData
+  ReferenceAttachedEventData,
+  IntentCompactedEventData
 } from '../types'

--- a/ui/src/lib/harness-patterns/patterns/simpleLoop.server.ts
+++ b/ui/src/lib/harness-patterns/patterns/simpleLoop.server.ts
@@ -25,6 +25,7 @@ import type { ErrorEventData } from '../types'
 import { getErrorHint } from '../error-hints'
 import { trackEvent, resolveConfig, generateId } from '../context.server'
 import { getRequestSettings } from '../../settings-context.server'
+import { getActiveSandbox } from '../../sandbox/scope.server'
 import { trimToFit, getContextWindow } from '../token-budget.server'
 import type { ControllerFnWithLLMData } from '../baml-adapters.server'
 import { dedupByRefId, annotateExpansions, LLMCallError } from '../baml-adapters.server'
@@ -370,8 +371,16 @@ export function simpleLoop<T extends SimpleLoopData>(
           continue
         }
 
-        // Validate tool
-        if (!tools.includes(action.tool_name)) {
+        // Validate tool. The static allowlist is augmented by an active
+        // `withSandbox` scope's tool surface — `sandbox_*` names pass without
+        // being listed in `tools` (see docs/sandbox-plan.md → "How tools reach
+        // the controller"). Outside any sandbox scope, `getActiveSandbox()`
+        // returns undefined and this collapses to the original check.
+        const sandbox = getActiveSandbox()
+        const allowed =
+          tools.includes(action.tool_name) ||
+          (sandbox?.ownsTool(action.tool_name) ?? false)
+        if (!allowed) {
           hasError = true
           errorMessage = `Tool not allowed: ${action.tool_name}. Allowed: ${tools.join(', ')}`
           errorTurn = turn

--- a/ui/src/lib/harness-patterns/types.ts
+++ b/ui/src/lib/harness-patterns/types.ts
@@ -53,6 +53,7 @@ export type EventType =
   | 'approval_response'
   | 'error'
   | 'reference_attached'
+  | 'intent_compacted'
 
 /** A single event in the context stream */
 export interface ContextEvent {
@@ -588,6 +589,22 @@ export interface ReferenceAttachedEventData {
   skipped?: 'empty' | 'single' | 'cached'
 }
 
+/** Data payload for intent_compacted event — emitted by `compactIntent` once
+ *  per chain invocation. Carries the rewritten brief and enough provenance to
+ *  audit the rewrite in the observability panel. `llmCall` (on the
+ *  ContextEvent) holds the BAML call detail. */
+export interface IntentCompactedEventData {
+  /** The self-contained brief written to `scope.data.intent`. */
+  intent: string
+  /** The user's raw latest message before rewriting. */
+  latest: string
+  /** Number of prior history messages fed to the rewrite. */
+  historyLength: number
+  /** Set when the LLM call was skipped (turn 1 has no back-references to
+   *  resolve, so the latest message passes through unchanged). */
+  skipped?: 'no-history'
+}
+
 // ============================================================================
 // LLM Call Observability
 // ============================================================================
@@ -662,7 +679,8 @@ export const DEFAULT_TRACK_HISTORY: Record<string, TrackHistory> = {
   router: true,
   routes: false,
   chain: false,
-  withApproval: true
+  withApproval: true,
+  compactIntent: 'intent_compacted'
 }
 
 /** Default commitStrategy by pattern type */
@@ -673,7 +691,8 @@ export const DEFAULT_COMMIT_STRATEGY: Record<string, CommitStrategy> = {
   router: 'always',
   routes: 'always',
   chain: 'always',
-  withApproval: 'on-success'
+  withApproval: 'on-success',
+  compactIntent: 'always'
 }
 
 /** Default errorSeverity by pattern type.
@@ -687,4 +706,7 @@ export const DEFAULT_ERROR_SEVERITY: Record<string, 'recoverable' | 'irrecoverab
   routes: 'irrecoverable',
   chain: 'irrecoverable',
   withApproval: 'recoverable',
+  // compactIntent is best-effort: on failure it leaves intent unset and the
+  // downstream actor falls back to the raw user message — never fatal.
+  compactIntent: 'recoverable',
 }

--- a/ui/src/lib/sandbox/attachment-table.server.ts
+++ b/ui/src/lib/sandbox/attachment-table.server.ts
@@ -1,0 +1,161 @@
+/**
+ * AttachmentTable — id-addressable, ref-counted sandbox attachments.
+ *
+ * `withSandbox({ id: 'foo' })` looks up an attachment by id; a hit reuses
+ * the live VM + transport, a miss boots one via the pool and stores it.
+ * Concurrent acquires on the same id share a single VM/transport via
+ * reference counting; release decrements; refCount=0 leaves the entry
+ * parked under the id (a sweeper destroys it after `idleMs`).
+ *
+ * Sweep model: lazy, not timer-driven. Each `acquire` fires a best-effort
+ * background sweep that destroys idle attachments AND cascades to
+ * `pool.evictIdle()`. Skipping the timer keeps test lifecycle simple — no
+ * unref/clear, no leak warnings — at the cost that a fully idle harness
+ * never sweeps. That's fine: idle means no resources are being held by
+ * the agent layer beyond the parked VMs themselves.
+ *
+ * Race-safe: parallel callers requesting the same id share the same boot
+ * promise via an `inFlight` map; only the first call does the work.
+ */
+
+import { assertServerOnImport } from '../harness-patterns/assert.server'
+import type { ComputeBackend, McpTransport, RootfsId, RuntimeConfig, VMHandle } from './types'
+import type { WarmPool } from './warm-pool.server'
+
+assertServerOnImport()
+
+export interface Attachment {
+  readonly id: string
+  readonly vm: VMHandle
+  readonly transport: McpTransport
+  refCount: number
+  lastUsedAt: number
+}
+
+export interface AttachmentTableConfig {
+  /** Idle time before a refCount=0 attachment is destroyed (ms). */
+  idleMs: number
+}
+
+export class AttachmentTable {
+  private readonly table = new Map<string, Attachment>()
+  private readonly inFlight = new Map<string, Promise<Attachment>>()
+
+  constructor(
+    private readonly backend: ComputeBackend,
+    private readonly pool: WarmPool,
+    private readonly config: AttachmentTableConfig,
+  ) {}
+
+  /**
+   * Acquire by id. Returns an existing live attachment with refCount bumped
+   * if one exists; otherwise boots via the pool and stores a new entry.
+   * Concurrent acquires of the same id share the same boot.
+   */
+  async acquire(id: string, rootfs: RootfsId, runtime: RuntimeConfig): Promise<Attachment> {
+    // Fire-and-forget sweep so this call isn't latency-bound by cleanup.
+    void this.sweepIdle().catch(() => {})
+
+    const existing = this.table.get(id)
+    if (existing) {
+      existing.refCount += 1
+      existing.lastUsedAt = Date.now()
+      return existing
+    }
+    const pending = this.inFlight.get(id)
+    if (pending) {
+      const att = await pending
+      att.refCount += 1
+      att.lastUsedAt = Date.now()
+      return att
+    }
+    const p = (async (): Promise<Attachment> => {
+      const vm = await this.pool.acquire(rootfs, runtime)
+      let transport: McpTransport
+      try {
+        transport = await this.backend.connectMcp(vm)
+      } catch (err) {
+        await this.pool.release(vm).catch(() => {})
+        throw err
+      }
+      const att: Attachment = {
+        id,
+        vm,
+        transport,
+        refCount: 1,
+        lastUsedAt: Date.now(),
+      }
+      this.table.set(id, att)
+      return att
+    })()
+    this.inFlight.set(id, p)
+    try {
+      return await p
+    } finally {
+      this.inFlight.delete(id)
+    }
+  }
+
+  /** Decrement refCount. At zero the attachment stays parked for idle sweep. */
+  release(att: Attachment): void {
+    att.refCount = Math.max(0, att.refCount - 1)
+    att.lastUsedAt = Date.now()
+  }
+
+  /**
+   * Force-destroy an attachment regardless of refCount. Used by
+   * `withSandbox({ id, fresh: true })` to blow away a stored entry before
+   * re-acquiring. Safe to call on an unknown id (no-op).
+   */
+  async destroyById(id: string): Promise<void> {
+    const att = this.table.get(id)
+    if (!att) return
+    this.table.delete(id)
+    await att.transport.close().catch(() => {})
+    await this.pool.release(att.vm).catch(() => {})
+  }
+
+  /**
+   * Destroy refCount=0 attachments idle past the threshold, and cascade to
+   * `pool.evictIdle` so warm-pool entries don't accumulate either. Public
+   * for tests; production calls it via the lazy hook in `acquire`.
+   */
+  async sweepIdle(now: number = Date.now()): Promise<void> {
+    const toEvict: Attachment[] = []
+    for (const att of this.table.values()) {
+      if (att.refCount === 0 && now - att.lastUsedAt >= this.config.idleMs) {
+        toEvict.push(att)
+      }
+    }
+    for (const att of toEvict) {
+      this.table.delete(att.id)
+    }
+    await Promise.all(
+      toEvict.map(async (att) => {
+        await att.transport.close().catch(() => {})
+        await this.pool.release(att.vm).catch(() => {})
+      }),
+    )
+    await this.pool.evictIdle(now).catch(() => {})
+  }
+
+  /** Destroy every attachment. Called on harness shutdown / between tests. */
+  async shutdown(): Promise<void> {
+    const all = [...this.table.values()]
+    this.table.clear()
+    await Promise.all(
+      all.map(async (att) => {
+        await att.transport.close().catch(() => {})
+        await this.pool.release(att.vm).catch(() => {})
+      }),
+    )
+  }
+
+  size(): number {
+    return this.table.size
+  }
+
+  has(id: string): boolean {
+    return this.table.has(id)
+  }
+}

--- a/ui/src/lib/sandbox/docker-backend.server.ts
+++ b/ui/src/lib/sandbox/docker-backend.server.ts
@@ -1,0 +1,284 @@
+/**
+ * DockerBackend — `ComputeBackend` over the local Docker engine.
+ *
+ * v0 substrate (see docs/sandbox-plan.md → "Backend interface" / "macOS
+ * development"). Works on macOS dev hosts; same MCP-in-VM architecture and
+ * tool surface as the future FirecrackerBackend — only boot latency and reset
+ * semantics differ.
+ *
+ * Boot model: run the rootfs image (`kg-sandbox:base`) as a detached, idle
+ * container with `/work` available. MCP servers are NOT foreground processes;
+ * `connectMcp` spawns each one on stdio via `docker exec -i <ctr> init.sh
+ * serve <name>` and wraps them in a unified `McpTransport`.
+ *
+ * Step 2 scope: boot / destroy / connectMcp (+ a cheap health). `reset`
+ * (warm-pool recycle) throws until step 5.
+ */
+
+import { spawn } from 'node:child_process'
+import { randomUUID } from 'node:crypto'
+import { assertServerOnImport } from '../harness-patterns/assert.server'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
+import type {
+  ComputeBackend,
+  HealthStatus,
+  McpTransport,
+  RootfsId,
+  RuntimeConfig,
+  VMHandle,
+} from './types'
+import { V0_IN_VM_SERVERS } from './types'
+import type { ToolCallResult, MCPToolDescription } from '../harness-patterns/types'
+
+assertServerOnImport()
+
+const DOCKER_BIN = process.env.DOCKER_BIN || 'docker'
+const SANDBOX_IMAGE = process.env.SANDBOX_IMAGE || 'kg-sandbox:base'
+const WORK_DIR = '/work'
+
+// ============================================================================
+// Small docker CLI helper
+// ============================================================================
+
+interface DockerNative extends Record<string, unknown> {
+  containerId: string
+}
+
+/** Run `docker <args>`, resolving stdout (trimmed). Rejects on non-zero exit. */
+function docker(args: string[], timeoutMs = 30_000): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(DOCKER_BIN, args, { stdio: ['ignore', 'pipe', 'pipe'] })
+    let stdout = ''
+    let stderr = ''
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL')
+      reject(new Error(`docker ${args[0]} timed out after ${timeoutMs}ms`))
+    }, timeoutMs)
+    child.stdout.on('data', (b) => (stdout += b.toString('utf8')))
+    child.stderr.on('data', (b) => (stderr += b.toString('utf8')))
+    child.on('error', (err) => {
+      clearTimeout(timer)
+      reject(err)
+    })
+    child.on('close', (code) => {
+      clearTimeout(timer)
+      if (code === 0) resolve(stdout.trim())
+      else reject(new Error(`docker ${args.join(' ')} exited ${code}: ${stderr.trim()}`))
+    })
+  })
+}
+
+function containerId(vm: VMHandle): string {
+  const native = vm.native as DockerNative
+  if (!native?.containerId) {
+    throw new Error(`VMHandle ${vm.id} has no docker containerId`)
+  }
+  return native.containerId
+}
+
+// ============================================================================
+// Unified in-VM MCP transport
+// ============================================================================
+
+/**
+ * Holds one MCP client per in-VM server and presents the `sandbox_*` surface.
+ * Tool name maps are built from V0_IN_VM_SERVERS so dispatch is O(1) and the
+ * exposed names never collide with host-gateway tools.
+ */
+class DockerMcpTransport implements McpTransport {
+  readonly vmId: string
+  private readonly cid: string
+  /** exposed (sandbox_*) name → { client, nativeName } */
+  private readonly route = new Map<string, { client: Client; nativeName: string }>()
+  /** exposed name → cached description */
+  private readonly descriptions: MCPToolDescription[] = []
+  private readonly clients: Client[] = []
+  private closed = false
+
+  private constructor(vmId: string, cid: string) {
+    this.vmId = vmId
+    this.cid = cid
+  }
+
+  /** Connect to every v0 in-VM server over `docker exec -i` stdio. */
+  static async open(vmId: string, cid: string): Promise<DockerMcpTransport> {
+    const t = new DockerMcpTransport(vmId, cid)
+    try {
+      for (const server of V0_IN_VM_SERVERS) {
+        const transport = new StdioClientTransport({
+          command: DOCKER_BIN,
+          args: ['exec', '-i', cid, ...server.launch],
+          // stderr from the in-VM server is diagnostic; let it surface to the
+          // host process stderr rather than being swallowed.
+          stderr: 'inherit',
+        })
+        const client = new Client({ name: `sandbox-${server.key}`, version: '1.0.0' })
+        await client.connect(transport)
+        t.clients.push(client)
+
+        const { tools } = await client.listTools()
+        const byName = new Map(tools.map((d) => [d.name, d]))
+        for (const [nativeName, exposed] of Object.entries(server.tools)) {
+          t.route.set(exposed, { client, nativeName })
+          const desc = byName.get(nativeName)
+          t.descriptions.push({
+            name: exposed,
+            description: desc?.description ?? '',
+            inputSchema: (desc?.inputSchema as Record<string, unknown>) ?? {},
+          })
+        }
+      }
+      return t
+    } catch (err) {
+      // Partial connect: tear down whatever opened so we don't leak exec pipes.
+      await t.close().catch(() => {})
+      throw err
+    }
+  }
+
+  async toolNames(): Promise<string[]> {
+    return [...this.route.keys()]
+  }
+
+  async listTools(): Promise<MCPToolDescription[]> {
+    return this.descriptions.slice()
+  }
+
+  ownsTool(name: string): boolean {
+    return this.route.has(name)
+  }
+
+  async callTool(name: string, args: Record<string, unknown>): Promise<ToolCallResult> {
+    const target = this.route.get(name)
+    if (!target) {
+      return { success: false, data: null, error: `Sandbox tool not found: ${name}` }
+    }
+    try {
+      const result = await target.client.callTool({ name: target.nativeName, arguments: args })
+      if (Array.isArray(result.content)) {
+        const textContent = result.content.find((c) => c.type === 'text')
+        if (textContent && 'text' in textContent) {
+          try {
+            return { success: result.isError !== true, data: JSON.parse(textContent.text) }
+          } catch {
+            return { success: result.isError !== true, data: textContent.text }
+          }
+        }
+      }
+      return { success: result.isError !== true, data: result.structuredContent ?? result }
+    } catch (error) {
+      return {
+        success: false,
+        data: null,
+        error: error instanceof Error ? error.message : String(error),
+      }
+    }
+  }
+
+  async close(): Promise<void> {
+    if (this.closed) return
+    this.closed = true
+    await Promise.all(this.clients.map((c) => c.close().catch(() => {})))
+  }
+}
+
+// ============================================================================
+// Backend
+// ============================================================================
+
+export class DockerBackend implements ComputeBackend {
+  readonly kind = 'docker' as const
+
+  async boot(rootfs: RootfsId, runtime: RuntimeConfig): Promise<VMHandle> {
+    const id = `sbx-${randomUUID().slice(0, 8)}`
+    const image = imageForRootfs(rootfs)
+
+    const args = ['run', '-d', '--rm', '--name', id]
+
+    // Resource caps. Docker accepts fractional --cpus and <N>m for memory.
+    if (runtime.cpus) args.push('--cpus', String(runtime.cpus))
+    if (runtime.memoryMB) args.push('--memory', `${runtime.memoryMB}m`)
+
+    // Egress. v0: mcp-only ⇒ no network at all (in-VM MCP is reached over the
+    // docker-exec stdio pipe, which does NOT require container networking).
+    // Anything else leaves the default bridge network in place. Finer egress
+    // profiles (pypi / github-trusted) are later work.
+    if ((runtime.egress ?? 'mcp-only') === 'mcp-only') {
+      args.push('--network', 'none')
+    }
+
+    // Label so orphaned sandboxes are findable/reapable.
+    args.push('--label', 'kg-sandbox=1', '--label', `kg-sandbox-id=${id}`)
+    args.push(image)
+
+    let containerId: string
+    try {
+      containerId = await docker(args)
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      throw new SandboxBootError(`boot failed for ${id} (${image}): ${msg}`)
+    }
+
+    return {
+      id,
+      backend: 'docker',
+      rootfs,
+      bootedAt: Date.now(),
+      native: { containerId } satisfies DockerNative,
+    }
+  }
+
+  async destroy(vm: VMHandle): Promise<void> {
+    const cid = containerId(vm)
+    // `--rm` means a stop auto-removes; force-rm covers the not-yet-stopped
+    // and already-gone cases without throwing.
+    await docker(['rm', '-f', cid]).catch(() => {
+      /* already gone — destroy is idempotent */
+    })
+  }
+
+  async connectMcp(vm: VMHandle): Promise<McpTransport> {
+    return DockerMcpTransport.open(vm.id, containerId(vm))
+  }
+
+  async health(vm: VMHandle): Promise<HealthStatus> {
+    const cid = containerId(vm)
+    try {
+      const status = await docker([
+        'inspect',
+        '-f',
+        '{{.State.Status}}',
+        cid,
+      ])
+      if (status === 'running') return { state: 'healthy', detail: status }
+      return { state: 'unhealthy', detail: status }
+    } catch {
+      // inspect fails ⇒ container no longer exists.
+      return { state: 'gone' }
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async reset(_vm: VMHandle): Promise<void> {
+    // Warm-pool recycle. For Docker the recycle strategy is destroy + boot
+    // fresh (no snapshot story); the pool wiring lands in build-order step 5.
+    throw new Error('DockerBackend.reset is not implemented until warm-pool (build-order step 5)')
+  }
+}
+
+/** Default backend selection knob (see plan → "macOS development"). */
+function imageForRootfs(rootfs: RootfsId): string {
+  // v0: a single image holds the `base` flavor. The flavor catalog (#78) will
+  // map other ids to other images/tags here.
+  if (rootfs === 'base') return SANDBOX_IMAGE
+  return `kg-sandbox:${rootfs}`
+}
+
+/** Boot-time failure (rootfs broken / engine unavailable). See failure modes. */
+export class SandboxBootError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'SandboxBootError'
+  }
+}

--- a/ui/src/lib/sandbox/docker-backend.server.ts
+++ b/ui/src/lib/sandbox/docker-backend.server.ts
@@ -11,8 +11,10 @@
  * `connectMcp` spawns each one on stdio via `docker exec -i <ctr> init.sh
  * serve <name>` and wraps them in a unified `McpTransport`.
  *
- * Step 2 scope: boot / destroy / connectMcp (+ a cheap health). `reset`
- * (warm-pool recycle) throws until step 5.
+ * Reset semantics: destroy + boot fresh (no Docker snapshot story). The
+ * sandbox `id` is preserved across the reset so warm-pool slot identity is
+ * stable; only `native.containerId` and `bootedAt` change. The caller must
+ * close any `McpTransport` first — its stdio pipes target the old container.
  */
 
 import { spawn } from 'node:child_process'
@@ -43,6 +45,8 @@ const WORK_DIR = '/work'
 
 interface DockerNative extends Record<string, unknown> {
   containerId: string
+  /** Preserved across `reset` so the recycle reboots with the same caps. */
+  runtime: RuntimeConfig
 }
 
 /** Run `docker <args>`, resolving stdout (trimmed). Rejects on non-zero exit. */
@@ -192,40 +196,13 @@ export class DockerBackend implements ComputeBackend {
 
   async boot(rootfs: RootfsId, runtime: RuntimeConfig): Promise<VMHandle> {
     const id = `sbx-${randomUUID().slice(0, 8)}`
-    const image = imageForRootfs(rootfs)
-
-    const args = ['run', '-d', '--rm', '--name', id]
-
-    // Resource caps. Docker accepts fractional --cpus and <N>m for memory.
-    if (runtime.cpus) args.push('--cpus', String(runtime.cpus))
-    if (runtime.memoryMB) args.push('--memory', `${runtime.memoryMB}m`)
-
-    // Egress. v0: mcp-only ⇒ no network at all (in-VM MCP is reached over the
-    // docker-exec stdio pipe, which does NOT require container networking).
-    // Anything else leaves the default bridge network in place. Finer egress
-    // profiles (pypi / github-trusted) are later work.
-    if ((runtime.egress ?? 'mcp-only') === 'mcp-only') {
-      args.push('--network', 'none')
-    }
-
-    // Label so orphaned sandboxes are findable/reapable.
-    args.push('--label', 'kg-sandbox=1', '--label', `kg-sandbox-id=${id}`)
-    args.push(image)
-
-    let containerId: string
-    try {
-      containerId = await docker(args)
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
-      throw new SandboxBootError(`boot failed for ${id} (${image}): ${msg}`)
-    }
-
+    const containerId = await this.runContainer(id, rootfs, runtime)
     return {
       id,
       backend: 'docker',
       rootfs,
       bootedAt: Date.now(),
-      native: { containerId } satisfies DockerNative,
+      native: { containerId, runtime } satisfies DockerNative,
     }
   }
 
@@ -259,11 +236,51 @@ export class DockerBackend implements ComputeBackend {
     }
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  async reset(_vm: VMHandle): Promise<void> {
-    // Warm-pool recycle. For Docker the recycle strategy is destroy + boot
-    // fresh (no snapshot story); the pool wiring lands in build-order step 5.
-    throw new Error('DockerBackend.reset is not implemented until warm-pool (build-order step 5)')
+  async reset(vm: VMHandle): Promise<void> {
+    const native = vm.native as DockerNative
+    const oldCid = containerId(vm)
+    // Caller is responsible for closing any open McpTransport; its stdio pipes
+    // target the container we're about to remove.
+    await docker(['rm', '-f', oldCid]).catch(() => {
+      /* already gone — recycle still proceeds */
+    })
+    const newCid = await this.runContainer(vm.id, vm.rootfs, native.runtime)
+    // Mutate in place: same logical slot (vm.id stable), new container under.
+    native.containerId = newCid
+    ;(vm as { bootedAt: number }).bootedAt = Date.now()
+  }
+
+  /** Boot a container under a given sandbox id. Shared by `boot` and `reset`. */
+  private async runContainer(
+    id: string,
+    rootfs: RootfsId,
+    runtime: RuntimeConfig,
+  ): Promise<string> {
+    const image = imageForRootfs(rootfs)
+    const args = ['run', '-d', '--rm', '--name', id]
+
+    // Resource caps. Docker accepts fractional --cpus and <N>m for memory.
+    if (runtime.cpus) args.push('--cpus', String(runtime.cpus))
+    if (runtime.memoryMB) args.push('--memory', `${runtime.memoryMB}m`)
+
+    // Egress. v0: mcp-only ⇒ no network at all (in-VM MCP is reached over the
+    // docker-exec stdio pipe, which does NOT require container networking).
+    // Anything else leaves the default bridge network in place. Finer egress
+    // profiles (pypi / github-trusted) are later work.
+    if ((runtime.egress ?? 'mcp-only') === 'mcp-only') {
+      args.push('--network', 'none')
+    }
+
+    // Label so orphaned sandboxes are findable/reapable.
+    args.push('--label', 'kg-sandbox=1', '--label', `kg-sandbox-id=${id}`)
+    args.push(image)
+
+    try {
+      return await docker(args)
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      throw new SandboxBootError(`boot failed for ${id} (${image}): ${msg}`)
+    }
   }
 }
 

--- a/ui/src/lib/sandbox/index.server.ts
+++ b/ui/src/lib/sandbox/index.server.ts
@@ -1,0 +1,53 @@
+/**
+ * Sandbox compute — server-only barrel + backend selection.
+ *
+ * `withSandbox` and the (future) sandbox manager import `getComputeBackend()`
+ * here rather than constructing a backend directly, so substrate choice stays
+ * a single operational decision (see docs/sandbox-plan.md → "macOS
+ * development" / "Substrate options").
+ */
+
+import { assertServerOnImport } from '../harness-patterns/assert.server'
+import { DockerBackend } from './docker-backend.server'
+import type { ComputeBackend } from './types'
+
+assertServerOnImport()
+
+export type { ComputeBackend, VMHandle, McpTransport, RootfsId, RuntimeConfig, HealthStatus, HealthState, InVmMcpServer } from './types'
+export { SANDBOX_TOOL_PREFIX, V0_IN_VM_SERVERS } from './types'
+export { DockerBackend, SandboxBootError } from './docker-backend.server'
+
+let backendSingleton: ComputeBackend | null = null
+
+/**
+ * Resolve which backend to use.
+ *
+ * `COMPUTE_BACKEND=docker|firecracker` selects explicitly. Default is `docker`
+ * (the v0 substrate and the only one implemented; Firecracker is #78, swapped
+ * in once the abstraction proves out). On Linux with `/dev/kvm` the eventual
+ * default flips to firecracker — encoded here as intent, but it still falls
+ * back to Docker because FirecrackerBackend does not exist yet.
+ */
+export function selectBackendKind(): 'docker' | 'firecracker' {
+  const explicit = process.env.COMPUTE_BACKEND
+  if (explicit === 'docker' || explicit === 'firecracker') return explicit
+  return 'docker'
+}
+
+/** Process-lifetime backend instance. */
+export function getComputeBackend(): ComputeBackend {
+  if (backendSingleton) return backendSingleton
+  const kind = selectBackendKind()
+  if (kind === 'firecracker') {
+    // Deferred (#78). Fall back to Docker rather than crash so dev on Linux
+    // hosts still works before the Firecracker driver lands.
+    console.warn('[sandbox] COMPUTE_BACKEND=firecracker requested but not implemented (#78); using docker')
+  }
+  backendSingleton = new DockerBackend()
+  return backendSingleton
+}
+
+/** Test seam: override or reset the backend singleton. */
+export function __setComputeBackend(backend: ComputeBackend | null): void {
+  backendSingleton = backend
+}

--- a/ui/src/lib/sandbox/pty-manager.server.ts
+++ b/ui/src/lib/sandbox/pty-manager.server.ts
@@ -1,0 +1,192 @@
+/**
+ * PtyManager — interactive shells into persistent session sandboxes (#79).
+ *
+ * One PTY per session id. `ensure(sessionId)` acquires the session's live
+ * attachment from the shared `AttachmentTable` (booting the VM if needed) and
+ * spawns `docker exec -it <containerId> bash` through node-pty, giving a real
+ * pseudo-TTY inside the container (prompt, colors, job control). Output fans
+ * out to any number of subscribers (SSE streams); keystrokes are written via
+ * `write`. The transport to the browser is SSE-down / POST-up — this module
+ * is transport-agnostic and just deals in subscriber callbacks.
+ *
+ * Lifetime is decoupled from subscribers: switching UI tabs (the SupportPanel
+ * unmounts tab content) drops the SSE connection, but the shell must survive
+ * so cwd / env / running processes persist. So the PTY lives until the bash
+ * process exits, or `IDLE_CLOSE_MS` passes with zero subscribers. While a PTY
+ * exists it holds the attachment (refCount > 0), so the warm-pool / attachment
+ * idle sweep can't reclaim the VM out from under an open terminal.
+ *
+ * A capped scrollback buffer is replayed to each new subscriber so a
+ * re-mounted terminal tab redraws the current screen.
+ */
+
+import { assertServerOnImport } from '../harness-patterns/assert.server'
+import { DEFAULT_SETTINGS } from '../settings'
+import { getDefaultAttachments } from './with-sandbox.server'
+import type { Attachment } from './attachment-table.server'
+import type { RuntimeConfig } from './types'
+import * as pty from 'node-pty'
+
+assertServerOnImport()
+
+const DOCKER_BIN = process.env.DOCKER_BIN || 'docker'
+/** Cap on replayed scrollback (bytes). Enough to redraw a screen + recent history. */
+const MAX_SCROLLBACK = 64 * 1024
+/** Keep a subscriber-less PTY alive this long (tab switches, brief disconnects). */
+const IDLE_CLOSE_MS = 5 * 60_000
+
+type Subscriber = (chunk: string) => void
+
+interface PtySession {
+  pty: pty.IPty
+  attachment: Attachment
+  subscribers: Set<Subscriber>
+  scrollback: string
+  cols: number
+  rows: number
+  closeTimer?: ReturnType<typeof setTimeout>
+}
+
+class PtyManager {
+  private readonly sessions = new Map<string, PtySession>()
+  private readonly starting = new Map<string, Promise<PtySession>>()
+
+  /** Ensure a live PTY exists for the session (boot + spawn on first call). */
+  async ensure(sessionId: string): Promise<void> {
+    if (this.sessions.has(sessionId)) return
+    const pending = this.starting.get(sessionId)
+    if (pending) {
+      await pending
+      return
+    }
+    const p = this.start(sessionId)
+    this.starting.set(sessionId, p)
+    try {
+      await p
+    } finally {
+      this.starting.delete(sessionId)
+    }
+  }
+
+  private async start(sessionId: string): Promise<PtySession> {
+    const runtime: RuntimeConfig = {
+      memoryMB: DEFAULT_SETTINGS.sandbox.defaultMemoryMB,
+      timeoutSec: DEFAULT_SETTINGS.sandbox.defaultTimeoutSec,
+      egress: DEFAULT_SETTINGS.sandbox.defaultEgress,
+    }
+    const attachments = getDefaultAttachments()
+    const attachment = await attachments.acquire(sessionId, 'base', runtime)
+    const containerId = (attachment.vm.native as { containerId: string }).containerId
+
+    const cols = 80
+    const rows = 24
+    const term = pty.spawn(DOCKER_BIN, ['exec', '-it', containerId, 'bash'], {
+      name: 'xterm-color',
+      cols,
+      rows,
+      cwd: process.cwd(),
+      env: process.env as Record<string, string>,
+    })
+
+    const session: PtySession = {
+      pty: term,
+      attachment,
+      subscribers: new Set(),
+      scrollback: '',
+      cols,
+      rows,
+    }
+
+    term.onData((chunk) => {
+      session.scrollback = (session.scrollback + chunk).slice(-MAX_SCROLLBACK)
+      for (const sub of session.subscribers) {
+        try {
+          sub(chunk)
+        } catch {
+          /* a dead subscriber shouldn't break the fan-out */
+        }
+      }
+    })
+    term.onExit(() => this.dispose(sessionId, 'shell exited'))
+
+    this.sessions.set(sessionId, session)
+    return session
+  }
+
+  /** Write keystrokes/data to the session's shell. No-op if none exists. */
+  write(sessionId: string, data: string): void {
+    this.sessions.get(sessionId)?.pty.write(data)
+  }
+
+  /** Resize the session's PTY. */
+  resize(sessionId: string, cols: number, rows: number): void {
+    const s = this.sessions.get(sessionId)
+    if (!s || !Number.isFinite(cols) || !Number.isFinite(rows)) return
+    s.cols = cols
+    s.rows = rows
+    try {
+      s.pty.resize(Math.max(1, Math.floor(cols)), Math.max(1, Math.floor(rows)))
+    } catch {
+      /* resize can race teardown; ignore */
+    }
+  }
+
+  /** Current scrollback so a freshly-connected subscriber can redraw. */
+  getScrollback(sessionId: string): string {
+    return this.sessions.get(sessionId)?.scrollback ?? ''
+  }
+
+  /** Subscribe to live output. Returns an unsubscribe fn. */
+  subscribe(sessionId: string, cb: Subscriber): () => void {
+    const s = this.sessions.get(sessionId)
+    if (!s) return () => {}
+    s.subscribers.add(cb)
+    if (s.closeTimer) {
+      clearTimeout(s.closeTimer)
+      s.closeTimer = undefined
+    }
+    return () => {
+      s.subscribers.delete(cb)
+      if (s.subscribers.size === 0) this.scheduleIdleClose(sessionId)
+    }
+  }
+
+  /** Whether a live PTY exists for the session. */
+  has(sessionId: string): boolean {
+    return this.sessions.has(sessionId)
+  }
+
+  private scheduleIdleClose(sessionId: string): void {
+    const s = this.sessions.get(sessionId)
+    if (!s || s.closeTimer) return
+    s.closeTimer = setTimeout(() => {
+      const cur = this.sessions.get(sessionId)
+      if (cur && cur.subscribers.size === 0) this.dispose(sessionId, 'idle')
+    }, IDLE_CLOSE_MS)
+  }
+
+  private dispose(sessionId: string, reason: string): void {
+    const s = this.sessions.get(sessionId)
+    if (!s) return
+    this.sessions.delete(sessionId)
+    if (s.closeTimer) clearTimeout(s.closeTimer)
+    for (const sub of s.subscribers) {
+      try {
+        sub(`\r\n[sandbox terminal closed: ${reason}]\r\n`)
+      } catch {
+        /* ignore */
+      }
+    }
+    s.subscribers.clear()
+    try {
+      s.pty.kill()
+    } catch {
+      /* already gone */
+    }
+    // Release the attachment hold so the VM can be reset/parked/swept normally.
+    getDefaultAttachments().release(s.attachment)
+  }
+}
+
+/** Process-shared singleton (one terminal per session across the harness). */
+export const ptyManager = new PtyManager()

--- a/ui/src/lib/sandbox/scheduler.server.ts
+++ b/ui/src/lib/sandbox/scheduler.server.ts
@@ -1,0 +1,124 @@
+/**
+ * SandboxScheduler — capacity gate for concurrent sandbox attachments.
+ *
+ * Two caps, both enforced:
+ *   - `globalCap`        — total in-flight sandboxes across the harness
+ *   - `perSessionCap`    — in-flight sandboxes for any single session
+ *
+ * `allocate(sessionId)` returns a `Slot` immediately if under both caps;
+ * otherwise the caller waits until a release frees space. Release is
+ * idempotent — calling it twice is a no-op on the second call (safer for
+ * try/finally patterns where the slot might already be released).
+ *
+ * Orthogonal to `WarmPool`: the scheduler decides *whether* a sandbox may
+ * exist right now, not where it comes from. `withSandbox` does
+ * `scheduler.allocate(...)` first (blocks on cap), then `pool.acquire(...)`
+ * (cold-boot vs. pool hit). See docs/sandbox-plan.md → "Scheduler".
+ *
+ * Queue fairness: FIFO with skip-on-session-cap. A waiter whose session is
+ * still over its per-session cap is passed over so later waiters in *other*
+ * sessions aren't blocked behind a noisy neighbor. Strict FIFO (no skip) is
+ * safer against pathological starvation but blocks a whole queue behind one
+ * over-cap session, which is worse for v0's interactive workloads.
+ */
+
+import { assertServerOnImport } from '../harness-patterns/assert.server'
+
+assertServerOnImport()
+
+export interface SandboxSchedulerConfig {
+  globalCap: number
+  perSessionCap: number
+}
+
+export interface Slot {
+  /** Free the slot. Idempotent — safe to call from try/finally. */
+  release(): void
+}
+
+interface Pending {
+  sessionId: string
+  resolve: (slot: Slot) => void
+}
+
+export class SandboxScheduler {
+  private readonly globalCap: number
+  private readonly perSessionCap: number
+  private inflightGlobal = 0
+  private readonly inflightPerSession = new Map<string, number>()
+  private readonly queue: Pending[] = []
+
+  constructor(config: SandboxSchedulerConfig) {
+    this.globalCap = config.globalCap
+    this.perSessionCap = config.perSessionCap
+  }
+
+  /** Acquire a slot, waiting if either cap is reached. */
+  async allocate(sessionId: string): Promise<Slot> {
+    if (this.canAdmit(sessionId)) {
+      return this.grant(sessionId)
+    }
+    return new Promise<Slot>((resolve) => {
+      this.queue.push({ sessionId, resolve })
+    })
+  }
+
+  /** Total in-flight count (or per-session if `sessionId` provided). */
+  inflightCount(sessionId?: string): number {
+    if (sessionId === undefined) return this.inflightGlobal
+    return this.inflightPerSession.get(sessionId) ?? 0
+  }
+
+  /** Number of pending waiters (overall or per-session). */
+  queueDepth(sessionId?: string): number {
+    if (sessionId === undefined) return this.queue.length
+    return this.queue.filter((p) => p.sessionId === sessionId).length
+  }
+
+  private canAdmit(sessionId: string): boolean {
+    if (this.inflightGlobal >= this.globalCap) return false
+    const perSession = this.inflightPerSession.get(sessionId) ?? 0
+    if (perSession >= this.perSessionCap) return false
+    return true
+  }
+
+  private grant(sessionId: string): Slot {
+    this.inflightGlobal += 1
+    this.inflightPerSession.set(
+      sessionId,
+      (this.inflightPerSession.get(sessionId) ?? 0) + 1,
+    )
+    let released = false
+    return {
+      release: () => {
+        if (released) return
+        released = true
+        this.inflightGlobal -= 1
+        const next = (this.inflightPerSession.get(sessionId) ?? 1) - 1
+        if (next <= 0) this.inflightPerSession.delete(sessionId)
+        else this.inflightPerSession.set(sessionId, next)
+        this.drainQueue()
+      },
+    }
+  }
+
+  /**
+   * Wake compatible waiters in FIFO order, skipping any whose session is
+   * still over its per-session cap. Stops when the global cap is full.
+   */
+  private drainQueue(): void {
+    let i = 0
+    while (i < this.queue.length && this.inflightGlobal < this.globalCap) {
+      const w = this.queue[i]
+      if (this.canAdmit(w.sessionId)) {
+        this.queue.splice(i, 1)
+        w.resolve(this.grant(w.sessionId))
+        // Indices shifted; restart from 0 since previously-skipped waiters
+        // remain over-cap unless their session also just released.
+        i = 0
+      } else {
+        i += 1
+      }
+    }
+  }
+}

--- a/ui/src/lib/sandbox/scope.server.ts
+++ b/ui/src/lib/sandbox/scope.server.ts
@@ -1,0 +1,42 @@
+/**
+ * Request-scoped sandbox context — AsyncLocalStorage.
+ *
+ * `withSandbox` acquires a sandbox (boot + connectMcp) and runs the wrapped
+ * pattern inside an ALS scope carrying the resulting `McpTransport`. Three
+ * downstream readers consult it (see docs/sandbox-plan.md → "How tools reach
+ * the controller"):
+ *
+ *   1. `mcp-client.callTool` — routes sandbox-owned tool names to the in-VM
+ *      transport instead of the host gateway.
+ *   2. `simpleLoop` / `actorCritic` — extend their allowlist guard with
+ *      `sandbox.ownsTool(...)` so sandbox tools pass `tools.includes(...)`
+ *      without being threaded through the pattern's `tools` / `availableTools`.
+ *   3. BAML adapters in `baml-adapters.server.ts` — append the active
+ *      sandbox's `listTools()` descriptions to the prompt's tool list so the
+ *      actor sees them in its first-turn prompt.
+ *
+ * Model: same shape as `settings-context.server.ts`. Sentinel is `undefined`
+ * (sandbox is opt-in — outside a wrapper, readers behave exactly as today).
+ */
+import { AsyncLocalStorage } from 'node:async_hooks'
+import { assertServerOnImport } from '../harness-patterns/assert.server'
+import type { McpTransport } from './types'
+
+assertServerOnImport()
+
+const sandboxStore = new AsyncLocalStorage<McpTransport>()
+
+/** Run `fn` with `transport` as the active sandbox scope. Used by
+ *  `withSandbox` to inject the sandbox for the wrapped pattern's lifetime. */
+export function runWithSandbox<T>(
+  transport: McpTransport,
+  fn: () => Promise<T>,
+): Promise<T> {
+  return sandboxStore.run(transport, fn)
+}
+
+/** Return the active sandbox's MCP transport, or `undefined` when no sandbox
+ *  is attached. Readers treat `undefined` as "route to gateway as today". */
+export function getActiveSandbox(): McpTransport | undefined {
+  return sandboxStore.getStore()
+}

--- a/ui/src/lib/sandbox/scripts/README.md
+++ b/ui/src/lib/sandbox/scripts/README.md
@@ -1,0 +1,81 @@
+# Sandbox smoke scripts
+
+Live-container smoke checks for `withSandbox(actorCritic(...))`. Complement
+the hermetic vitest tests under `ui/src/__tests__/lib/sandbox/` — those mock
+`node:child_process.spawn` and the MCP SDK at the lowest seam to stay
+CI-friendly. These scripts spin up **real Docker containers** and prove the
+chain works for real.
+
+## When to run
+
+After any change to the sandbox lane (`DockerBackend`, the ALS scope, the
+`withSandbox` wrapper, the controller/adapter dispatch wiring) and before
+opening a PR. The vitest suite catches most regressions; smoke scripts catch
+the ones the mocks would mask — anything that depends on the actual docker
+engine, the real `rust-mcp-filesystem` binary, or stdio handshake details
+that the SDK mocks gloss over.
+
+## Prerequisites
+
+- Docker engine running (colima on macOS).
+- `kg-sandbox:base` image built:
+  ```sh
+  cd rootfs && docker build -t kg-sandbox:base .
+  ```
+- Nix-shell users: the flake's `shellHook` bridges `~/.docker/contexts` into
+  `$DOCKER_CONFIG/contexts` so colima resolves. If you see
+  `context "colima": context not found`, re-enter `nix develop` (the
+  symlink only gets created on shell entry) or consult `rootfs/README.md`
+  → "Inside the nix shell".
+
+## The two scripts
+
+| File | Driven by | Cost | Typical runtime |
+|---|---|---|---|
+| `smoke-scripted.ts` | hand-scripted actor + critic | none | ~340ms |
+| `smoke-llm.ts` | real Anthropic via BAML adapters | a few cents | ~4–5s (2× Anthropic calls) |
+
+Run from `ui/`:
+
+```sh
+pnpm dlx tsx src/lib/sandbox/scripts/smoke-scripted.ts
+pnpm dlx tsx --env-file=.env src/lib/sandbox/scripts/smoke-llm.ts
+```
+
+`smoke-llm.ts` needs `ANTHROPIC_API_KEY` (the Anthropic-default chain — see
+`CLAUDE.md` → "Client routing"). Set `USE_MIXED_CHAINS=1` to swap in the
+mixed Groq / OpenRouter / OpenAI chain instead; corresponding keys then
+required. The `--env-file=.env` flag lets the script pick up the repo's
+`.env` without a separate `dotenv` import.
+
+Each script's file header documents its own actor/critic logic, the
+expected event log, and any quirks. Read those before extending.
+
+## What "passing" looks like
+
+Both scripts print:
+1. A header — the sentence + the expected count.
+2. A boot/run note.
+3. The event log — one line per `controller_action`, `tool_result`, and
+   `critic_result`, plus any `error`.
+4. The final `result` from `scope.data`.
+5. Elapsed wall-clock time.
+
+For the word-count task, the result's `stdout` ends with `"9\n"`. The
+scripted run takes the deterministic write-then-run path (`sandbox_write`
+then `sandbox_bash`); the LLM run picks its own — the verified run went
+straight to `sandbox_bash` with a `python3 -c` one-liner.
+
+## Cleanup
+
+`DockerBackend` boots containers with `docker run --rm`, and the
+`withSandbox` `finally` block calls `backend.destroy()` on exit — including
+on inner-pattern throws and `connectMcp` failures. So normal exits never
+leak.
+
+On SIGKILL or harness crash, leftover sandboxes carry the `kg-sandbox=1`
+label. Reap them with:
+
+```sh
+docker ps -a --filter label=kg-sandbox=1 -q | xargs -r docker rm -f
+```

--- a/ui/src/lib/sandbox/scripts/README.md
+++ b/ui/src/lib/sandbox/scripts/README.md
@@ -32,7 +32,7 @@ that the SDK mocks gloss over.
 
 | File | Driven by | Cost | Typical runtime |
 |---|---|---|---|
-| `smoke-scripted.ts` | hand-scripted actor + critic | none | ~340ms |
+| `smoke-scripted.ts` | hand-scripted actor + critic, **runs twice to prove pool hit** | none | ~1.5s (1 cold boot + 1 pool hit + 1 reset) |
 | `smoke-llm.ts` | real Anthropic via BAML adapters | a few cents | ~4–5s (2× Anthropic calls) |
 
 Run from `ui/`:
@@ -65,6 +65,12 @@ For the word-count task, the result's `stdout` ends with `"9\n"`. The
 scripted run takes the deterministic write-then-run path (`sandbox_write`
 then `sandbox_bash`); the LLM run picks its own — the verified run went
 straight to `sandbox_bash` with a `python3 -c` one-liner.
+
+`smoke-scripted` additionally asserts that `bootCount === 1` after two
+invocations of the same wrapper, sharing one `WarmPool(caps: { base: 1 })`.
+The first run cold-boots, the second hits the pool. The script throws if
+either invocation cold-booted independently — a regression in the wrapper's
+acquire/release wiring would show up here before it reaches production.
 
 ## Cleanup
 

--- a/ui/src/lib/sandbox/scripts/_shared.ts
+++ b/ui/src/lib/sandbox/scripts/_shared.ts
@@ -1,0 +1,95 @@
+/**
+ * Shared helpers for the sandbox smoke scripts.
+ *
+ * Not a server module — runs as a `tsx` script from the CLI. Imports
+ * server-side modules; the `assertServerOnImport` guards pass because tsx
+ * runs in Node.
+ */
+
+import type { ContextEvent, PatternScope } from '../../harness-patterns/types'
+
+/** Print every tracked event in execution order, summarized to one line each.
+ *  Covers the four event shapes the smoke scripts care about — controller
+ *  actions, tool calls/results, critic outcomes — plus any errors. */
+export function printEventSummary(scope: PatternScope<unknown>): void {
+  const events = (scope as { events?: ContextEvent[] }).events ?? []
+  console.log('\n— Event log —')
+  if (events.length === 0) {
+    console.log('  (no events tracked)')
+    return
+  }
+  for (const ev of events) {
+    const t = new Date(ev.ts).toISOString().slice(11, 23)
+    switch (ev.type) {
+      case 'controller_action': {
+        const data = ev.data as { action: { tool_name: string; tool_args: string }; turn: number }
+        console.log(
+          `[${t}] turn ${data.turn} actor → ${data.action.tool_name}(${truncate(data.action.tool_args, 100)})`,
+        )
+        break
+      }
+      case 'tool_result': {
+        const data = ev.data as { tool: string; success: boolean; result: unknown; error?: string }
+        const ok = data.success ? '✓' : '✗'
+        const payload = data.success
+          ? truncate(safeJson(data.result), 120)
+          : data.error ?? 'error'
+        console.log(`           ${ok} ${data.tool} → ${payload}`)
+        break
+      }
+      case 'critic_result': {
+        const data = ev.data as {
+          result: { is_sufficient: boolean; explanation?: string; suggested_approach?: string }
+        }
+        const verdict = data.result.is_sufficient ? 'OK' : 'reject'
+        const reason = data.result.explanation ?? data.result.suggested_approach ?? ''
+        console.log(`           critic: ${verdict} — ${reason}`)
+        break
+      }
+      case 'error': {
+        const data = ev.data as { error: string }
+        console.log(`           ✗ ERROR: ${data.error}`)
+        break
+      }
+      default:
+        // ignore other event types in the summary
+        break
+    }
+  }
+  console.log()
+}
+
+function truncate(s: string, n: number): string {
+  return s.length > n ? s.slice(0, n - 1) + '…' : s
+}
+
+function safeJson(x: unknown): string {
+  if (typeof x === 'string') return x
+  try {
+    return JSON.stringify(x)
+  } catch {
+    return String(x)
+  }
+}
+
+/** Pre-flight: complain loudly if the rootfs image isn't built. The wrapper
+ *  would fail more cryptically later. */
+export async function checkRootfsImage(): Promise<void> {
+  const { spawn } = await import('node:child_process')
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn('docker', ['image', 'inspect', 'kg-sandbox:base'], {
+      stdio: ['ignore', 'ignore', 'ignore'],
+    })
+    child.on('error', reject)
+    child.on('close', (code) => {
+      if (code === 0) return resolve()
+      reject(
+        new Error(
+          'kg-sandbox:base image not found. Build it first:\n' +
+            '  cd rootfs && docker build -t kg-sandbox:base .\n' +
+            '(See rootfs/README.md for the nix-shell DOCKER_CONFIG bridge.)',
+        ),
+      )
+    })
+  })
+}

--- a/ui/src/lib/sandbox/scripts/smoke-llm.ts
+++ b/ui/src/lib/sandbox/scripts/smoke-llm.ts
@@ -1,0 +1,112 @@
+/**
+ * Real-LLM smoke test for `withSandbox(actorCritic(...))`.
+ *
+ * Same chain as `smoke-scripted.ts`, but the actor + critic are the real
+ * BAML adapters (`createActorControllerAdapter` / `createCriticAdapter`)
+ * driven by Anthropic (the default chain — see CLAUDE.md → "Client routing").
+ * The actor's decisions are not fixed: it sees the `sandbox_*` tool surface
+ * in its prompt (prepended by the adapter from the active ALS scope) and
+ * picks how to satisfy the user's task.
+ *
+ * Prerequisites:
+ *   - Docker engine running (colima on macOS).
+ *   - `kg-sandbox:base` image built:
+ *       cd rootfs && docker build -t kg-sandbox:base .
+ *   - BAML client generated:
+ *       pnpm baml-generate
+ *   - `ANTHROPIC_API_KEY` in env (the Anthropic-default chain routes through
+ *     `ControllerAnthropic` → `AnthropicSonnet46` etc.). To use the mixed-
+ *     provider chain instead, set `USE_MIXED_CHAINS=1` and the corresponding
+ *     keys.
+ *
+ * Run from `ui/`:
+ *   pnpm dlx tsx src/lib/sandbox/scripts/smoke-llm.ts
+ *
+ * Cost: a handful of Sonnet calls (actor + critic per turn). Should be a
+ * few cents at most. Look for the word count (9) in the final result; the
+ * exact path the agent takes is its own choice.
+ */
+
+import { withSandbox } from '../with-sandbox.server'
+import { actorCritic } from '../../harness-patterns/patterns/actorCritic.server'
+import {
+  createActorControllerAdapter,
+  createCriticAdapter,
+} from '../../harness-patterns/baml-adapters.server'
+import { createScope } from '../../harness-patterns/context.server'
+import { createEventView } from '../../harness-patterns/patterns'
+import { printEventSummary, checkRootfsImage } from './_shared'
+
+const SENTENCE = 'the quick brown fox jumps over the lazy dog'
+
+function preflight(): void {
+  if (!process.env.ANTHROPIC_API_KEY) {
+    throw new Error(
+      'ANTHROPIC_API_KEY is not set.\n' +
+        'Export it before running:\n' +
+        '  export ANTHROPIC_API_KEY=sk-ant-...\n' +
+        '(Or use USE_MIXED_CHAINS=1 with the corresponding provider keys.)',
+    )
+  }
+}
+
+async function main(): Promise<void> {
+  console.log('🚀 Real-LLM sandbox smoke — Anthropic actor/critic')
+  console.log(`   sentence: "${SENTENCE}"`)
+  console.log(`   expected word count: ${SENTENCE.split(/\s+/).length}`)
+
+  preflight()
+  await checkRootfsImage()
+
+  // Empty tool lists — the sandbox's tools are surfaced to the actor's
+  // prompt via the ALS scope from inside `withSandbox`. No gateway tools
+  // needed for this task.
+  const actor = createActorControllerAdapter([])
+  const critic = createCriticAdapter()
+
+  const pattern = withSandbox({ rootfs: 'base' })(
+    actorCritic(actor, critic, [], {
+      availableTools: [],
+      maxRetries: 5,
+      patternId: 'smoke-llm',
+      trackHistory: true,
+    }),
+  )
+
+  const userMsg =
+    `Count the number of words in this sentence: "${SENTENCE}". ` +
+    'Use the sandbox tools (Python via sandbox_bash, files under /work) ' +
+    'to compute the answer. Return just the integer count.'
+
+  const scope = createScope('smoke-llm', { intent: 'count the words' })
+  const view = createEventView({
+    sessionId: 'smoke-llm',
+    createdAt: Date.now(),
+    events: [
+      {
+        type: 'user_message' as const,
+        ts: Date.now(),
+        patternId: 'harness',
+        data: { content: userMsg },
+      },
+    ],
+    status: 'running' as const,
+    data: {},
+    input: userMsg,
+  })
+
+  console.log('\n⏳ booting sandbox + running pattern (this calls Anthropic)...')
+  const t0 = Date.now()
+  const out = await pattern.fn(scope, view)
+  const elapsedMs = Date.now() - t0
+
+  printEventSummary(out)
+  const final = (out.data as { result?: unknown }).result
+  console.log(`📦 final result: ${JSON.stringify(final)}`)
+  console.log(`⏱  elapsed: ${elapsedMs}ms`)
+}
+
+main().catch((err) => {
+  console.error('\n❌ smoke failed:', err instanceof Error ? err.message : err)
+  process.exit(1)
+})

--- a/ui/src/lib/sandbox/scripts/smoke-scripted.ts
+++ b/ui/src/lib/sandbox/scripts/smoke-scripted.ts
@@ -1,0 +1,128 @@
+/**
+ * LLM-free smoke test for `withSandbox(actorCritic(...))`.
+ *
+ * Drives a real `DockerBackend` booting a real `kg-sandbox:base` container,
+ * but hand-scripts the actor + critic instead of calling BAML. Proves the
+ * wrapper, ALS scope, `callTool` dispatch, and DockerBackend lifecycle work
+ * end-to-end against a live container, with zero LLM cost or API key.
+ *
+ * Prerequisites:
+ *   - Docker engine running (colima on macOS).
+ *   - `kg-sandbox:base` image built:
+ *       cd rootfs && docker build -t kg-sandbox:base .
+ *     (Inside the nix shell, the flake's shellHook bridges
+ *     ~/.docker/contexts. See rootfs/README.md → "Inside the nix shell".)
+ *
+ * Run from `ui/`:
+ *   pnpm dlx tsx src/lib/sandbox/scripts/smoke-scripted.ts
+ *
+ * Expected: the actor writes a Python script counting words in a fixed
+ * sentence; the in-VM `sandbox_bash` runs it; the critic accepts; the
+ * script prints the count (9) plus an event log.
+ */
+
+import { withSandbox } from '../with-sandbox.server'
+import { actorCritic } from '../../harness-patterns/patterns/actorCritic.server'
+import { createScope } from '../../harness-patterns/context.server'
+import { createEventView } from '../../harness-patterns/patterns'
+import type {
+  CodeModeControllerFnWithLLMData,
+  CriticFnWithLLMData,
+} from '../../harness-patterns/baml-adapters.server'
+import { printEventSummary, checkRootfsImage } from './_shared'
+
+const SENTENCE = 'the quick brown fox jumps over the lazy dog'
+const SCRIPT = `text = "${SENTENCE}"\nprint(len(text.split()))\n`
+
+// Scripted actor: turn 1 writes `/work/count.py`, turn 2 runs it via bash.
+let actorCalls = 0
+const scriptedActor: CodeModeControllerFnWithLLMData = async () => {
+  actorCalls += 1
+  if (actorCalls === 1) {
+    return {
+      action: {
+        reasoning: 'Write the word-count script to /work/count.py.',
+        tool_name: 'sandbox_write',
+        tool_args: JSON.stringify({ path: '/work/count.py', content: SCRIPT }),
+        status: 'success',
+        is_final: false,
+      },
+    }
+  }
+  return {
+    action: {
+      reasoning: 'Run the script with python3.',
+      tool_name: 'sandbox_bash',
+      tool_args: JSON.stringify({ command: 'python3 /work/count.py' }),
+      status: 'success',
+      is_final: false,
+    },
+  }
+}
+
+// Scripted critic: rejects after the write (needs to see a result), accepts
+// after the bash returns the count.
+let criticCalls = 0
+const scriptedCritic: CriticFnWithLLMData = async () => {
+  criticCalls += 1
+  return {
+    result: {
+      is_sufficient: criticCalls >= 2,
+      explanation:
+        criticCalls === 1
+          ? 'Script written but not yet executed.'
+          : 'Got the word count.',
+      suggested_approach: criticCalls === 1 ? 'Run it with python3.' : undefined,
+    },
+  }
+}
+
+async function main(): Promise<void> {
+  console.log('🚀 LLM-free sandbox smoke — scripted actor/critic')
+  console.log(`   sentence: "${SENTENCE}"`)
+  console.log(`   expected word count: ${SENTENCE.split(/\s+/).length}`)
+
+  await checkRootfsImage()
+
+  const pattern = withSandbox({ rootfs: 'base' })(
+    actorCritic(scriptedActor, scriptedCritic, [], {
+      availableTools: [],
+      maxRetries: 3,
+      patternId: 'smoke-scripted',
+      trackHistory: true,
+    }),
+  )
+
+  const scope = createScope('smoke-scripted', { intent: 'count the words' })
+  const view = createEventView({
+    sessionId: 'smoke-scripted',
+    createdAt: Date.now(),
+    events: [
+      {
+        type: 'user_message' as const,
+        ts: Date.now(),
+        patternId: 'harness',
+        data: { content: `count the words in: ${SENTENCE}` },
+      },
+    ],
+    status: 'running' as const,
+    data: {},
+    input: `count the words in: ${SENTENCE}`,
+  })
+
+  console.log('\n⏳ booting sandbox + running pattern...')
+  const t0 = Date.now()
+  const out = await pattern.fn(scope, view)
+  const elapsedMs = Date.now() - t0
+
+  printEventSummary(out)
+  const final = (out.data as { result?: unknown }).result
+  console.log(`📦 final result: ${JSON.stringify(final)}`)
+  console.log(`⏱  elapsed: ${elapsedMs}ms`)
+  console.log(`👣 actor calls: ${actorCalls}, critic calls: ${criticCalls}`)
+}
+
+main().catch((err) => {
+  console.error('\n❌ smoke failed:', err instanceof Error ? err.message : err)
+  process.exit(1)
+})

--- a/ui/src/lib/sandbox/scripts/smoke-scripted.ts
+++ b/ui/src/lib/sandbox/scripts/smoke-scripted.ts
@@ -6,6 +6,10 @@
  * wrapper, ALS scope, `callTool` dispatch, and DockerBackend lifecycle work
  * end-to-end against a live container, with zero LLM cost or API key.
  *
+ * Runs **twice** with a shared pool + scheduler to demonstrate the warm-pool
+ * pay-off: invocation 1 boots a container; invocation 2 hits the pool and
+ * reuses the same backend slot. Asserts `bootCount === 1` after both runs.
+ *
  * Prerequisites:
  *   - Docker engine running (colima on macOS).
  *   - `kg-sandbox:base` image built:
@@ -16,11 +20,14 @@
  * Run from `ui/`:
  *   pnpm dlx tsx src/lib/sandbox/scripts/smoke-scripted.ts
  *
- * Expected: the actor writes a Python script counting words in a fixed
- * sentence; the in-VM `sandbox_bash` runs it; the critic accepts; the
- * script prints the count (9) plus an event log.
+ * Expected: each invocation writes a Python script counting words in a
+ * fixed sentence, runs it via in-VM bash, and prints the count (9). After
+ * the second invocation, bootCount remains 1 — proof of pool hit.
  */
 
+import { DockerBackend } from '../docker-backend.server'
+import { WarmPool } from '../warm-pool.server'
+import { SandboxScheduler } from '../scheduler.server'
 import { withSandbox } from '../with-sandbox.server'
 import { actorCritic } from '../../harness-patterns/patterns/actorCritic.server'
 import { createScope } from '../../harness-patterns/context.server'
@@ -34,58 +41,63 @@ import { printEventSummary, checkRootfsImage } from './_shared'
 const SENTENCE = 'the quick brown fox jumps over the lazy dog'
 const SCRIPT = `text = "${SENTENCE}"\nprint(len(text.split()))\n`
 
-// Scripted actor: turn 1 writes `/work/count.py`, turn 2 runs it via bash.
-let actorCalls = 0
-const scriptedActor: CodeModeControllerFnWithLLMData = async () => {
-  actorCalls += 1
-  if (actorCalls === 1) {
+// Fresh actor/critic factory — one set of closures per invocation so counts
+// don't bleed between runs.
+function makeScriptedActorCritic(): {
+  actor: CodeModeControllerFnWithLLMData
+  critic: CriticFnWithLLMData
+  counts: () => { actorCalls: number; criticCalls: number }
+} {
+  let actorCalls = 0
+  let criticCalls = 0
+  const actor: CodeModeControllerFnWithLLMData = async () => {
+    actorCalls += 1
+    if (actorCalls === 1) {
+      return {
+        action: {
+          reasoning: 'Write the word-count script to /work/count.py.',
+          tool_name: 'sandbox_write',
+          tool_args: JSON.stringify({ path: '/work/count.py', content: SCRIPT }),
+          status: 'success',
+          is_final: false,
+        },
+      }
+    }
     return {
       action: {
-        reasoning: 'Write the word-count script to /work/count.py.',
-        tool_name: 'sandbox_write',
-        tool_args: JSON.stringify({ path: '/work/count.py', content: SCRIPT }),
+        reasoning: 'Run the script with python3.',
+        tool_name: 'sandbox_bash',
+        tool_args: JSON.stringify({ command: 'python3 /work/count.py' }),
         status: 'success',
         is_final: false,
       },
     }
   }
-  return {
-    action: {
-      reasoning: 'Run the script with python3.',
-      tool_name: 'sandbox_bash',
-      tool_args: JSON.stringify({ command: 'python3 /work/count.py' }),
-      status: 'success',
-      is_final: false,
-    },
+  const critic: CriticFnWithLLMData = async () => {
+    criticCalls += 1
+    return {
+      result: {
+        is_sufficient: criticCalls >= 2,
+        explanation:
+          criticCalls === 1
+            ? 'Script written but not yet executed.'
+            : 'Got the word count.',
+        suggested_approach: criticCalls === 1 ? 'Run it with python3.' : undefined,
+      },
+    }
   }
+  return { actor, critic, counts: () => ({ actorCalls, criticCalls }) }
 }
 
-// Scripted critic: rejects after the write (needs to see a result), accepts
-// after the bash returns the count.
-let criticCalls = 0
-const scriptedCritic: CriticFnWithLLMData = async () => {
-  criticCalls += 1
-  return {
-    result: {
-      is_sufficient: criticCalls >= 2,
-      explanation:
-        criticCalls === 1
-          ? 'Script written but not yet executed.'
-          : 'Got the word count.',
-      suggested_approach: criticCalls === 1 ? 'Run it with python3.' : undefined,
-    },
-  }
-}
-
-async function main(): Promise<void> {
-  console.log('🚀 LLM-free sandbox smoke — scripted actor/critic')
-  console.log(`   sentence: "${SENTENCE}"`)
-  console.log(`   expected word count: ${SENTENCE.split(/\s+/).length}`)
-
-  await checkRootfsImage()
-
-  const pattern = withSandbox({ rootfs: 'base' })(
-    actorCritic(scriptedActor, scriptedCritic, [], {
+async function runOnce(
+  label: string,
+  backend: DockerBackend,
+  pool: WarmPool,
+  scheduler: SandboxScheduler,
+): Promise<void> {
+  const { actor, critic, counts } = makeScriptedActorCritic()
+  const pattern = withSandbox({ backend, pool, scheduler, rootfs: 'base' })(
+    actorCritic(actor, critic, [], {
       availableTools: [],
       maxRetries: 3,
       patternId: 'smoke-scripted',
@@ -110,16 +122,53 @@ async function main(): Promise<void> {
     input: `count the words in: ${SENTENCE}`,
   })
 
-  console.log('\n⏳ booting sandbox + running pattern...')
+  console.log(`\n— ${label} —`)
   const t0 = Date.now()
   const out = await pattern.fn(scope, view)
   const elapsedMs = Date.now() - t0
-
   printEventSummary(out)
   const final = (out.data as { result?: unknown }).result
+  const { actorCalls, criticCalls } = counts()
   console.log(`📦 final result: ${JSON.stringify(final)}`)
   console.log(`⏱  elapsed: ${elapsedMs}ms`)
   console.log(`👣 actor calls: ${actorCalls}, critic calls: ${criticCalls}`)
+}
+
+async function main(): Promise<void> {
+  console.log('🚀 LLM-free sandbox smoke — scripted actor/critic (×2 with pool)')
+  console.log(`   sentence: "${SENTENCE}"`)
+  console.log(`   expected word count: ${SENTENCE.split(/\s+/).length}`)
+
+  await checkRootfsImage()
+
+  // Shared backend + pool + scheduler so the second invocation hits the pool.
+  // Count cold boots by wrapping backend.boot.
+  const backend = new DockerBackend()
+  let bootCount = 0
+  const realBoot = backend.boot.bind(backend)
+  backend.boot = async (rootfs, runtime) => {
+    bootCount += 1
+    return realBoot(rootfs, runtime)
+  }
+  const pool = new WarmPool(backend, { caps: { base: 1 }, idleEvictMs: 60_000 })
+  const scheduler = new SandboxScheduler({ globalCap: 4, perSessionCap: 4 })
+
+  try {
+    await runOnce('run 1 (cold boot expected)', backend, pool, scheduler)
+    console.log(`   bootCount after run 1: ${bootCount} (expected 1)`)
+    console.log(`   pool size: ${pool.size('base')} (expected 1 — VM parked)`)
+
+    await runOnce('run 2 (pool hit expected)', backend, pool, scheduler)
+    console.log(`\n   bootCount after run 2: ${bootCount} (expected 1 — pool hit)`)
+    console.log(`   pool size: ${pool.size('base')} (expected 1 — VM re-parked)`)
+
+    if (bootCount !== 1) {
+      throw new Error(`pool-hit assertion failed: bootCount=${bootCount}, expected 1`)
+    }
+    console.log('\n✅ pool hit confirmed: single docker run across two pattern invocations')
+  } finally {
+    await pool.shutdown()
+  }
 }
 
 main().catch((err) => {

--- a/ui/src/lib/sandbox/types.ts
+++ b/ui/src/lib/sandbox/types.ts
@@ -1,0 +1,172 @@
+/**
+ * Sandbox compute — shared types.
+ *
+ * The `ComputeBackend` trait abstracts the substrate (Docker today,
+ * Firecracker later) behind a single interface so substrate choice is
+ * operational config, not application code. See
+ * docs/sandbox-plan.md → "Backend interface".
+ *
+ * Pure types only — safe to import from anywhere. The actual backend
+ * implementations live in `*.server.ts` files (server-only).
+ */
+
+import type { ToolCallResult, MCPToolDescription } from '../harness-patterns/types'
+
+// ============================================================================
+// Identity & config
+// ============================================================================
+
+/** Rootfs flavor. v0 ships only `'base'`; flavor catalog is v1 (#78). */
+export type RootfsId = 'base' | (string & {})
+
+/** Per-VM runtime knobs. Defaults come from HarnessSettings at call time. */
+export interface RuntimeConfig {
+  /** vCPU cap. */
+  cpus?: number
+  /** Memory cap in MB. */
+  memoryMB?: number
+  /** Per-tool-call wall-clock cap in seconds. */
+  timeoutSec?: number
+  /**
+   * Egress profile. Enforced at the kernel/container level, never exposed as
+   * a tool surface. v0 DockerBackend honors `'mcp-only'` (network disabled)
+   * vs. anything else (network enabled) — finer profiles are later work.
+   */
+  egress?: 'mcp-only' | 'pypi' | 'github-trusted' | 'open'
+}
+
+// ============================================================================
+// Handles & status
+// ============================================================================
+
+/**
+ * Opaque handle to a booted VM. The backend that minted it knows how to
+ * address it; callers treat it as a token. `backend` tags which backend owns
+ * it so a manager juggling multiple backends can route correctly.
+ */
+export interface VMHandle {
+  /** Stable sandbox id (also the attachment id when ID-addressable). */
+  id: string
+  /** Which backend minted this handle. */
+  backend: 'docker' | 'firecracker'
+  /** Rootfs flavor this VM was booted from. */
+  rootfs: RootfsId
+  /** Wall-clock boot time (epoch ms), for idle-eviction bookkeeping. */
+  bootedAt: number
+  /**
+   * Backend-private addressing. For Docker this is the container id. Typed as
+   * unknown-ish to keep the handle opaque; the owning backend casts it.
+   */
+  readonly native: Record<string, unknown>
+}
+
+export type HealthState = 'healthy' | 'unhealthy' | 'gone'
+
+export interface HealthStatus {
+  state: HealthState
+  /** Human-readable detail, e.g. the container status string. */
+  detail?: string
+}
+
+// ============================================================================
+// In-VM MCP transport
+// ============================================================================
+
+/**
+ * A live connection to the MCP servers running inside one VM. Returned by
+ * `connectMcp`. Unlike the host gateway client, this is per-VM: "which
+ * sandbox?" is implicit in the connection (see plan → "Architecture:
+ * MCP-in-VM").
+ *
+ * The transport owns one MCP client per in-VM server (filesystem + shell in
+ * v0) and presents a unified surface. Tool names are returned already
+ * `sandbox_`-prefixed via `listTools`/`toolNames`; `callTool` accepts the
+ * prefixed name and routes to the right in-VM server.
+ */
+export interface McpTransport {
+  /** The VM this transport is bound to. */
+  readonly vmId: string
+  /** Prefixed tool names this sandbox owns (e.g. `sandbox_bash`). */
+  toolNames(): Promise<string[]>
+  /** Full descriptions, names already prefixed, for the actor's prompt. */
+  listTools(): Promise<MCPToolDescription[]>
+  /** Call a `sandbox_`-prefixed tool; routes to the owning in-VM server. */
+  callTool(name: string, args: Record<string, unknown>): Promise<ToolCallResult>
+  /** True if `name` is a tool this sandbox owns. */
+  ownsTool(name: string): boolean
+  /** Tear down all in-VM MCP client connections (does not destroy the VM). */
+  close(): Promise<void>
+}
+
+// ============================================================================
+// Backend trait
+// ============================================================================
+
+/**
+ * Single backend trait; substrate choice is operational config. See plan →
+ * "Backend interface". v0 implements `boot` / `destroy` / `connectMcp` (+ a
+ * cheap `health`); `reset` (warm-pool recycle) lands with the pool in step 5.
+ */
+export interface ComputeBackend {
+  readonly kind: 'docker' | 'firecracker'
+  boot(rootfs: RootfsId, runtime: RuntimeConfig): Promise<VMHandle>
+  destroy(vm: VMHandle): Promise<void>
+  /** Warm-pool recycle. Not implemented until build-order step 5. */
+  reset(vm: VMHandle): Promise<void>
+  /** Tunneled connection to the in-VM MCP servers. */
+  connectMcp(vm: VMHandle): Promise<McpTransport>
+  health(vm: VMHandle): Promise<HealthStatus>
+}
+
+// ============================================================================
+// In-VM MCP server registry (the `sandbox_*` tool surface)
+// ============================================================================
+
+/** The `sandbox_` prefix the harness applies to in-VM tool names. */
+export const SANDBOX_TOOL_PREFIX = 'sandbox_' as const
+
+/**
+ * One MCP server running inside the VM. `launch` is the argv handed to the
+ * backend to start it on stdio (Docker: appended after `docker exec -i <ctr>`).
+ * `tools` maps the server's *native* tool name → the exposed `sandbox_*` name.
+ */
+export interface InVmMcpServer {
+  /** Stable key for the server (filesystem | shell). */
+  key: string
+  /** Argv to launch the server on stdio inside the VM. */
+  launch: string[]
+  /**
+   * native tool name → exposed (prefixed) name. Only listed tools are
+   * surfaced; the in-VM filesystem server exposes far more than v0 needs, so
+   * we curate to the six tools in the plan.
+   */
+  tools: Record<string, string>
+}
+
+/**
+ * v0 in-VM server registry — the six tools from
+ * docs/sandbox-plan.md → "Tools available in v0".
+ *
+ * `launch` argv targets `/opt/mcp/init.sh serve <name>`, the stable launch
+ * path baked into the rootfs (see rootfs/init.sh).
+ */
+export const V0_IN_VM_SERVERS: readonly InVmMcpServer[] = [
+  {
+    key: 'filesystem',
+    launch: ['/opt/mcp/init.sh', 'serve', 'filesystem'],
+    tools: {
+      read_text_file: 'sandbox_read',
+      write_file: 'sandbox_write',
+      edit_file: 'sandbox_edit',
+      list_directory: 'sandbox_list',
+      search_files_content: 'sandbox_search',
+    },
+  },
+  {
+    key: 'shell',
+    launch: ['/opt/mcp/init.sh', 'serve', 'shell'],
+    tools: {
+      bash: 'sandbox_bash',
+    },
+  },
+] as const

--- a/ui/src/lib/sandbox/warm-pool.server.ts
+++ b/ui/src/lib/sandbox/warm-pool.server.ts
@@ -1,0 +1,140 @@
+/**
+ * WarmPool — pool of pre-booted VMs per rootfs flavor.
+ *
+ * Acquisition is O(ms) on a hit (return a parked VM); cold-boot via the
+ * backend otherwise. Release calls `backend.reset(vm)` and parks the VM if
+ * the pool has capacity; otherwise (cap reached or reset failed) destroys
+ * it. See docs/sandbox-plan.md → "Warm pool".
+ *
+ * Pool is keyed by rootfs flavor only — v0 sandboxes use settings-driven
+ * defaults, so all parked VMs share a runtime fingerprint. If a future
+ * caller passes non-default runtime to `acquire`, they'll get either a
+ * parked VM with the pool's original runtime (pool hit) or a cold-boot
+ * with their runtime (pool miss). Segmenting by runtime fingerprint can
+ * land if/when per-call overrides become common.
+ *
+ * This is a library, not a service: the harness creates one instance and
+ * shares it; tests instantiate per-test. No background timers — the host
+ * is expected to call `evictIdle` on a cadence (the `withSandbox` wiring
+ * sets this up in build-order step 5 wiring, alongside `SandboxScheduler`).
+ */
+
+import { assertServerOnImport } from '../harness-patterns/assert.server'
+import type { ComputeBackend, RootfsId, RuntimeConfig, VMHandle } from './types'
+
+assertServerOnImport()
+
+export interface WarmPoolConfig {
+  /**
+   * Per-rootfs max parked count. Flavors not listed default to 0 (no pooling
+   * for that flavor — release always destroys). Defaults come from
+   * HarnessSettings (`sandbox.warmPool.*`) once wired.
+   */
+  caps: Partial<Record<RootfsId, number>>
+  /** Idle threshold for `evictIdle`. */
+  idleEvictMs: number
+}
+
+interface ParkedVm {
+  vm: VMHandle
+  parkedAt: number
+}
+
+export class WarmPool {
+  private readonly pool = new Map<RootfsId, ParkedVm[]>()
+
+  constructor(
+    private readonly backend: ComputeBackend,
+    private readonly config: WarmPoolConfig,
+  ) {}
+
+  /** Hit the pool if a VM of the right flavor is parked; cold-boot otherwise. */
+  async acquire(rootfs: RootfsId, runtime: RuntimeConfig): Promise<VMHandle> {
+    const parked = this.pool.get(rootfs)
+    if (parked && parked.length > 0) {
+      return parked.shift()!.vm
+    }
+    return this.backend.boot(rootfs, runtime)
+  }
+
+  /**
+   * Recycle and park, or destroy if pool is full or recycle fails. The
+   * caller is responsible for closing any McpTransport for this VM first
+   * (its stdio pipes target the soon-to-be-destroyed container — see
+   * `DockerBackend.reset`).
+   */
+  async release(vm: VMHandle): Promise<void> {
+    try {
+      await this.backend.reset(vm)
+    } catch {
+      await this.backend.destroy(vm).catch(() => {})
+      return
+    }
+    const cap = this.config.caps[vm.rootfs] ?? 0
+    const parked = this.pool.get(vm.rootfs) ?? []
+    if (parked.length >= cap) {
+      await this.backend.destroy(vm).catch(() => {})
+      return
+    }
+    parked.push({ vm, parkedAt: Date.now() })
+    this.pool.set(vm.rootfs, parked)
+  }
+
+  /** Destroy any parked VM idle past `idleEvictMs`. Idempotent; safe to call often. */
+  async evictIdle(now: number = Date.now()): Promise<void> {
+    const evictions: Promise<void>[] = []
+    for (const [rootfs, parked] of this.pool) {
+      const fresh: ParkedVm[] = []
+      for (const p of parked) {
+        if (now - p.parkedAt >= this.config.idleEvictMs) {
+          evictions.push(this.backend.destroy(p.vm).catch(() => {}))
+        } else {
+          fresh.push(p)
+        }
+      }
+      this.pool.set(rootfs, fresh)
+    }
+    await Promise.all(evictions)
+  }
+
+  /**
+   * Boot `count` VMs into the pool ahead of demand (capped by `caps[rootfs]`).
+   * Used to seed the baseline pool depth at process start. Boots happen
+   * concurrently; one failure does not abort the others.
+   */
+  async prewarm(rootfs: RootfsId, count: number, runtime: RuntimeConfig): Promise<void> {
+    const cap = this.config.caps[rootfs] ?? 0
+    const current = this.pool.get(rootfs)?.length ?? 0
+    const target = Math.min(count, cap - current)
+    if (target <= 0) return
+    const results = await Promise.allSettled(
+      Array.from({ length: target }, () => this.backend.boot(rootfs, runtime)),
+    )
+    const now = Date.now()
+    const parked = this.pool.get(rootfs) ?? []
+    for (const r of results) {
+      if (r.status === 'fulfilled') {
+        parked.push({ vm: r.value, parkedAt: now })
+      }
+    }
+    this.pool.set(rootfs, parked)
+  }
+
+  /** Destroy every parked VM. Called on harness shutdown. */
+  async shutdown(): Promise<void> {
+    const all: VMHandle[] = []
+    for (const parked of this.pool.values()) {
+      for (const p of parked) all.push(p.vm)
+    }
+    this.pool.clear()
+    await Promise.all(all.map((vm) => this.backend.destroy(vm).catch(() => {})))
+  }
+
+  /** Current parked count, optionally narrowed to one flavor. */
+  size(rootfs?: RootfsId): number {
+    if (rootfs) return this.pool.get(rootfs)?.length ?? 0
+    let total = 0
+    for (const p of this.pool.values()) total += p.length
+    return total
+  }
+}

--- a/ui/src/lib/sandbox/with-sandbox.server.ts
+++ b/ui/src/lib/sandbox/with-sandbox.server.ts
@@ -1,0 +1,91 @@
+/**
+ * `withSandbox` — outer wrapper that attaches a sandbox VM to a controller
+ * pattern for its lifetime. See docs/sandbox-plan.md → "What withSandbox is".
+ *
+ * Build-order step 3 scope (this file): auto-attachment only. Every invocation
+ * boots a fresh VM, runs the wrapped pattern inside the ALS sandbox scope,
+ * then closes the transport and destroys the VM on exit. ID-addressable reuse
+ * (`id: 'foo'`) and force-fresh (`fresh: true`) land in step 6; warm pool +
+ * idle eviction + scheduler caps in step 5.
+ */
+import { assertServerOnImport } from '../harness-patterns/assert.server'
+import { DockerBackend } from './docker-backend.server'
+import { runWithSandbox } from './scope.server'
+import type { ComputeBackend, RootfsId, RuntimeConfig } from './types'
+import type {
+  ConfiguredPattern,
+  PatternScope,
+  EventView,
+} from '../harness-patterns/types'
+
+assertServerOnImport()
+
+export interface WithSandboxConfig {
+  /** Reserved for step 6 (ID-addressable attachment); currently ignored. */
+  id?: string
+  /** Reserved for step 6 (force fresh); currently ignored — every invocation
+   *  is fresh anyway in the no-pool world. */
+  fresh?: boolean
+  /** Rootfs flavor. v0: `'base'` only. */
+  rootfs?: RootfsId
+  /** Per-VM runtime knobs. Defaults come from HarnessSettings (added later). */
+  resources?: Pick<RuntimeConfig, 'cpus' | 'memoryMB' | 'timeoutSec'>
+  /** Egress profile. v0 honors `'mcp-only'` (no network) vs anything else. */
+  egress?: RuntimeConfig['egress']
+  /** Backend override. Defaults to a process-shared `DockerBackend`. Tests
+   *  inject a mock here to exercise the wrapper without spinning containers. */
+  backend?: ComputeBackend
+}
+
+let defaultBackend: ComputeBackend | null = null
+function getDefaultBackend(): ComputeBackend {
+  if (!defaultBackend) defaultBackend = new DockerBackend()
+  return defaultBackend
+}
+
+/**
+ * Wrap a pattern so its lifetime owns a sandbox VM. Composes orthogonally with
+ * everything in the harness — `chain(withSandbox(actorCritic), synth)`,
+ * `withSandbox(chain(simpleLoop, …, actorCritic))`, `router → routes`, etc.
+ * The sandbox handle propagates to nested tool-calling controllers via ALS;
+ * `chain` / `router` / `withReferences` don't need to be sandbox-aware.
+ */
+export function withSandbox(config?: WithSandboxConfig) {
+  return <T>(pattern: ConfiguredPattern<T>): ConfiguredPattern<T> => {
+    const backend = config?.backend ?? getDefaultBackend()
+    const rootfs: RootfsId = config?.rootfs ?? 'base'
+    const runtime: RuntimeConfig = {
+      ...(config?.resources ?? {}),
+      ...(config?.egress ? { egress: config.egress } : {}),
+    }
+
+    const fn = async (
+      scope: PatternScope<T>,
+      view: EventView,
+    ): Promise<PatternScope<T>> => {
+      const vm = await backend.boot(rootfs, runtime)
+      let transport
+      try {
+        transport = await backend.connectMcp(vm)
+      } catch (err) {
+        // boot succeeded but transport setup failed — clean up the VM so we
+        // don't leak. Swallow destroy errors; the original error is what the
+        // caller cares about.
+        await backend.destroy(vm).catch(() => {})
+        throw err
+      }
+      try {
+        return await runWithSandbox(transport, () => pattern.fn(scope, view))
+      } finally {
+        await transport.close().catch(() => {})
+        await backend.destroy(vm).catch(() => {})
+      }
+    }
+
+    return {
+      ...pattern,
+      name: `withSandbox(${pattern.name})`,
+      fn,
+    }
+  }
+}

--- a/ui/src/lib/sandbox/with-sandbox.server.ts
+++ b/ui/src/lib/sandbox/with-sandbox.server.ts
@@ -2,15 +2,26 @@
  * `withSandbox` — outer wrapper that attaches a sandbox VM to a controller
  * pattern for its lifetime. See docs/sandbox-plan.md → "What withSandbox is".
  *
- * Build-order step 3 scope (this file): auto-attachment only. Every invocation
- * boots a fresh VM, runs the wrapped pattern inside the ALS sandbox scope,
- * then closes the transport and destroys the VM on exit. ID-addressable reuse
- * (`id: 'foo'`) and force-fresh (`fresh: true`) land in step 6; warm pool +
- * idle eviction + scheduler caps in step 5.
+ * Acquisition path (build-order step 5):
+ *   1. `scheduler.allocate(sessionId)` — blocks if either cap is reached.
+ *   2. `pool.acquire(rootfs, runtime)`  — pool-hit (O(ms)) or cold-boot.
+ *   3. `backend.connectMcp(vm)`         — open the in-VM MCP transport.
+ *
+ * Release path (reverse order, runs even on inner throws / partial failure):
+ *   1. `transport.close()`              — tear down stdio pipes.
+ *   2. `pool.release(vm)`               — reset & park, or destroy on cap/fail.
+ *   3. `slot.release()`                 — free the scheduler slot.
+ *
+ * ID-addressable reuse (`id: 'foo'`) and force-fresh (`fresh: true`) remain
+ * deferred to build-order step 6.
  */
 import { assertServerOnImport } from '../harness-patterns/assert.server'
+import { DEFAULT_SETTINGS } from '../settings'
+import { getRequestSettings } from '../settings-context.server'
 import { DockerBackend } from './docker-backend.server'
 import { runWithSandbox } from './scope.server'
+import { SandboxScheduler } from './scheduler.server'
+import { WarmPool } from './warm-pool.server'
 import type { ComputeBackend, RootfsId, RuntimeConfig } from './types'
 import type {
   ConfiguredPattern,
@@ -23,29 +34,58 @@ assertServerOnImport()
 export interface WithSandboxConfig {
   /** Reserved for step 6 (ID-addressable attachment); currently ignored. */
   id?: string
-  /** Reserved for step 6 (force fresh); currently ignored — every invocation
-   *  is fresh anyway in the no-pool world. */
+  /** Reserved for step 6 (force fresh); currently ignored. */
   fresh?: boolean
   /** Rootfs flavor. v0: `'base'` only. */
   rootfs?: RootfsId
-  /** Per-VM runtime knobs. Defaults come from HarnessSettings (added later). */
+  /** Per-VM runtime knobs. Defaults come from `settings.sandbox.*`. */
   resources?: Pick<RuntimeConfig, 'cpus' | 'memoryMB' | 'timeoutSec'>
-  /** Egress profile. v0 honors `'mcp-only'` (no network) vs anything else. */
+  /** Egress profile. Defaults to `settings.sandbox.defaultEgress`. */
   egress?: RuntimeConfig['egress']
-  /** Backend override. Defaults to a process-shared `DockerBackend`. Tests
-   *  inject a mock here to exercise the wrapper without spinning containers. */
+  /** Session id for `SandboxScheduler` per-session-cap accounting. */
+  sessionId?: string
+  /** Backend override. Defaults to a process-shared `DockerBackend`. */
   backend?: ComputeBackend
+  /** Pool override. Defaults to a process-shared `WarmPool` from settings. */
+  pool?: WarmPool
+  /** Scheduler override. Defaults to a process-shared `SandboxScheduler`. */
+  scheduler?: SandboxScheduler
 }
 
+// Process-shared singletons, lazily constructed from DEFAULT_SETTINGS. Cap
+// values are read once at first use; the settings panel can't reshape an
+// already-built scheduler/pool at runtime (those caps are process-scoped, not
+// per-request — see docs/sandbox-plan.md → "Settings").
 let defaultBackend: ComputeBackend | null = null
+let defaultPool: WarmPool | null = null
+let defaultScheduler: SandboxScheduler | null = null
+
 function getDefaultBackend(): ComputeBackend {
   if (!defaultBackend) defaultBackend = new DockerBackend()
   return defaultBackend
 }
+function getDefaultPool(): WarmPool {
+  if (!defaultPool) {
+    defaultPool = new WarmPool(getDefaultBackend(), {
+      caps: DEFAULT_SETTINGS.sandbox.warmPool,
+      idleEvictMs: DEFAULT_SETTINGS.sandbox.idleEvictMs,
+    })
+  }
+  return defaultPool
+}
+function getDefaultScheduler(): SandboxScheduler {
+  if (!defaultScheduler) {
+    defaultScheduler = new SandboxScheduler({
+      globalCap: DEFAULT_SETTINGS.sandbox.globalCap,
+      perSessionCap: DEFAULT_SETTINGS.sandbox.perSessionCap,
+    })
+  }
+  return defaultScheduler
+}
 
 /**
- * Wrap a pattern so its lifetime owns a sandbox VM. Composes orthogonally with
- * everything in the harness — `chain(withSandbox(actorCritic), synth)`,
+ * Wrap a pattern so its lifetime owns a sandbox VM. Composes orthogonally
+ * with everything in the harness — `chain(withSandbox(actorCritic), synth)`,
  * `withSandbox(chain(simpleLoop, …, actorCritic))`, `router → routes`, etc.
  * The sandbox handle propagates to nested tool-calling controllers via ALS;
  * `chain` / `router` / `withReferences` don't need to be sandbox-aware.
@@ -53,32 +93,64 @@ function getDefaultBackend(): ComputeBackend {
 export function withSandbox(config?: WithSandboxConfig) {
   return <T>(pattern: ConfiguredPattern<T>): ConfiguredPattern<T> => {
     const backend = config?.backend ?? getDefaultBackend()
+    // When the caller injects a custom backend (test scenario), build per-call
+    // pool + scheduler so test state doesn't bleed through the singletons.
+    // Tests can still inject `pool` / `scheduler` explicitly to share state
+    // across multiple withSandbox invocations (smoke-script pool-hit case).
+    const usingDefaultBackend = !config?.backend
+    const pool =
+      config?.pool ??
+      (usingDefaultBackend
+        ? getDefaultPool()
+        : new WarmPool(backend, {
+            caps: DEFAULT_SETTINGS.sandbox.warmPool,
+            idleEvictMs: DEFAULT_SETTINGS.sandbox.idleEvictMs,
+          }))
+    const scheduler =
+      config?.scheduler ??
+      (usingDefaultBackend
+        ? getDefaultScheduler()
+        : new SandboxScheduler({
+            globalCap: DEFAULT_SETTINGS.sandbox.globalCap,
+            perSessionCap: DEFAULT_SETTINGS.sandbox.perSessionCap,
+          }))
+
     const rootfs: RootfsId = config?.rootfs ?? 'base'
-    const runtime: RuntimeConfig = {
-      ...(config?.resources ?? {}),
-      ...(config?.egress ? { egress: config.egress } : {}),
-    }
+    const sessionId = config?.sessionId ?? 'default'
 
     const fn = async (
       scope: PatternScope<T>,
       view: EventView,
     ): Promise<PatternScope<T>> => {
-      const vm = await backend.boot(rootfs, runtime)
-      let transport
-      try {
-        transport = await backend.connectMcp(vm)
-      } catch (err) {
-        // boot succeeded but transport setup failed — clean up the VM so we
-        // don't leak. Swallow destroy errors; the original error is what the
-        // caller cares about.
-        await backend.destroy(vm).catch(() => {})
-        throw err
+      const settings = getRequestSettings()
+      const runtime: RuntimeConfig = {
+        cpus: config?.resources?.cpus,
+        memoryMB: config?.resources?.memoryMB ?? settings.sandbox.defaultMemoryMB,
+        timeoutSec: config?.resources?.timeoutSec ?? settings.sandbox.defaultTimeoutSec,
+        egress: config?.egress ?? settings.sandbox.defaultEgress,
       }
+
+      const slot = await scheduler.allocate(sessionId)
       try {
-        return await runWithSandbox(transport, () => pattern.fn(scope, view))
+        const vm = await pool.acquire(rootfs, runtime)
+        let transport
+        try {
+          transport = await backend.connectMcp(vm)
+        } catch (err) {
+          // Acquire succeeded but transport setup failed — recycle the VM
+          // (pool.release destroys if reset fails, parks if it succeeds and
+          // there's cap). Original error wins.
+          await pool.release(vm).catch(() => {})
+          throw err
+        }
+        try {
+          return await runWithSandbox(transport, () => pattern.fn(scope, view))
+        } finally {
+          await transport.close().catch(() => {})
+          await pool.release(vm).catch(() => {})
+        }
       } finally {
-        await transport.close().catch(() => {})
-        await backend.destroy(vm).catch(() => {})
+        slot.release()
       }
     }
 

--- a/ui/src/lib/sandbox/with-sandbox.server.ts
+++ b/ui/src/lib/sandbox/with-sandbox.server.ts
@@ -2,22 +2,24 @@
  * `withSandbox` — outer wrapper that attaches a sandbox VM to a controller
  * pattern for its lifetime. See docs/sandbox-plan.md → "What withSandbox is".
  *
- * Acquisition path (build-order step 5):
- *   1. `scheduler.allocate(sessionId)` — blocks if either cap is reached.
- *   2. `pool.acquire(rootfs, runtime)`  — pool-hit (O(ms)) or cold-boot.
- *   3. `backend.connectMcp(vm)`         — open the in-VM MCP transport.
+ * Four acquire paths, picked by `id` and `fresh`:
  *
- * Release path (reverse order, runs even on inner throws / partial failure):
- *   1. `transport.close()`              — tear down stdio pipes.
- *   2. `pool.release(vm)`               — reset & park, or destroy on cap/fail.
- *   3. `slot.release()`                 — free the scheduler slot.
+ *   {}                      anonymous pool. acquire/release through `WarmPool`.
+ *   { id }                  id-addressable. `AttachmentTable.acquire(id)`
+ *                           reuses or boots; release decrements refCount and
+ *                           parks under the id. Sweeper destroys on idle.
+ *   { id, fresh: true }     destroy any existing entry for `id`, then acquire
+ *                           anew. Stores under id like the plain `id` case.
+ *   { fresh: true }         direct `backend.boot/destroy`, bypassing both pool
+ *                           and attachment table. One-shot private VM.
  *
- * ID-addressable reuse (`id: 'foo'`) and force-fresh (`fresh: true`) remain
- * deferred to build-order step 6.
+ * All four go through the scheduler first (`scheduler.allocate(sessionId)`)
+ * and release the slot in the outer finally regardless of branch.
  */
 import { assertServerOnImport } from '../harness-patterns/assert.server'
 import { DEFAULT_SETTINGS } from '../settings'
 import { getRequestSettings } from '../settings-context.server'
+import { AttachmentTable } from './attachment-table.server'
 import { DockerBackend } from './docker-backend.server'
 import { runWithSandbox } from './scope.server'
 import { SandboxScheduler } from './scheduler.server'
@@ -32,9 +34,17 @@ import type {
 assertServerOnImport()
 
 export interface WithSandboxConfig {
-  /** Reserved for step 6 (ID-addressable attachment); currently ignored. */
+  /**
+   * Id-addressable attachment. Two calls with the same id share one VM /
+   * transport; the attachment stays parked under the id between calls.
+   * Without `fresh`, an existing entry is reused.
+   */
   id?: string
-  /** Reserved for step 6 (force fresh); currently ignored. */
+  /**
+   * Force a fresh VM. With `id`: destroy any existing entry first, then
+   * acquire a new one for the id. Without `id`: bypass both the pool and the
+   * attachment table — one-shot `backend.boot/destroy` for a private VM.
+   */
   fresh?: boolean
   /** Rootfs flavor. v0: `'base'` only. */
   rootfs?: RootfsId
@@ -50,15 +60,18 @@ export interface WithSandboxConfig {
   pool?: WarmPool
   /** Scheduler override. Defaults to a process-shared `SandboxScheduler`. */
   scheduler?: SandboxScheduler
+  /** Attachment table override. Defaults to a process-shared instance. */
+  attachments?: AttachmentTable
 }
 
 // Process-shared singletons, lazily constructed from DEFAULT_SETTINGS. Cap
 // values are read once at first use; the settings panel can't reshape an
-// already-built scheduler/pool at runtime (those caps are process-scoped, not
-// per-request — see docs/sandbox-plan.md → "Settings").
+// already-built scheduler/pool/table at runtime (those caps are process-
+// scoped, not per-request — see docs/sandbox-plan.md → "Settings").
 let defaultBackend: ComputeBackend | null = null
 let defaultPool: WarmPool | null = null
 let defaultScheduler: SandboxScheduler | null = null
+let defaultAttachments: AttachmentTable | null = null
 
 function getDefaultBackend(): ComputeBackend {
   if (!defaultBackend) defaultBackend = new DockerBackend()
@@ -82,6 +95,14 @@ function getDefaultScheduler(): SandboxScheduler {
   }
   return defaultScheduler
 }
+function getDefaultAttachments(): AttachmentTable {
+  if (!defaultAttachments) {
+    defaultAttachments = new AttachmentTable(getDefaultBackend(), getDefaultPool(), {
+      idleMs: DEFAULT_SETTINGS.sandbox.idleEvictMs,
+    })
+  }
+  return defaultAttachments
+}
 
 /**
  * Wrap a pattern so its lifetime owns a sandbox VM. Composes orthogonally
@@ -94,9 +115,9 @@ export function withSandbox(config?: WithSandboxConfig) {
   return <T>(pattern: ConfiguredPattern<T>): ConfiguredPattern<T> => {
     const backend = config?.backend ?? getDefaultBackend()
     // When the caller injects a custom backend (test scenario), build per-call
-    // pool + scheduler so test state doesn't bleed through the singletons.
-    // Tests can still inject `pool` / `scheduler` explicitly to share state
-    // across multiple withSandbox invocations (smoke-script pool-hit case).
+    // pool/scheduler/attachments so test state doesn't bleed through the
+    // singletons. Tests can still inject any of them explicitly to share
+    // state across multiple withSandbox invocations.
     const usingDefaultBackend = !config?.backend
     const pool =
       config?.pool ??
@@ -114,9 +135,18 @@ export function withSandbox(config?: WithSandboxConfig) {
             globalCap: DEFAULT_SETTINGS.sandbox.globalCap,
             perSessionCap: DEFAULT_SETTINGS.sandbox.perSessionCap,
           }))
+    const attachments =
+      config?.attachments ??
+      (usingDefaultBackend
+        ? getDefaultAttachments()
+        : new AttachmentTable(backend, pool, {
+            idleMs: DEFAULT_SETTINGS.sandbox.idleEvictMs,
+          }))
 
     const rootfs: RootfsId = config?.rootfs ?? 'base'
     const sessionId = config?.sessionId ?? 'default'
+    const id = config?.id
+    const fresh = config?.fresh === true
 
     const fn = async (
       scope: PatternScope<T>,
@@ -132,23 +162,22 @@ export function withSandbox(config?: WithSandboxConfig) {
 
       const slot = await scheduler.allocate(sessionId)
       try {
-        const vm = await pool.acquire(rootfs, runtime)
-        let transport
-        try {
-          transport = await backend.connectMcp(vm)
-        } catch (err) {
-          // Acquire succeeded but transport setup failed — recycle the VM
-          // (pool.release destroys if reset fails, parks if it succeeds and
-          // there's cap). Original error wins.
-          await pool.release(vm).catch(() => {})
-          throw err
+        if (id) {
+          return await runWithIdAttachment(
+            attachments,
+            id,
+            fresh,
+            rootfs,
+            runtime,
+            scope,
+            view,
+            pattern,
+          )
         }
-        try {
-          return await runWithSandbox(transport, () => pattern.fn(scope, view))
-        } finally {
-          await transport.close().catch(() => {})
-          await pool.release(vm).catch(() => {})
+        if (fresh) {
+          return await runWithFreshVm(backend, rootfs, runtime, scope, view, pattern)
         }
+        return await runWithPool(backend, pool, rootfs, runtime, scope, view, pattern)
       } finally {
         slot.release()
       }
@@ -159,5 +188,79 @@ export function withSandbox(config?: WithSandboxConfig) {
       name: `withSandbox(${pattern.name})`,
       fn,
     }
+  }
+}
+
+// ============================================================================
+// Branch implementations — extracted so the main `fn` reads top-to-bottom.
+// ============================================================================
+
+async function runWithPool<T>(
+  backend: ComputeBackend,
+  pool: WarmPool,
+  rootfs: RootfsId,
+  runtime: RuntimeConfig,
+  scope: PatternScope<T>,
+  view: EventView,
+  pattern: ConfiguredPattern<T>,
+): Promise<PatternScope<T>> {
+  const vm = await pool.acquire(rootfs, runtime)
+  let transport
+  try {
+    transport = await backend.connectMcp(vm)
+  } catch (err) {
+    await pool.release(vm).catch(() => {})
+    throw err
+  }
+  try {
+    return await runWithSandbox(transport, () => pattern.fn(scope, view))
+  } finally {
+    await transport.close().catch(() => {})
+    await pool.release(vm).catch(() => {})
+  }
+}
+
+async function runWithFreshVm<T>(
+  backend: ComputeBackend,
+  rootfs: RootfsId,
+  runtime: RuntimeConfig,
+  scope: PatternScope<T>,
+  view: EventView,
+  pattern: ConfiguredPattern<T>,
+): Promise<PatternScope<T>> {
+  const vm = await backend.boot(rootfs, runtime)
+  let transport
+  try {
+    transport = await backend.connectMcp(vm)
+  } catch (err) {
+    await backend.destroy(vm).catch(() => {})
+    throw err
+  }
+  try {
+    return await runWithSandbox(transport, () => pattern.fn(scope, view))
+  } finally {
+    await transport.close().catch(() => {})
+    await backend.destroy(vm).catch(() => {})
+  }
+}
+
+async function runWithIdAttachment<T>(
+  attachments: AttachmentTable,
+  id: string,
+  fresh: boolean,
+  rootfs: RootfsId,
+  runtime: RuntimeConfig,
+  scope: PatternScope<T>,
+  view: EventView,
+  pattern: ConfiguredPattern<T>,
+): Promise<PatternScope<T>> {
+  if (fresh) {
+    await attachments.destroyById(id).catch(() => {})
+  }
+  const att = await attachments.acquire(id, rootfs, runtime)
+  try {
+    return await runWithSandbox(att.transport, () => pattern.fn(scope, view))
+  } finally {
+    attachments.release(att)
   }
 }

--- a/ui/src/lib/sandbox/with-sandbox.server.ts
+++ b/ui/src/lib/sandbox/with-sandbox.server.ts
@@ -95,7 +95,7 @@ function getDefaultScheduler(): SandboxScheduler {
   }
   return defaultScheduler
 }
-function getDefaultAttachments(): AttachmentTable {
+export function getDefaultAttachments(): AttachmentTable {
   if (!defaultAttachments) {
     defaultAttachments = new AttachmentTable(getDefaultBackend(), getDefaultPool(), {
       idleMs: DEFAULT_SETTINGS.sandbox.idleEvictMs,

--- a/ui/src/lib/settings.ts
+++ b/ui/src/lib/settings.ts
@@ -4,6 +4,33 @@
  * Safe to import from both client and server — contains only types and plain constants.
  */
 
+/**
+ * Sandbox compute settings. See docs/sandbox-plan.md → "Settings".
+ *
+ * Process-scoped values (`globalCap`, `perSessionCap`, `warmPool`, `idleEvictMs`)
+ * are read once when the harness lazily constructs its singleton scheduler
+ * and pool; per-call defaults (`defaultTimeoutSec`, `defaultMemoryMB`,
+ * `defaultEgress`) are read each time `withSandbox` boots a VM whose caller
+ * didn't override them. The settings panel UI does not currently surface
+ * these — they're programmatic for v0.
+ */
+export interface SandboxSettings {
+  /** Max concurrent sandbox attachments across the harness. */
+  globalCap: number
+  /** Max concurrent sandbox attachments per session. */
+  perSessionCap: number
+  /** Per-rootfs warm-pool depth. e.g. `{ base: 1 }`. */
+  warmPool: Partial<Record<string, number>>
+  /** Idle time before a pooled VM is destroyed (ms). */
+  idleEvictMs: number
+  /** Per-tool-call wall-clock cap when caller does not override. */
+  defaultTimeoutSec: number
+  /** Per-VM memory cap (MB) when caller does not override. */
+  defaultMemoryMB: number
+  /** Default egress profile when caller does not override. */
+  defaultEgress: 'mcp-only' | 'pypi' | 'github-trusted' | 'open'
+}
+
 export interface HarnessSettings {
   maxToolTurns: number        // simpleLoop max iterations (default: 5)
   maxRetries: number          // actorCritic max attempts (default: 3)
@@ -11,6 +38,7 @@ export interface HarnessSettings {
   maxResultForSummary: number // summarizer input limit chars (default: 3000)
   priorTurnCount: number      // prior turns for tool result memory (default: 3)
   routerTurnWindow: number    // router history window in turns (default: 5)
+  sandbox: SandboxSettings    // compute sandbox caps + defaults
 }
 
 export const DEFAULT_SETTINGS: HarnessSettings = {
@@ -20,6 +48,15 @@ export const DEFAULT_SETTINGS: HarnessSettings = {
   maxResultForSummary: 3000,
   priorTurnCount: 3,
   routerTurnWindow: 5,
+  sandbox: {
+    globalCap: 16,
+    perSessionCap: 4,
+    warmPool: { base: 1 },
+    idleEvictMs: 300_000,
+    defaultTimeoutSec: 60,
+    defaultMemoryMB: 512,
+    defaultEgress: 'mcp-only',
+  },
 }
 
 /** Context window limits per BAML client (tokens) */

--- a/ui/src/routes/api/sandbox/pty/input.ts
+++ b/ui/src/routes/api/sandbox/pty/input.ts
@@ -1,0 +1,36 @@
+/**
+ * Keystroke / data input for a session's interactive sandbox terminal (#79).
+ *
+ * POST /api/sandbox/pty/input  { sessionId, data }
+ *
+ * `data` is written verbatim to the PTY's stdin (raw bytes from xterm's
+ * onData — includes control sequences). No-op if no PTY exists for the
+ * session (the next stream connect will start one).
+ */
+import type { APIEvent } from '@solidjs/start/server'
+import { ptyManager } from '../../../../lib/sandbox/pty-manager.server'
+import { getAuthenticatedUser } from '../../../../lib/auth/server'
+import { isBypassEnabled } from '../../../../lib/auth/dev-bypass'
+
+async function requireAuth(): Promise<void> {
+  if (isBypassEnabled()) return
+  await getAuthenticatedUser()
+}
+
+export async function POST(event: APIEvent) {
+  try {
+    await requireAuth()
+  } catch (err) {
+    return new Response(err instanceof Error ? err.message : 'Unauthorized', { status: 401 })
+  }
+
+  const body = (await event.request.json().catch(() => null)) as
+    | { sessionId?: string; data?: string }
+    | null
+  if (!body || !body.sessionId || typeof body.data !== 'string') {
+    return new Response('sessionId and data (string) are required', { status: 400 })
+  }
+
+  ptyManager.write(body.sessionId, body.data)
+  return new Response(null, { status: 204 })
+}

--- a/ui/src/routes/api/sandbox/pty/resize.ts
+++ b/ui/src/routes/api/sandbox/pty/resize.ts
@@ -1,0 +1,35 @@
+/**
+ * Resize a session's interactive sandbox terminal (#79).
+ *
+ * POST /api/sandbox/pty/resize  { sessionId, cols, rows }
+ *
+ * Forwarded to the PTY so the in-container shell wraps lines to the browser
+ * terminal's dimensions. No-op if no PTY exists for the session.
+ */
+import type { APIEvent } from '@solidjs/start/server'
+import { ptyManager } from '../../../../lib/sandbox/pty-manager.server'
+import { getAuthenticatedUser } from '../../../../lib/auth/server'
+import { isBypassEnabled } from '../../../../lib/auth/dev-bypass'
+
+async function requireAuth(): Promise<void> {
+  if (isBypassEnabled()) return
+  await getAuthenticatedUser()
+}
+
+export async function POST(event: APIEvent) {
+  try {
+    await requireAuth()
+  } catch (err) {
+    return new Response(err instanceof Error ? err.message : 'Unauthorized', { status: 401 })
+  }
+
+  const body = (await event.request.json().catch(() => null)) as
+    | { sessionId?: string; cols?: number; rows?: number }
+    | null
+  if (!body || !body.sessionId || typeof body.cols !== 'number' || typeof body.rows !== 'number') {
+    return new Response('sessionId, cols, rows are required', { status: 400 })
+  }
+
+  ptyManager.resize(body.sessionId, body.cols, body.rows)
+  return new Response(null, { status: 204 })
+}

--- a/ui/src/routes/api/sandbox/pty/stream.ts
+++ b/ui/src/routes/api/sandbox/pty/stream.ts
@@ -1,0 +1,78 @@
+/**
+ * SSE stream of a session's interactive sandbox terminal (#79).
+ *
+ * GET /api/sandbox/pty/stream?sessionId=<id>
+ *
+ * Ensures a PTY exists for the session (boots the VM + spawns the shell on
+ * first connect), replays the current scrollback, then streams live PTY
+ * output. Each frame is `data: <json-string>` — the raw PTY bytes are
+ * JSON-encoded so control chars / newlines survive the SSE line protocol;
+ * the client `JSON.parse`s and writes straight into xterm.
+ *
+ * Keystrokes go the other way via POST /api/sandbox/pty/input.
+ */
+import type { APIEvent } from '@solidjs/start/server'
+import { ptyManager } from '../../../../lib/sandbox/pty-manager.server'
+import { getAuthenticatedUser } from '../../../../lib/auth/server'
+import { isBypassEnabled } from '../../../../lib/auth/dev-bypass'
+
+async function requireAuth(): Promise<void> {
+  if (isBypassEnabled()) return
+  await getAuthenticatedUser() // throws if unauthenticated
+}
+
+export async function GET(event: APIEvent) {
+  const url = new URL(event.request.url)
+  const sessionId = url.searchParams.get('sessionId')
+  if (!sessionId) {
+    return new Response('sessionId is required', { status: 400 })
+  }
+
+  try {
+    await requireAuth()
+  } catch (err) {
+    return new Response(err instanceof Error ? err.message : 'Unauthorized', { status: 401 })
+  }
+
+  try {
+    await ptyManager.ensure(sessionId)
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    return new Response(`failed to start sandbox terminal: ${msg}`, { status: 500 })
+  }
+
+  const encoder = new TextEncoder()
+  const stream = new ReadableStream({
+    start(controller) {
+      const send = (chunk: string) => {
+        try {
+          controller.enqueue(encoder.encode(`data: ${JSON.stringify(chunk)}\n\n`))
+        } catch {
+          /* controller closed mid-write */
+        }
+      }
+
+      // Redraw the current screen for a freshly-connected (or re-mounted) tab.
+      const scrollback = ptyManager.getScrollback(sessionId)
+      if (scrollback) send(scrollback)
+
+      const unsubscribe = ptyManager.subscribe(sessionId, send)
+      event.request.signal.addEventListener('abort', () => {
+        unsubscribe()
+        try {
+          controller.close()
+        } catch {
+          /* already closed */
+        }
+      })
+    },
+  })
+
+  return new Response(stream, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+    },
+  })
+}


### PR DESCRIPTION
## Summary

Implements the **compute sandbox** (issue #79) — `withSandbox(...)` attaches an isolated VM (Docker substrate in v0) to any controller pattern, exposing in-VM filesystem + shell MCP tools (`sandbox_*`) to the agent with no per-pattern wiring. Ships **all v0 phases (1–7)** plus an interactive xterm terminal and two registered agents (ephemeral + persistent). Verified end-to-end in the running app.

## What's in here

**Substrate & rootfs**
- `rootfs/` — two-stage `kg-sandbox:base` image: lifted `rust-mcp-filesystem` binary + a self-authored stdio shell-exec MCP + python3. `init.sh` idle-host entrypoint with a `serve <name>` launch path.
- `ComputeBackend` interface + `DockerBackend` (`boot` / `destroy` / `connectMcp` / `health` / `reset`). MCP-in-VM: each in-VM server runs on stdio over `docker exec -i`, presented as a unified six-tool `sandbox_*` surface.

**The load-bearing dispatch refactor (one-time, ALS-based)**
- A request-scoped `AsyncLocalStorage` sandbox scope (`scope.server.ts`).
- `mcp-client.callTool`, `simpleLoop`, `actorCritic`, and `baml-adapters` each consult the active scope so sandbox-owned tool names (1) route to the in-VM transport, (2) pass the allowlist guard, and (3) appear in the actor's prompt — with no per-pattern changes. This is what lets `withSandbox(chain(simpleLoop, …, actorCritic))` share one VM across children for free.

**Lifecycle & capacity (phase 5)**
- `WarmPool` — pre-booted VMs per rootfs flavor; acquire is O(ms) on a hit. `DockerBackend.reset` = destroy + boot fresh under a stable id.
- `SandboxScheduler` — `globalCap`=16, `perSessionCap`=4 with FIFO-with-skip queueing.
- `HarnessSettings.sandbox` — caps + per-VM defaults (plan values).

**ID-addressable attachment (phase 6)**
- `AttachmentTable` — ref-counted, id-keyed live attachments. `withSandbox({ id })` reuses one VM across calls; `{ id, fresh }` recycles it; `{ fresh }` bypasses the pool for a one-shot private VM. Lazy idle sweep cascades into the warm pool.

**In-app integration (phase 7)**
- **Read-only Activity feed** in a new `SupportPanel` Terminal tab — derives entirely from the existing live event stream (filters `sandbox_*` tool calls, pairs by `callId`). No new event type, no SSE/transport/in-VM changes.
- **Interactive xterm Shell** (`InteractiveTerminal.tsx`) backed by a `PtyManager` driving `docker exec -it <container> bash` via `node-pty`. Transport is SSE-down / POST-up; PTY survives tab-unmount with 64KB scrollback replay; 5-min idle close.
- Two registered agents: **🧪 Sandbox Demo** (ephemeral, fresh VM per turn) and **🖥️ Sandbox · Session** (persistent, shares VM with the Shell terminal — write a file in chat, `cat` it in the Shell).

**Verification**
- 720 hermetic tests passing (Docker CLI + MCP SDK mocked at the lowest seam). `tsc --noEmit` shows zero new errors (baseline 26 unchanged).
- Two live-container smoke scripts under `ui/src/lib/sandbox/scripts/` — one LLM-free (proves a warm-pool hit across two runs), one driven by real Anthropic via the BAML adapters.
- **End-to-end verified in the running app:** Sandbox · Session agent wrote `/work/handoff.txt` = `created-by-agent-turn-1`; the Shell terminal `cat`'d the exact file from the same container (`6a22461ffcef`). Agent + user terminal share one workspace.
- `docs/sandbox-plan.md` — the full design spec (process topology, attachment model, MCP-in-VM architecture, ALS dispatch, backend interface, build order).

## Follow-ups landed (closing out the PR)

Two issues from the Sandbox · Session diagnosis ship here:

- **#83 Part A — `compactIntent`**: a new chain primitive that rewrites the latest user message into a self-contained `intent` before a router-less actor runs. Sandbox · Session has no router, so a follow-up like *"I can't find the file"* previously reached the actor with zero context for which file (the loop exhausted on blind `find`s). `compactIntent` resolves back-references against the recent message history and writes `scope.data.intent` — the carrier `actorCritic` already reads — so there is **no controller-prompt change**. It skips the LLM call on turn 1 (nothing to resolve) and is backward-safe: on failure it leaves `intent` unset and the actor falls back to the raw message. Backed by a new `CompactIntent` BAML function on the cheap `DescribeAnthropic` client and a new `intent_compacted` observability event (mirrors `reference_attached`). Adopted as the **first pattern** in Sandbox · Session.
- **#85 — actor few-shots**: two `FewShot` examples (a multi-line `sandbox_write`, a quoted `sandbox_bash`) wired through the existing `ActorAdapterOptions.fewShots` channel, anchoring valid `tool_args` JSON so the actor stops burning retries on JS-object-literal args (unquoted keys / raw newlines). Also dropped the stale *"call Return"* actor guidance (consistent with `19ec2bc`) since the critic owns termination.

**New tests (+8, suite now 720):** 6 `compactIntent` pattern tests (turn-1 skip, back-reference rewrite, blank-output fallback, error-path safety, no-op without a user message) + 2 Sandbox · Session structural tests asserting the `compactIntent → withSandbox(actorCritic) → synthesizer` chain shape. `tsc --noEmit` clean (no new errors).

**Remaining deferred (tracked, not in this PR):** #83 **Part E** (the `compact*` naming unification — pure rename, smaller-blast-radius follow-up), #82 (timer-driven attachment sweep + LRU), #84 (extend `withApproval` for free-text clarification).

## Carry-overs (tracked, not in this PR)

- **#82** — timer-driven attachment sweep + LRU cap on parked attachments. The current sweep is lazy (fires only on `acquire`), so dormant attachments persist until next activity; fine for solo dev, worth tightening for multi-user prod.
- **#78** — `FirecrackerBackend`, deferred until the Docker abstraction proves out in production.
- **`PtyManager`** has no unit coverage yet — verified manually end-to-end, but worth backfilling for regression safety.

## Test plan
- [x] `pnpm test:run` — 720 passing
- [x] `pnpm exec tsc --noEmit` — zero new errors
- [x] LLM-free smoke (`smoke-scripted.ts`) against a live container — pool hit confirmed, word count = 9
- [x] Real-LLM smoke (`smoke-llm.ts`) against a live container
- [x] Sandbox Demo agent live in-app (ephemeral, agent runs python in VM, Terminal Activity shows command + result)
- [x] Sandbox · Session agent live in-app (persistent)
- [x] Interactive Shell live in-app (xterm, `python3 -c "print(7*7)"` → 49, tab-switch + reconnect with scrollback)
- [x] **Shared workspace**: agent-written file readable from the Shell terminal in the same session

🤖 Generated with [Claude Code](https://claude.com/claude-code)
