### PR TITLE
fix(infra): redis-stack image + drop bogus redis MCP password secret

### DIFF
--- a/configs/custom-catalog.yaml
+++ b/configs/custom-catalog.yaml
@@ -180,10 +180,6 @@ registry:
       - name: scan_all_keys
       - name: search_redis_documents
       - name: client_list
-    secrets:
-      - name: redis.password
-        env: REDIS_PWD
-        example: ""
     env:
       - name: REDIS_HOST
         value: "{{redis.host}}"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -79,7 +79,10 @@ services:
       retries: 10
 
   redis:
-    image: redis:7-alpine
+    # redis-stack bundles RedisJSON + RediSearch, required by the Data Stash
+    # pipeline (json_set/json_get for documents, vector index/search for chunks).
+    # Plain redis:7-alpine has no modules. RedisInsight (8001) is left unmapped.
+    image: redis/redis-stack:7.4.0-v8
     container_name: redis-seederis
     restart: unless-stopped
     ports:


### PR DESCRIPTION
## Summary

Fixes the shared MCP-gateway Redis so the **DataStash pipeline** can store and search documents against the live gateway. Two infra-only changes (no app code):

- **`docker-compose.yaml`** — `redis:7-alpine` → `redis/redis-stack:7.4.0-v8`. DataStash uses RedisJSON (`json_set`/`json_get` for documents) and RediSearch (vector index/search for chunks); plain alpine ships neither module. RedisInsight (8001) left unmapped.
- **`configs/custom-catalog.yaml`** — remove the `redis.password` / `REDIS_PWD` secret block from the redis MCP server. The gateway Redis runs **without auth**, so requiring a password made *every* redis MCP op fail with an `AUTH` error. Dropping it aligns the MCP client with the password-less instance.

## Why

The gateway Redis was failing every operation on an AUTH mismatch, which blocked live DataStash store/search end-to-end. This is the infra half of that fix; it touches only tracked config (the gitignored `configs/mcp-config.yaml` secrets file is untouched).

## After merge

Gateway needs a restart to pick up the new image + catalog:
```
docker compose up -d redis && docker compose restart mcp-gateway
```

## Notes

- Originated from the data-pipeline lane (#6); the edits were made in the main checkout because compose runs there, so they're PR'd as a focused standalone infra fix rather than folded into the data-pipeline app-code branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
