### PR TITLE
feat(data-stash): document upload → chunk → embed → search pipeline (closes #6, #9, #8)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,8 +14,13 @@ pnpm test:run         # Run all tests once (vitest)
 pnpm test             # Watch mode
 pnpm baml-generate    # Regenerate baml_client/ from baml_src/
 pnpm baml-test        # Run BAML tests
-pnpm dev:llama        # Start local GLM-4.7-Flash inference server (port 8080)
+pnpm dev:llama        # Start local GLM-4.7-Flash *chat* model (port 8080)
 pnpm exec tsc --noEmit --project tsconfig.json  # Type-check (from ui/)
+```
+
+Local **embedding** server for the Data Stash pipeline (separate from `dev:llama`'s chat model — different model, port 8090):
+```bash
+llama-server --embedding -m models/Qwen3-Embedding-0.6B-Q8_0.gguf --port 8090 --ctx-size 8192
 ```
 
 Run a single test file:
@@ -151,6 +156,11 @@ Tool namespaces in `tools.server.ts`: `neo4j`, `web`, `context7`, `filesystem`, 
 
 `KNOWN_TOOL_SERVERS` maps tool names to namespaces when auto-detection would fail.
 
+**Redis MCP quirks** (encapsulated by `document-store.server.ts` / `document-ingest.server.ts`; full detail in [`docs/DATA_STASH.md`](docs/DATA_STASH.md)):
+- The `redis` service must be **redis-stack** (RedisJSON + RediSearch); plain `redis` has no modules. On Apple-Silicon/colima, run it `platform: linux/amd64` (a git-ignored `docker-compose.override.yml`) — the arm64 `redisearch.so` SIGILLs on vector ops.
+- Param names: `json_get`/`json_set` use `name`/`path`; `expire`/`hset`/`sadd` take `expire_seconds`; `delete` uses `key` (not `name`); `set_vector_in_hash`/`vector_search_hash` use `name`/`index_name` + a float `vector`/`query_vector`.
+- The gateway runs each redis server over **serial stdio** (so bulk writes are sequential), returns multi-value results (e.g. `smembers`) as **one text block per element** (`callTool` aggregates these into an array), and **auto-parses JSON-looking string args into objects** (so chunk metadata is base64-encoded before `hset`).
+
 ---
 
 ## Styling
@@ -178,5 +188,6 @@ Custom tokens: `dark-bg-{primary,secondary,tertiary}`, `dark-text-{primary,secon
 | [`docs/INDEX.md`](docs/INDEX.md) | Full documentation index |
 | [GitHub Project — "Harness Playground tasks"](https://github.com/users/mknw/projects/5) | Planning board / roadmap — replaced `docs/ROADMAP.md`; planning lives in GitHub Projects now |
 | [`docs/UI_ARCHITECTURE.md`](docs/UI_ARCHITECTURE.md) | Component structure, data flow, Chat-Graph linking |
+| [`docs/DATA_STASH.md`](docs/DATA_STASH.md) | Data Stash pipeline: upload → chunk → embed → search (#6/#9/#8), API routes, Redis storage, redis-stack + local-embedder requirements |
 | [`ui/README.md`](ui/README.md) | UI quick start and file index |
 | [`ui/src/lib/harness-patterns/README.md`](ui/src/lib/harness-patterns/README.md) | Harness patterns full API |

--- a/docs/DATA_STASH.md
+++ b/docs/DATA_STASH.md
@@ -1,0 +1,76 @@
+# Data Stash — Document Ingestion Pipeline
+
+The Data Stash lets users upload documents that the agent can reference and
+search. This doc covers the **store → chunk → embed → search** pipeline
+(issues #6, #9, #8). For the tool-result side of the stash (hide/archive of
+agent-produced results) see [UI_ARCHITECTURE.md](UI_ARCHITECTURE.md).
+
+```
+upload ─▶ store (RedisJSON) ─▶ chunk ─▶ embed (local/OpenRouter) ─▶ HNSW index
+                                                                         │
+query ─────────────────────── embed query (same model) ────▶ KNN search ┘
+```
+
+## Modules (`ui/src/lib/`)
+
+| Module | Role |
+|--------|------|
+| `document-store.server.ts` (#6) | RedisJSON storage: CRUD, TTL, per-session index, hide/archive flags, `toPriorResult` adapter |
+| `chunking.server.ts` (#9) | Pure text chunking — `fixed` / `sentence` / `paragraph` + MIME-aware `chunkDocument` |
+| `embeddings.server.ts` (#8) | Provider-pluggable embedding with a one-model-per-corpus guard |
+| `document-ingest.server.ts` | Orchestrator: chunk → embed → Redis HNSW index, and `searchDocuments` (KNN) |
+| `stash/upload-service.server.ts`, `stash/http.server.ts` | Upload request parsing (multipart + JSON), auth/response helpers |
+
+## API routes (`ui/src/routes/api/stash/`)
+
+| Method · Path | Purpose |
+|---|---|
+| `POST /api/stash/upload` | Store a document (multipart `file`, or JSON `{sessionId, filename, content}`) |
+| `GET /api/stash/upload?sessionId=` | List a session's documents (metadata) |
+| `GET /api/stash/document/:id?sessionId=` | Fetch a document (content + metadata) |
+| `DELETE /api/stash/document/:id?sessionId=` | Remove a document + its index entry |
+| `PATCH /api/stash/document/:id` | Toggle `hidden` / `archived` (`{sessionId, hidden?, archived?}`) |
+| `POST /api/stash/ingest` | Chunk → embed → index a stored doc (`{sessionId, docId, chunk?, embedding?}`) |
+| `GET /api/stash/search?sessionId=&q=&k=` | KNN similarity search over a session's chunks |
+
+Auth follows the existing posture (dev-bypass aware; see `lib/auth/dev-bypass.ts`). Ingest is **explicit**, not auto-run on upload — it needs an embedding backend and binds the corpus to one model.
+
+## Storage model (Redis)
+
+- **Document**: RedisJSON blob at `stash:doc:{sessionId}:{docId}`, TTL default 7 days. `content` is opaque UTF-8 text (binary extraction is the upstream caller's job — not done yet).
+- **Session index**: a Redis SET `stash:docs:{sessionId}` of doc ids (self-healing — stale entries pruned on list).
+- **Chunk**: a Redis HASH `stashvec:{sessionId}:{spaceTag}:{docId}:{chunkIndex}` with `vector` (float blob) + `meta` (base64 of a JSON `{content, doc_id, source, chunk_index, offsets, model, provider, dim}`). 2 writes/chunk.
+- **Vector index**: a RediSearch HNSW index per `(session, embedding-space)`; `dim` matches the embedding model.
+- **Embedding space**: recorded at `stash:space:{sessionId}` as `{provider, model, dimensions}`.
+
+`MAX_CONTENT_BYTES` = 5 MiB. Accepts any text-decodable file; the picker hints Text/Markdown/JSON/CSV (no hard allow-list — binaries decode as garbage today).
+
+## Chunking (#9)
+
+Default `{ maxChars: 1000, overlap: 200, strategy: 'paragraph' }`. `chunkDocument(content, mimeType)` routes by type: **CSV/TSV** → row-grouping with the header repeated; **JSON** → pretty-print then chunk; everything else → `chunkText`. Strategies: `paragraph` (blank lines), `sentence` (`.!?`), `fixed` (sliding window). Overlap is carried between chunks; an oversized single unit falls back to a fixed window. Offsets satisfy `content === text.slice(start, end)` (CSV excepted).
+
+## Embeddings (#8) — one model per corpus
+
+Vectors are only comparable within one model, so there is **no silent cross-provider fallback**. The provider is a deliberate choice:
+
+- **`local`** (dev default) — `llama-server --embedding` on `:8090` (Qwen3-Embedding-0.6B, 1024-dim), OpenAI-compatible `/v1/embeddings`.
+- **`openrouter`** — selectable; requires `OPENROUTER_API_KEY`.
+
+`embed()` returns vectors tagged with `{provider, model, dimensions}`; `assertSameSpace()` enforces comparability. The space is baked into the index name and key prefix, and re-ingesting a session under a different model **throws** (override with `allowSpaceChange`). Env: `EMBEDDINGS_PROVIDER`, `EMBEDDINGS_LOCAL_URL`, `EMBEDDINGS_LOCAL_MODEL`.
+
+Start the local embedder (separate from `pnpm dev:llama`, which serves a *chat* model on `:8080`):
+
+```bash
+llama-server --embedding -m models/Qwen3-Embedding-0.6B-Q8_0.gguf --port 8090 --ctx-size 8192
+```
+
+## Requirements & gotchas
+
+- **redis-stack** (not plain `redis`): the pipeline needs **RedisJSON** (`json_*`) and **RediSearch** (`create_vector_index_hash` / `vector_search_hash`). The compose `redis` service uses `redis/redis-stack` (merged in #91).
+- **Apple-Silicon / colima:** redis-stack's arm64 `redisearch.so` SIGILL-crashes on the colima VM during vector ops. Run the redis service as `platform: linux/amd64` (emulated) — see the git-ignored `docker-compose.override.yml`. Long-term: colima CPU passthrough (`--vm-type vz`). Store/RedisJSON is unaffected; only vector search needs this.
+- **Gateway argument/result quirks** (see [CLAUDE.md → Redis MCP Tool Parameters](../CLAUDE.md)): the MCP gateway runs the redis server over serial stdio (so ingest is sequential and minimal-call), returns multi-value results as one text block per element (handled by `callTool` aggregation), and auto-parses JSON-looking string args into objects (so chunk `meta` is base64-encoded).
+
+## Relationships
+
+- **#89** (sandbox `/work` ⇄ DataStash artifact sync) builds on the store/retrieve path (`getDocument` / `toPriorResult`); it does not require vector search.
+- Distinct from **#17** (RDF/OWL → Neo4j): this is documents → Redis + vectors.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -37,6 +37,12 @@ Authoritative source-level docs (closer to the code):
 
 Source-level index: see [ui/README.md](../ui/README.md#documentation-index).
 
+### Data Stash
+
+| Document | Description |
+|----------|-------------|
+| [DATA_STASH.md](DATA_STASH.md) | Document upload → chunk → embed → search pipeline (#6/#9/#8): modules, API routes, Redis storage model, embedding-space rule, redis-stack + local-embedder requirements |
+
 ---
 
 ## Infrastructure Documentation
@@ -70,7 +76,9 @@ Scripts: `scripts/export-neo4j.sh` · `scripts/import-neo4j.sh` · `scripts/rese
 | Variable | Purpose |
 |----------|---------|
 | `GROQ_API_KEY` | Groq LLM inference (GroqFast, GroqGPT120B, GroqQwen3_32b) |
-| `OPENROUTER_API_KEY` | OpenRouter models (Nemotron, Gemma4, MiniMax) |
+| `OPENROUTER_API_KEY` | OpenRouter models (Nemotron, Gemma4, MiniMax) + the `openrouter` embedding provider |
+| `EMBEDDINGS_PROVIDER` | Data Stash embedding provider: `local` (default) or `openrouter` (see [DATA_STASH.md](DATA_STASH.md)) |
+| `EMBEDDINGS_LOCAL_URL` / `EMBEDDINGS_LOCAL_MODEL` | Override the local embedder URL (`http://localhost:8090/v1`) / model (`Qwen3-Embedding-0.6B`) |
 | `OPENAI_API_KEY` | OpenAI models (GPT-5, GPT-5 Mini, GPT-5 Nano) |
 | `ANTHROPIC_API_KEY` | Anthropic models (Opus 4, Sonnet 4, Haiku) |
 | `VITE_STACK_PROJECT_ID` | Stack Auth project |

--- a/docs/UI_ARCHITECTURE.md
+++ b/docs/UI_ARCHITECTURE.md
@@ -371,7 +371,7 @@ Tabbed right panel. **Context manager is the default tab.** Uses `lazyMount` + `
 | Memory | Graph visualization for Memory MCP entities |
 | All (Turn Explorer) | Turn-based graph explorer — select specific turns, color-coded |
 | **Context manager** *(default)* | Event timeline + LLM call detail |
-| Data | Data Stash — tool result icons, hide/archive controls |
+| Data | Data Stash — document upload (drag-drop/picker) + tool-result icons, with hide/archive/delete. See [DATA_STASH.md](DATA_STASH.md) for the upload→chunk→embed→search pipeline. |
 | Tools | MCP tool configuration via `ToolsPanel` |
 
 **Conversation Sync toggle:** The Neo4j and Memory graph tabs have a ⏸/▶ "Sync" button (cyan when live, amber when paused). Implemented in `GraphTabContent` via a `syncEnabled` signal. When paused, the current element list is snapshotted into `frozenElements` and passed to `GraphVisualization` instead of live `props.elements`. Resuming restores the live feed.

--- a/ui/README.md
+++ b/ui/README.md
@@ -38,6 +38,11 @@ src/
 │   ├── db/
 │   │   ├── client.server.ts         # Lazy pg.Pool singleton + idempotent schema bootstrap
 │   │   └── conversations.server.ts  # Conversations repo (load/save/list/delete + deriveTitle)
+│   ├── document-store.server.ts # Data Stash: RedisJSON document storage (#6)
+│   ├── chunking.server.ts       # Data Stash: fixed/sentence/paragraph chunking (#9)
+│   ├── embeddings.server.ts     # Data Stash: provider-pluggable embeddings (#8)
+│   ├── document-ingest.server.ts # Data Stash: chunk→embed→HNSW index + KNN search
+│   ├── stash/                   # Data Stash upload HTTP helpers (parse + auth). See docs/DATA_STASH.md
 │   ├── settings.ts            # HarnessSettings type, defaults, MODEL_CONTEXT_WINDOWS
 │   ├── settings-store.ts      # Client-side reactive store (localStorage persistence)
 │   ├── settings-context.server.ts # Request-scoped settings via AsyncLocalStorage
@@ -112,4 +117,5 @@ See [examples/README.md](src/lib/harness-client/examples/README.md) for detailed
 | [src/lib/harness-patterns/README.md](src/lib/harness-patterns/README.md) | Harness patterns full API reference |
 | [src/lib/harness-client/examples/README.md](src/lib/harness-client/examples/README.md) | Example agent implementations (10 agents) |
 | [../docs/UI_ARCHITECTURE.md](../docs/UI_ARCHITECTURE.md) | Component structure, data flow, Chat-Graph linking |
+| [../docs/DATA_STASH.md](../docs/DATA_STASH.md) | Data Stash upload → chunk → embed → search pipeline (#6/#9/#8) |
 | [../docs/INDEX.md](../docs/INDEX.md) | Full project documentation index |

--- a/ui/src/__tests__/lib/chunking.test.ts
+++ b/ui/src/__tests__/lib/chunking.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Chunking Tests (Issue #9)
+ *
+ * Pure-function coverage for the fixed / sentence / paragraph strategies, the
+ * type-aware `chunkDocument` dispatcher, and the offset invariant
+ * (`content === text.slice(startOffset, endOffset)` for non-CSV strategies).
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+
+// chunking self-asserts server-only on import; stub it out under jsdom.
+vi.mock('../../lib/harness-patterns/assert.server', () => ({
+  assertServerOnImport: vi.fn(),
+  assertServer: vi.fn(),
+}))
+
+import {
+  chunkText,
+  chunkFixed,
+  chunkBySentence,
+  chunkByParagraph,
+  chunkDocument,
+  chunkCsv,
+  DEFAULT_CHUNK_CONFIG,
+  type Chunk,
+} from '../../lib/chunking.server'
+
+// ----------------------------------------------------------------------------
+// Helpers
+// ----------------------------------------------------------------------------
+
+/** Offsets must faithfully slice the source for non-CSV strategies. */
+function assertOffsetInvariant(text: string, chunks: Chunk[]) {
+  for (const c of chunks) {
+    expect(text.slice(c.startOffset, c.endOffset)).toBe(c.content)
+  }
+}
+
+/** Indices are a contiguous 0..n-1 run. */
+function assertContiguousIndices(chunks: Chunk[]) {
+  chunks.forEach((c, i) => expect(c.index).toBe(i))
+}
+
+// ----------------------------------------------------------------------------
+
+describe('chunking (Issue #9)', () => {
+  describe('chunkFixed', () => {
+    it('produces sliding windows stepping by maxChars - overlap', () => {
+      const text = 'abcdefghij' // 10 chars
+      const chunks = chunkFixed(text, { maxChars: 4, overlap: 1 })
+      // step = 3 → windows at 0,3,6 ([6,10) hits the end and stops); fully covers 10 chars
+      expect(chunks.map((c) => c.content)).toEqual(['abcd', 'defg', 'ghij'])
+      assertOffsetInvariant(text, chunks)
+      assertContiguousIndices(chunks)
+    })
+
+    it('returns a single chunk when text fits in one window', () => {
+      const chunks = chunkFixed('short', { maxChars: 100, overlap: 10 })
+      expect(chunks).toHaveLength(1)
+      expect(chunks[0].content).toBe('short')
+    })
+
+    it('returns [] for empty text', () => {
+      expect(chunkFixed('', { maxChars: 10, overlap: 2 })).toEqual([])
+    })
+
+    it('does not stall when overlap >= maxChars (clamped)', () => {
+      const chunks = chunkFixed('abcdefgh', { maxChars: 3, overlap: 99 })
+      // overlap clamped to maxChars-1 = 2 → step 1
+      expect(chunks.length).toBeGreaterThan(0)
+      expect(chunks.length).toBeLessThan(20)
+      assertOffsetInvariant('abcdefgh', chunks)
+    })
+  })
+
+  describe('chunkByParagraph', () => {
+    it('merges short paragraphs up to maxChars and splits on blank lines', () => {
+      const text = 'Para one.\n\nPara two.\n\nA much longer third paragraph that stands alone here.'
+      const chunks = chunkByParagraph(text, { maxChars: 25, overlap: 0 })
+      expect(chunks.length).toBeGreaterThan(1)
+      assertOffsetInvariant(text, chunks)
+      assertContiguousIndices(chunks)
+      // Content is trimmed of surrounding whitespace.
+      chunks.forEach((c) => expect(c.content).toBe(c.content.trim()))
+    })
+
+    it('falls back to a fixed window for a single oversized paragraph', () => {
+      const huge = 'x'.repeat(50)
+      const chunks = chunkByParagraph(huge, { maxChars: 10, overlap: 0 })
+      expect(chunks.length).toBe(5)
+      assertOffsetInvariant(huge, chunks)
+      assertContiguousIndices(chunks)
+    })
+
+    it('returns [] for whitespace-only input', () => {
+      expect(chunkByParagraph('   \n\n  \n', { maxChars: 10 })).toEqual([])
+    })
+  })
+
+  describe('chunkBySentence', () => {
+    it('splits on sentence punctuation and packs to maxChars', () => {
+      const text = 'First sentence. Second one! Third here? Fourth final.'
+      const chunks = chunkBySentence(text, { maxChars: 30, overlap: 0 })
+      expect(chunks.length).toBeGreaterThan(1)
+      assertOffsetInvariant(text, chunks)
+      assertContiguousIndices(chunks)
+    })
+
+    it('keeps a single short sentence as one chunk', () => {
+      const chunks = chunkBySentence('Just one sentence.', { maxChars: 100 })
+      expect(chunks).toHaveLength(1)
+      expect(chunks[0].content).toBe('Just one sentence.')
+    })
+
+    it('realises overlap by carrying trailing sentences forward', () => {
+      const text = 'Aaaa. Bbbb. Cccc. Dddd. Eeee.'
+      const noOverlap = chunkBySentence(text, { maxChars: 12, overlap: 0 })
+      const withOverlap = chunkBySentence(text, { maxChars: 12, overlap: 6 })
+      // Overlap should not reduce the chunk count and should still be valid.
+      expect(withOverlap.length).toBeGreaterThanOrEqual(noOverlap.length)
+      assertOffsetInvariant(text, withOverlap)
+    })
+  })
+
+  describe('chunkText dispatch', () => {
+    it('defaults to the paragraph strategy', () => {
+      expect(DEFAULT_CHUNK_CONFIG.strategy).toBe('paragraph')
+      const text = 'Alpha.\n\nBeta.'
+      expect(chunkText(text)).toEqual(chunkByParagraph(text))
+    })
+
+    it('routes to fixed when asked', () => {
+      const text = 'abcdefghij'
+      expect(chunkText(text, { strategy: 'fixed', maxChars: 4, overlap: 0 })).toEqual(
+        chunkFixed(text, { maxChars: 4, overlap: 0 }),
+      )
+    })
+  })
+
+  describe('chunkCsv', () => {
+    it('prepends the header to each row group and tracks data-row offsets', () => {
+      const csv = 'id,name\n1,alice\n2,bob\n3,carol'
+      const chunks = chunkCsv(csv, { maxChars: 20, overlap: 0 })
+      expect(chunks.length).toBeGreaterThan(1)
+      for (const c of chunks) {
+        expect(c.content.startsWith('id,name')).toBe(true)
+        expect(c.metadata?.csvHeader).toBe(true)
+      }
+    })
+
+    it('emits header-only when there are no data rows', () => {
+      const chunks = chunkCsv('a,b,c', { maxChars: 100 })
+      expect(chunks).toHaveLength(1)
+      expect(chunks[0].content).toBe('a,b,c')
+    })
+
+    it('returns [] for empty input', () => {
+      expect(chunkCsv('', {})).toEqual([])
+    })
+  })
+
+  describe('chunkDocument type routing', () => {
+    it('routes CSV mime to row-based chunking', () => {
+      const csv = 'h1,h2\n1,2\n3,4'
+      const chunks = chunkDocument(csv, 'text/csv', { maxChars: 100 })
+      expect(chunks[0].content.startsWith('h1,h2')).toBe(true)
+    })
+
+    it('pretty-prints JSON before chunking', () => {
+      const json = '{"a":1,"b":[1,2,3]}'
+      const chunks = chunkDocument(json, 'application/json', { maxChars: 1000 })
+      // Pretty-printed JSON spans multiple lines.
+      expect(chunks[0].content).toContain('\n')
+    })
+
+    it('chunks plain text directly', () => {
+      const text = 'Hello world.\n\nSecond paragraph.'
+      const chunks = chunkDocument(text, 'text/plain', { maxChars: 1000 })
+      assertOffsetInvariant(text, chunks)
+    })
+  })
+})

--- a/ui/src/__tests__/lib/document-ingest.test.ts
+++ b/ui/src/__tests__/lib/document-ingest.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Document Ingestion Tests (pipeline capstone: #6 + #9 + #8)
+ *
+ * Verifies chunk → embed → Redis-index wiring and, crucially, the
+ * one-model-per-corpus guard, against fake `callTool` + fake embedders.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+vi.mock('../../lib/harness-patterns/assert.server', () => ({
+  assertServerOnImport: vi.fn(),
+  assertServer: vi.fn(),
+}))
+vi.mock('../../lib/harness-patterns/mcp-client.server', () => ({
+  callTool: vi.fn(async () => ({ success: false, data: null, error: 'no gateway' })),
+}))
+
+import {
+  ingestDocument,
+  searchDocuments,
+  getEmbeddingSpace,
+  indexNameFor,
+  prefixFor,
+} from '../../lib/document-ingest.server'
+import type { StashDocument } from '../../lib/document-store.server'
+import type { CallTool } from '../../lib/document-store.server'
+import type { ToolCallResult } from '../../lib/harness-patterns/types'
+import type { EmbeddingConfig, EmbeddingResult } from '../../lib/embeddings.server'
+
+// ----------------------------------------------------------------------------
+// Fake Redis (json + hashes + vector search) behind a fake callTool
+// ----------------------------------------------------------------------------
+
+function makeFakeRedis() {
+  const json = new Map<string, unknown>()
+  const hashes = new Map<string, Record<string, unknown>>()
+  const indexes = new Map<string, { prefix: string; dim: number }>()
+  const calls: Array<[string, Record<string, unknown>]> = []
+
+  const callTool = (async (name: string, args: Record<string, unknown>): Promise<ToolCallResult> => {
+    calls.push([name, args])
+    switch (name) {
+      case 'json_set':
+        json.set(args.name as string, JSON.parse(args.value as string))
+        return { success: true, data: 'OK' }
+      case 'json_get': {
+        const v = json.get(args.name as string)
+        return { success: true, data: v == null ? null : [v] }
+      }
+      case 'create_vector_index_hash':
+        indexes.set(args.index_name as string, {
+          prefix: args.prefix as string,
+          dim: args.dim as number,
+        })
+        return { success: true, data: 'Index created' }
+      case 'set_vector_in_hash': {
+        const key = args.name as string
+        const h = hashes.get(key) ?? {}
+        h.vector = args.vector
+        hashes.set(key, h)
+        return { success: true, data: true }
+      }
+      case 'hset': {
+        const key = args.name as string
+        const h = hashes.get(key) ?? {}
+        h[args.key as string] = args.value
+        hashes.set(key, h)
+        return { success: true, data: 1 }
+      }
+      case 'vector_search_hash': {
+        // Return every stored chunk hash as a "match" (field dicts, no vector).
+        const rows = Array.from(hashes.values()).map((h) => {
+          const { vector: _v, ...fields } = h
+          return { ...fields, score: 0.1 }
+        })
+        return { success: true, data: rows }
+      }
+      default:
+        return { success: false, data: null, error: `unhandled ${name}` }
+    }
+  }) as CallTool
+  return { json, hashes, indexes, calls, callTool }
+}
+
+function makeDoc(overrides: Partial<StashDocument> = {}): StashDocument {
+  return {
+    id: 'doc1',
+    sessionId: 's1',
+    filename: 'notes.txt',
+    mimeType: 'text/plain',
+    size: 11,
+    uploadedAt: 1,
+    content: 'Alpha sentence.\n\nBeta paragraph here.\n\nGamma final part.',
+    ...overrides,
+  }
+}
+
+/** Fake embedder bound to a given space; vectors echo text length. */
+function makeEmbedder(model: string, dim: number) {
+  const embedFn = async (texts: string[], config?: EmbeddingConfig): Promise<EmbeddingResult> => ({
+    provider: config?.provider ?? 'local',
+    model: config?.model ?? model,
+    dimensions: dim,
+    vectors: texts.map((t, i) => Array.from({ length: dim }, (_, d) => t.length + i + d)),
+  })
+  const embedOneFn = async (text: string, config?: EmbeddingConfig) => {
+    const r = await embedFn([text], config)
+    return { provider: r.provider, model: r.model, dimensions: r.dimensions, vector: r.vectors[0] }
+  }
+  return { embedFn, embedOneFn }
+}
+
+// ----------------------------------------------------------------------------
+
+describe('document-ingest', () => {
+  let fake: ReturnType<typeof makeFakeRedis>
+  beforeEach(() => {
+    fake = makeFakeRedis()
+  })
+
+  describe('ingestDocument', () => {
+    it('chunks, embeds, and stores a vector + fields per chunk', async () => {
+      const { embedFn } = makeEmbedder('fake-model', 3)
+      const result = await ingestDocument(makeDoc(), {
+        chunk: { strategy: 'paragraph', maxChars: 30, overlap: 0 },
+        callTool: fake.callTool,
+        embedFn,
+      })
+
+      expect(result.chunks).toBeGreaterThan(0)
+      expect(result.space).toEqual({ provider: 'local', model: 'fake-model', dimensions: 3 })
+      expect(result.indexName).toBe(indexNameFor('s1', result.space))
+      expect(result.prefix).toBe(prefixFor('s1', result.space))
+
+      // One hash per chunk, each carrying a vector + content + provenance.
+      expect(fake.hashes.size).toBe(result.chunks)
+      for (const h of fake.hashes.values()) {
+        expect(Array.isArray(h.vector)).toBe(true)
+        expect(typeof h.content).toBe('string')
+        expect(h.doc_id).toBe('doc1')
+        expect(h.source).toBe('notes.txt')
+        expect(h.model).toBe('fake-model')
+      }
+    })
+
+    it('creates the index with the embedding dimensionality', async () => {
+      const { embedFn } = makeEmbedder('fake-model', 7)
+      await ingestDocument(makeDoc(), { callTool: fake.callTool, embedFn })
+      const idx = Array.from(fake.indexes.values())[0]
+      expect(idx.dim).toBe(7)
+      expect(idx.prefix.startsWith('stashvec:s1:')).toBe(true)
+    })
+
+    it('records the session embedding space', async () => {
+      const { embedFn } = makeEmbedder('fake-model', 3)
+      await ingestDocument(makeDoc(), { callTool: fake.callTool, embedFn })
+      const space = await getEmbeddingSpace('s1', fake.callTool)
+      expect(space).toEqual({ provider: 'local', model: 'fake-model', dimensions: 3 })
+    })
+
+    it('allows re-ingesting under the SAME space', async () => {
+      const { embedFn } = makeEmbedder('fake-model', 3)
+      await ingestDocument(makeDoc({ id: 'doc1' }), { callTool: fake.callTool, embedFn })
+      await expect(
+        ingestDocument(makeDoc({ id: 'doc2' }), { callTool: fake.callTool, embedFn }),
+      ).resolves.toBeTruthy()
+    })
+
+    it('refuses a DIFFERENT embedding space for the same session (comparability)', async () => {
+      const first = makeEmbedder('model-A', 3)
+      await ingestDocument(makeDoc({ id: 'doc1' }), {
+        callTool: fake.callTool,
+        embedFn: first.embedFn,
+      })
+
+      const second = makeEmbedder('model-B', 5) // different model + dim
+      await expect(
+        ingestDocument(makeDoc({ id: 'doc2' }), {
+          callTool: fake.callTool,
+          embedFn: second.embedFn,
+        }),
+      ).rejects.toThrow(/not\s+comparable|mismatch/i)
+    })
+
+    it('permits a space change when explicitly allowed', async () => {
+      const first = makeEmbedder('model-A', 3)
+      await ingestDocument(makeDoc({ id: 'doc1' }), {
+        callTool: fake.callTool,
+        embedFn: first.embedFn,
+      })
+      const second = makeEmbedder('model-B', 5)
+      await expect(
+        ingestDocument(makeDoc({ id: 'doc2' }), {
+          callTool: fake.callTool,
+          embedFn: second.embedFn,
+          allowSpaceChange: true,
+        }),
+      ).resolves.toBeTruthy()
+    })
+
+    it('tolerates an "already exists" index error', async () => {
+      const existsRedis = makeFakeRedis()
+      const base = existsRedis.callTool
+      const callTool = (async (name: string, args: Record<string, unknown>) => {
+        if (name === 'create_vector_index_hash') {
+          return { success: false, data: null, error: 'Index already exists' }
+        }
+        return base(name, args)
+      }) as CallTool
+      const { embedFn } = makeEmbedder('fake-model', 3)
+      await expect(
+        ingestDocument(makeDoc(), { callTool, embedFn }),
+      ).resolves.toBeTruthy()
+    })
+  })
+
+  describe('searchDocuments', () => {
+    it('returns [] when the session has no ingested corpus', async () => {
+      const { embedOneFn } = makeEmbedder('fake-model', 3)
+      const hits = await searchDocuments('ghost', 'query', {
+        callTool: fake.callTool,
+        embedOneFn,
+      })
+      expect(hits).toEqual([])
+    })
+
+    it('embeds the query with the recorded model and returns parsed hits', async () => {
+      const { embedFn, embedOneFn } = makeEmbedder('fake-model', 3)
+      await ingestDocument(makeDoc(), {
+        chunk: { strategy: 'paragraph', maxChars: 30, overlap: 0 },
+        callTool: fake.callTool,
+        embedFn,
+      })
+
+      const hits = await searchDocuments('s1', 'alpha', {
+        callTool: fake.callTool,
+        embedOneFn,
+        k: 3,
+      })
+      expect(hits.length).toBeGreaterThan(0)
+      expect(hits[0].docId).toBe('doc1')
+      expect(typeof hits[0].content).toBe('string')
+
+      // The search must target the recorded space's index.
+      const searchCall = fake.calls.find((c) => c[0] === 'vector_search_hash')!
+      expect(searchCall[1].index_name).toBe(
+        indexNameFor('s1', { provider: 'local', model: 'fake-model', dimensions: 3 }),
+      )
+      expect(searchCall[1].k).toBe(3)
+    })
+  })
+})

--- a/ui/src/__tests__/lib/document-ingest.test.ts
+++ b/ui/src/__tests__/lib/document-ingest.test.ts
@@ -132,14 +132,19 @@ describe('document-ingest', () => {
       expect(result.indexName).toBe(indexNameFor('s1', result.space))
       expect(result.prefix).toBe(prefixFor('s1', result.space))
 
-      // One hash per chunk, each carrying a vector + content + provenance.
+      // One hash per chunk: vector + a single JSON `meta` field carrying
+      // content AND provenance — 2 writes/chunk (the gateway's redis MCP is
+      // serial stdio, so call count is the cost).
       expect(fake.hashes.size).toBe(result.chunks)
       for (const h of fake.hashes.values()) {
         expect(Array.isArray(h.vector)).toBe(true)
-        expect(typeof h.content).toBe('string')
-        expect(h.doc_id).toBe('doc1')
-        expect(h.source).toBe('notes.txt')
-        expect(h.model).toBe('fake-model')
+        const raw = h.meta as string
+        expect(raw.startsWith('b64:')).toBe(true) // opaque, non-JSON (gateway-safe)
+        const meta = JSON.parse(Buffer.from(raw.slice(4), 'base64').toString('utf8'))
+        expect(typeof meta.content).toBe('string')
+        expect(meta.doc_id).toBe('doc1')
+        expect(meta.source).toBe('notes.txt')
+        expect(meta.model).toBe('fake-model')
       }
     })
 

--- a/ui/src/__tests__/lib/document-store.test.ts
+++ b/ui/src/__tests__/lib/document-store.test.ts
@@ -29,6 +29,7 @@ import {
   setDocumentFlags,
   deleteDocument,
   toPriorResult,
+  redisWriteError,
   DEFAULT_TTL_SECONDS,
   MAX_CONTENT_BYTES,
   type CallTool,
@@ -160,6 +161,41 @@ describe('document-store (Issue #6)', () => {
       await expect(
         storeDocument({ sessionId: 's1', filename: 'a', mimeType: 'text/plain', content: 'x' }, failing),
       ).rejects.toThrow(/boom/)
+    })
+
+    it('throws when the MCP reports success but Redis returned an error payload', async () => {
+      // The Redis MCP can surface AUTH/WRONGTYPE failures as a `success: true`
+      // text payload — a stored doc must not silently "succeed" in that case.
+      const authFail: CallTool = async (name) =>
+        name === 'json_set'
+          ? {
+              success: true,
+              data: 'Error setting JSON value: AUTH <password> called without any password configured',
+            }
+          : { success: true, data: 1 }
+      await expect(
+        storeDocument({ sessionId: 's1', filename: 'a', mimeType: 'text/plain', content: 'x' }, authFail),
+      ).rejects.toThrow(/AUTH|Failed to store/)
+    })
+  })
+
+  describe('redisWriteError', () => {
+    it('passes clean success payloads (OK / count)', () => {
+      expect(redisWriteError({ success: true, data: 'OK' })).toBeNull()
+      expect(redisWriteError({ success: true, data: 1 })).toBeNull()
+    })
+    it('flags transport failures', () => {
+      expect(redisWriteError({ success: false, data: null, error: 'boom' })).toBe('boom')
+    })
+    it('flags Redis errors smuggled in as success-data', () => {
+      expect(redisWriteError({ success: true, data: 'Error doing thing: WRONGTYPE' })).toMatch(/WRONGTYPE/)
+      expect(
+        redisWriteError({ success: true, data: 'AUTH <password> called without any password configured' }),
+      ).toMatch(/AUTH/)
+      expect(redisWriteError({ success: true, data: { result: 'Error: NOAUTH' } })).toMatch(/NOAUTH/)
+    })
+    it('does not false-positive on normal content containing the word later', () => {
+      expect(redisWriteError({ success: true, data: 'stored without issue' })).toBeNull()
     })
   })
 

--- a/ui/src/__tests__/lib/document-store.test.ts
+++ b/ui/src/__tests__/lib/document-store.test.ts
@@ -1,0 +1,321 @@
+/**
+ * Document Store Tests (Issue #6)
+ *
+ * Exercises the Redis-backed document storage layer against an in-memory
+ * fake `callTool` that emulates the subset of Redis MCP tools the store uses
+ * (json_set / json_get / sadd / smembers / srem / delete), including the
+ * RedisJSON `$`-path array wrapping the real gateway returns.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+// The store self-asserts server-only on import; stub it out under jsdom.
+vi.mock('../../lib/harness-patterns/assert.server', () => ({
+  assertServerOnImport: vi.fn(),
+  assertServer: vi.fn(),
+}))
+
+// Stub the MCP client module so importing the store never reaches a real
+// gateway. Tests inject their own fake callTool per-call instead.
+vi.mock('../../lib/harness-patterns/mcp-client.server', () => ({
+  callTool: vi.fn(async () => ({ success: false, data: null, error: 'no gateway' })),
+}))
+
+import {
+  storeDocument,
+  getDocument,
+  getDocumentMeta,
+  listDocuments,
+  setDocumentFlags,
+  deleteDocument,
+  toPriorResult,
+  DEFAULT_TTL_SECONDS,
+  MAX_CONTENT_BYTES,
+  type CallTool,
+} from '../../lib/document-store.server'
+import type { ToolCallResult } from '../../lib/harness-patterns/types'
+
+// ----------------------------------------------------------------------------
+// Fake Redis backing a fake callTool
+// ----------------------------------------------------------------------------
+
+interface FakeRedis {
+  json: Map<string, unknown>
+  sets: Map<string, Set<string>>
+  expires: Map<string, number>
+}
+
+function makeFakeRedis(): { redis: FakeRedis; callTool: CallTool & { calls: Array<[string, Record<string, unknown>]> } } {
+  const redis: FakeRedis = { json: new Map(), sets: new Map(), expires: new Map() }
+  const calls: Array<[string, Record<string, unknown>]> = []
+
+  const fn = (async (name: string, args: Record<string, unknown>): Promise<ToolCallResult> => {
+    calls.push([name, args])
+    switch (name) {
+      case 'json_set': {
+        const key = args.name as string
+        // The store stringifies the doc into `value`.
+        redis.json.set(key, JSON.parse(args.value as string))
+        if (typeof args.expire_seconds === 'number') redis.expires.set(key, args.expire_seconds)
+        return { success: true, data: 'OK' }
+      }
+      case 'json_get': {
+        const key = args.name as string
+        if (!redis.json.has(key)) return { success: true, data: null }
+        // Emulate RedisJSON: `$` path returns the value wrapped in an array.
+        return { success: true, data: [redis.json.get(key)] }
+      }
+      case 'json_del':
+      case 'delete': {
+        const key = (args.key ?? args.name) as string
+        redis.json.delete(key)
+        redis.expires.delete(key)
+        return { success: true, data: 1 }
+      }
+      case 'sadd': {
+        const key = args.name as string
+        if (!redis.sets.has(key)) redis.sets.set(key, new Set())
+        redis.sets.get(key)!.add(args.value as string)
+        if (typeof args.expire_seconds === 'number') redis.expires.set(key, args.expire_seconds)
+        return { success: true, data: 1 }
+      }
+      case 'smembers': {
+        const key = args.name as string
+        return { success: true, data: Array.from(redis.sets.get(key) ?? []) }
+      }
+      case 'srem': {
+        const key = args.name as string
+        redis.sets.get(key)?.delete(args.value as string)
+        return { success: true, data: 1 }
+      }
+      default:
+        return { success: false, data: null, error: `unhandled tool ${name}` }
+    }
+  }) as CallTool & { calls: Array<[string, Record<string, unknown>]> }
+  fn.calls = calls
+  return { redis, callTool: fn }
+}
+
+// ----------------------------------------------------------------------------
+
+describe('document-store (Issue #6)', () => {
+  let fake: ReturnType<typeof makeFakeRedis>
+
+  beforeEach(() => {
+    fake = makeFakeRedis()
+  })
+
+  describe('storeDocument', () => {
+    it('stores content + metadata and returns a complete document', async () => {
+      const before = Date.now()
+      const doc = await storeDocument(
+        { sessionId: 's1', filename: 'notes.txt', mimeType: 'text/plain', content: 'hello world' },
+        fake.callTool,
+      )
+
+      expect(doc.id).toBeTruthy()
+      expect(doc.sessionId).toBe('s1')
+      expect(doc.filename).toBe('notes.txt')
+      expect(doc.mimeType).toBe('text/plain')
+      expect(doc.content).toBe('hello world')
+      expect(doc.size).toBe(Buffer.byteLength('hello world', 'utf8'))
+      expect(doc.uploadedAt).toBeGreaterThanOrEqual(before)
+    })
+
+    it('writes to the namespaced key and registers the session index with a TTL', async () => {
+      const doc = await storeDocument(
+        { sessionId: 's1', filename: 'a.txt', mimeType: 'text/plain', content: 'x', id: 'fixed-id' },
+        fake.callTool,
+      )
+
+      const jsonSet = fake.callTool.calls.find((c) => c[0] === 'json_set')!
+      expect(jsonSet[1].name).toBe('stash:doc:s1:fixed-id')
+      expect(jsonSet[1].expire_seconds).toBe(DEFAULT_TTL_SECONDS)
+
+      const sadd = fake.callTool.calls.find((c) => c[0] === 'sadd')!
+      expect(sadd[1].name).toBe('stash:docs:s1')
+      expect(sadd[1].value).toBe('fixed-id')
+      expect(sadd[1].expire_seconds).toBe(DEFAULT_TTL_SECONDS)
+      expect(doc.id).toBe('fixed-id')
+    })
+
+    it('honours a custom TTL override', async () => {
+      await storeDocument(
+        { sessionId: 's1', filename: 'a.txt', mimeType: 'text/plain', content: 'x', ttlSeconds: 60 },
+        fake.callTool,
+      )
+      const jsonSet = fake.callTool.calls.find((c) => c[0] === 'json_set')!
+      expect(jsonSet[1].expire_seconds).toBe(60)
+    })
+
+    it('rejects content larger than the size limit', async () => {
+      const huge = 'a'.repeat(MAX_CONTENT_BYTES + 1)
+      await expect(
+        storeDocument({ sessionId: 's1', filename: 'big', mimeType: 'text/plain', content: huge }, fake.callTool),
+      ).rejects.toThrow(/too large/i)
+    })
+
+    it('throws when the Redis write fails', async () => {
+      const failing: CallTool = async () => ({ success: false, data: null, error: 'boom' })
+      await expect(
+        storeDocument({ sessionId: 's1', filename: 'a', mimeType: 'text/plain', content: 'x' }, failing),
+      ).rejects.toThrow(/boom/)
+    })
+  })
+
+  describe('getDocument / getDocumentMeta', () => {
+    it('round-trips a stored document, unwrapping the RedisJSON array', async () => {
+      const stored = await storeDocument(
+        { sessionId: 's1', filename: 'a.txt', mimeType: 'text/plain', content: 'payload' },
+        fake.callTool,
+      )
+      const got = await getDocument('s1', stored.id, fake.callTool)
+      expect(got).toEqual(stored)
+    })
+
+    it('returns null for a missing document', async () => {
+      expect(await getDocument('s1', 'nope', fake.callTool)).toBeNull()
+    })
+
+    it('getDocumentMeta omits the content field', async () => {
+      const stored = await storeDocument(
+        { sessionId: 's1', filename: 'a.txt', mimeType: 'text/plain', content: 'secret' },
+        fake.callTool,
+      )
+      const meta = await getDocumentMeta('s1', stored.id, fake.callTool)
+      expect(meta).not.toBeNull()
+      expect((meta as unknown as Record<string, unknown>).content).toBeUndefined()
+      expect(meta!.filename).toBe('a.txt')
+    })
+  })
+
+  describe('listDocuments', () => {
+    it('lists metadata newest-first and never includes content', async () => {
+      const d1 = await storeDocument(
+        { sessionId: 's1', filename: 'first.txt', mimeType: 'text/plain', content: 'one' },
+        fake.callTool,
+      )
+      // Force a later timestamp for the second doc.
+      vi.spyOn(Date, 'now').mockReturnValue(d1.uploadedAt + 1000)
+      const d2 = await storeDocument(
+        { sessionId: 's1', filename: 'second.txt', mimeType: 'text/plain', content: 'two' },
+        fake.callTool,
+      )
+      vi.restoreAllMocks()
+
+      const list = await listDocuments('s1', fake.callTool)
+      expect(list.map((d) => d.id)).toEqual([d2.id, d1.id])
+      expect(list.every((d) => !('content' in d))).toBe(true)
+    })
+
+    it('prunes stale index entries whose keys have expired', async () => {
+      const doc = await storeDocument(
+        { sessionId: 's1', filename: 'a.txt', mimeType: 'text/plain', content: 'x' },
+        fake.callTool,
+      )
+      // Simulate the doc key expiring while the index still references it.
+      fake.redis.json.delete(`stash:doc:s1:${doc.id}`)
+
+      const list = await listDocuments('s1', fake.callTool)
+      expect(list).toEqual([])
+      // The index entry should have been removed.
+      expect(fake.callTool.calls.some((c) => c[0] === 'srem' && c[1].value === doc.id)).toBe(true)
+    })
+
+    it('returns [] for an empty/unknown session', async () => {
+      expect(await listDocuments('ghost', fake.callTool)).toEqual([])
+    })
+  })
+
+  describe('setDocumentFlags', () => {
+    it('hides and archives a document in place', async () => {
+      const doc = await storeDocument(
+        { sessionId: 's1', filename: 'a.txt', mimeType: 'text/plain', content: 'x' },
+        fake.callTool,
+      )
+
+      const hidden = await setDocumentFlags('s1', doc.id, { hidden: true }, fake.callTool)
+      expect(hidden!.hidden).toBe(true)
+
+      const archived = await setDocumentFlags('s1', doc.id, { archived: true, hidden: false }, fake.callTool)
+      expect(archived!.archived).toBe(true)
+      expect(archived!.hidden).toBe(false)
+
+      // Persisted, not just returned.
+      const reread = await getDocument('s1', doc.id, fake.callTool)
+      expect(reread!.archived).toBe(true)
+    })
+
+    it('returns null for a missing document', async () => {
+      expect(await setDocumentFlags('s1', 'nope', { hidden: true }, fake.callTool)).toBeNull()
+    })
+  })
+
+  describe('deleteDocument', () => {
+    it('removes the document and its index entry', async () => {
+      const doc = await storeDocument(
+        { sessionId: 's1', filename: 'a.txt', mimeType: 'text/plain', content: 'x' },
+        fake.callTool,
+      )
+      await deleteDocument('s1', doc.id, fake.callTool)
+
+      expect(await getDocument('s1', doc.id, fake.callTool)).toBeNull()
+      expect(await listDocuments('s1', fake.callTool)).toEqual([])
+
+      const del = fake.callTool.calls.find((c) => c[0] === 'delete')!
+      expect(del[1].key).toBe(`stash:doc:s1:${doc.id}`)
+    })
+
+    it('is idempotent for a non-existent document', async () => {
+      await expect(deleteDocument('s1', 'nope', fake.callTool)).resolves.toBeUndefined()
+    })
+  })
+
+  describe('toPriorResult', () => {
+    it('maps a document to a PriorResult with a content preview', () => {
+      const pr = toPriorResult({
+        id: 'doc-1',
+        sessionId: 's1',
+        filename: 'report.md',
+        mimeType: 'text/markdown',
+        size: 12,
+        uploadedAt: Date.now(),
+        content: 'The quick brown fox',
+      })
+      expect(pr.ref_id).toBe('doc-1')
+      expect(pr.tool).toBe('upload:report.md')
+      expect(pr.summary).toContain('The quick brown fox')
+      expect(pr.expanded_in_turn).toBeNull()
+    })
+
+    it('truncates long content with an ellipsis', () => {
+      const pr = toPriorResult(
+        {
+          id: 'doc-1',
+          sessionId: 's1',
+          filename: 'long.txt',
+          mimeType: 'text/plain',
+          size: 100,
+          uploadedAt: Date.now(),
+          content: 'x'.repeat(500),
+        },
+        50,
+      )
+      expect(pr.summary.endsWith('…')).toBe(true)
+      expect(pr.summary.length).toBeLessThanOrEqual(51)
+    })
+
+    it('falls back to a metadata summary when content is absent', () => {
+      const pr = toPriorResult({
+        id: 'doc-1',
+        sessionId: 's1',
+        filename: 'data.csv',
+        mimeType: 'text/csv',
+        size: 2048,
+        uploadedAt: Date.now(),
+      })
+      expect(pr.summary).toContain('data.csv')
+      expect(pr.summary).toContain('text/csv')
+    })
+  })
+})

--- a/ui/src/__tests__/lib/document-store.test.ts
+++ b/ui/src/__tests__/lib/document-store.test.ts
@@ -261,6 +261,42 @@ describe('document-store (Issue #6)', () => {
     it('returns [] for an empty/unknown session', async () => {
       expect(await listDocuments('ghost', fake.callTool)).toEqual([])
     })
+
+    // The live Redis MCP returns ONE text block per set member, so callTool
+    // yields a *bare string* for a 1-member set (not an array). listDocuments
+    // must still resolve it (regression: lists came back empty against the
+    // real gateway because of a strict Array.isArray check).
+    it('lists a single doc when smembers returns a bare member string', async () => {
+      const stored = await storeDocument(
+        { sessionId: 's1', filename: 'solo.txt', mimeType: 'text/plain', content: 'x' },
+        fake.callTool,
+      )
+      const liveShape: CallTool = async (name, args) =>
+        name === 'smembers'
+          ? { success: true, data: stored.id } // bare string, not array
+          : fake.callTool(name, args)
+
+      const list = await listDocuments('s1', liveShape)
+      expect(list.map((d) => d.id)).toEqual([stored.id])
+    })
+
+    it('lists docs when smembers returns a JSON-string array', async () => {
+      await storeDocument(
+        { sessionId: 's2', filename: 'a', mimeType: 'text/plain', content: 'x', id: 'id-a' },
+        fake.callTool,
+      )
+      await storeDocument(
+        { sessionId: 's2', filename: 'b', mimeType: 'text/plain', content: 'y', id: 'id-b' },
+        fake.callTool,
+      )
+      const liveShape: CallTool = async (name, args) =>
+        name === 'smembers'
+          ? { success: true, data: JSON.stringify(['id-a', 'id-b']) } // JSON-string
+          : fake.callTool(name, args)
+
+      const list = await listDocuments('s2', liveShape)
+      expect(list.map((d) => d.id).sort()).toEqual(['id-a', 'id-b'])
+    })
   })
 
   describe('setDocumentFlags', () => {

--- a/ui/src/__tests__/lib/embeddings.test.ts
+++ b/ui/src/__tests__/lib/embeddings.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Embeddings Tests (Issue #8)
+ *
+ * Exercises the provider-pluggable embedder against an injected fake `fetch`
+ * (no live model server), plus the comparability guard that keeps a corpus on
+ * one model.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+vi.mock('../../lib/harness-patterns/assert.server', () => ({
+  assertServerOnImport: vi.fn(),
+  assertServer: vi.fn(),
+}))
+
+import {
+  embed,
+  embedOne,
+  embeddingSpaceId,
+  assertSameSpace,
+  type EmbeddingSpace,
+} from '../../lib/embeddings.server'
+
+// ----------------------------------------------------------------------------
+// Fake OpenAI-compatible /embeddings endpoint
+// ----------------------------------------------------------------------------
+
+/** Returns a deterministic `dim`-length vector per input, echoing call count. */
+function makeFakeFetch(dim = 3) {
+  const calls: Array<{ url: string; body: any; headers: any }> = []
+  const fetchImpl = (async (url: string | URL, init?: RequestInit) => {
+    const body = JSON.parse(String(init?.body))
+    calls.push({ url: String(url), body, headers: init?.headers })
+    const inputs: string[] = Array.isArray(body.input) ? body.input : [body.input]
+    const data = inputs.map((text, i) => ({
+      index: i,
+      embedding: Array.from({ length: dim }, (_, d) => text.length + d),
+    }))
+    return new Response(JSON.stringify({ data, model: body.model }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }) as unknown as typeof fetch
+  return { fetchImpl, calls }
+}
+
+describe('embeddings (Issue #8)', () => {
+  const ORIGINAL_ENV = { ...process.env }
+  beforeEach(() => {
+    delete process.env.EMBEDDINGS_PROVIDER
+    delete process.env.EMBEDDINGS_LOCAL_URL
+    delete process.env.EMBEDDINGS_LOCAL_MODEL
+    delete process.env.OPENROUTER_API_KEY
+  })
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV }
+    vi.restoreAllMocks()
+  })
+
+  describe('embed', () => {
+    it('returns vectors tagged with provider/model/dimensions (local default)', async () => {
+      const { fetchImpl, calls } = makeFakeFetch(4)
+      const res = await embed(['hello', 'world!'], { fetchImpl })
+      expect(res.provider).toBe('local')
+      expect(res.model).toBe('Qwen3-Embedding-0.6B')
+      expect(res.dimensions).toBe(4)
+      expect(res.vectors).toHaveLength(2)
+      expect(res.vectors[0]).toHaveLength(4)
+      // Hits the local :8090 OpenAI-compatible endpoint.
+      expect(calls[0].url).toBe('http://localhost:8090/v1/embeddings')
+    })
+
+    it('honours EMBEDDINGS_LOCAL_URL / MODEL env overrides', async () => {
+      process.env.EMBEDDINGS_LOCAL_URL = 'http://127.0.0.1:9000/v1/'
+      process.env.EMBEDDINGS_LOCAL_MODEL = 'my-model'
+      const { fetchImpl, calls } = makeFakeFetch()
+      const res = await embed(['x'], { fetchImpl })
+      expect(calls[0].url).toBe('http://127.0.0.1:9000/v1/embeddings')
+      expect(res.model).toBe('my-model')
+    })
+
+    it('batches inputs beyond batchSize, preserving order', async () => {
+      const { fetchImpl, calls } = makeFakeFetch(2)
+      const texts = ['a', 'bb', 'ccc', 'dddd', 'eeeee']
+      const res = await embed(texts, { fetchImpl, batchSize: 2 })
+      expect(calls).toHaveLength(3) // 2 + 2 + 1
+      // First dim component equals the text length (per fake) → order preserved.
+      expect(res.vectors.map((v) => v[0])).toEqual([1, 2, 3, 4, 5])
+    })
+
+    it('throws on inconsistent dimensions across the batch', async () => {
+      const fetchImpl = (async (_url: any, init: any) => {
+        const inputs = JSON.parse(init.body).input
+        const data = inputs.map((t: string, i: number) => ({
+          index: i,
+          embedding: i === 0 ? [1, 2, 3] : [1, 2], // mismatched length
+        }))
+        return new Response(JSON.stringify({ data }), { status: 200 })
+      }) as unknown as typeof fetch
+      await expect(embed(['a', 'b'], { fetchImpl })).rejects.toThrow(/inconsistent/i)
+    })
+
+    it('throws when the model returns a different dim than requested', async () => {
+      const { fetchImpl } = makeFakeFetch(3)
+      await expect(embed(['a'], { fetchImpl, dimensions: 1536 })).rejects.toThrow(/1536/)
+    })
+
+    it('surfaces HTTP errors with status', async () => {
+      const fetchImpl = (async () =>
+        new Response('rate limited', { status: 429 })) as unknown as typeof fetch
+      await expect(embed(['a'], { fetchImpl })).rejects.toThrow(/429/)
+    })
+
+    it('wraps network errors with a local-server hint', async () => {
+      const fetchImpl = (async () => {
+        throw new Error('ECONNREFUSED')
+      }) as unknown as typeof fetch
+      await expect(embed(['a'], { fetchImpl })).rejects.toThrow(/llama-server/)
+    })
+
+    it('returns an empty result for empty input without calling fetch', async () => {
+      const { fetchImpl, calls } = makeFakeFetch()
+      const res = await embed([], { fetchImpl })
+      expect(res.vectors).toEqual([])
+      expect(calls).toHaveLength(0)
+    })
+  })
+
+  describe('openrouter provider', () => {
+    it('requires an API key', async () => {
+      const { fetchImpl } = makeFakeFetch()
+      await expect(embed(['a'], { provider: 'openrouter', fetchImpl })).rejects.toThrow(
+        /OPENROUTER_API_KEY/,
+      )
+    })
+
+    it('sends a bearer token and hits the OpenRouter endpoint', async () => {
+      const { fetchImpl, calls } = makeFakeFetch()
+      await embed(['a'], { provider: 'openrouter', apiKey: 'sk-test', fetchImpl })
+      expect(calls[0].url).toBe('https://openrouter.ai/api/v1/embeddings')
+      expect(calls[0].headers.Authorization).toBe('Bearer sk-test')
+    })
+  })
+
+  describe('embedOne', () => {
+    it('returns a single vector with its space', async () => {
+      const { fetchImpl } = makeFakeFetch(3)
+      const res = await embedOne('hi', { fetchImpl })
+      expect(res.vector).toHaveLength(3)
+      expect(res.provider).toBe('local')
+    })
+  })
+
+  describe('comparability guard', () => {
+    const a: EmbeddingSpace = { provider: 'local', model: 'Qwen3', dimensions: 1024 }
+    const b: EmbeddingSpace = { provider: 'openrouter', model: 'nemotron', dimensions: 768 }
+
+    it('builds a stable space id', () => {
+      expect(embeddingSpaceId(a)).toBe('local:Qwen3:1024')
+    })
+
+    it('passes for identical spaces', () => {
+      expect(() => assertSameSpace(a, { ...a })).not.toThrow()
+    })
+
+    it('throws for a different model/provider/dim', () => {
+      expect(() => assertSameSpace(a, b)).toThrow(/not\s+comparable/i)
+      expect(() => assertSameSpace(a, { ...a, dimensions: 512 })).toThrow(/mismatch/i)
+    })
+  })
+})

--- a/ui/src/__tests__/lib/harness-patterns/mcp-client.test.ts
+++ b/ui/src/__tests__/lib/harness-patterns/mcp-client.test.ts
@@ -241,6 +241,59 @@ describe('mcp-client', () => {
       expect(result.success).toBe(true)
       expect(result.data).toBe('The result has no Error: here')
     })
+
+    // Multi-value Redis tools (smembers, lrange, search-style) return ONE text
+    // block PER element. callTool used to `.find` only the first block and
+    // silently drop the rest (so e.g. a 3-member set listed as 1); it now
+    // aggregates them into an array. Single-block behavior is unchanged.
+    it('aggregates multiple text blocks into an array (e.g. smembers)', async () => {
+      mockCallTool.mockResolvedValue({
+        content: [
+          { type: 'text', text: 'id-a' },
+          { type: 'text', text: 'id-b' },
+          { type: 'text', text: 'id-c' },
+        ]
+      })
+
+      const { callTool } = await import('../../../lib/harness-patterns/mcp-client.server')
+
+      const result = await callTool('smembers', { name: 'some:set' })
+
+      expect(result.success).toBe(true)
+      expect(result.data).toEqual(['id-a', 'id-b', 'id-c'])
+    })
+
+    it('JSON-parses each block when aggregating', async () => {
+      mockCallTool.mockResolvedValue({
+        content: [
+          { type: 'text', text: '{"k":1}' },
+          { type: 'text', text: '{"k":2}' },
+        ]
+      })
+
+      const { callTool } = await import('../../../lib/harness-patterns/mcp-client.server')
+
+      const result = await callTool('search', {})
+
+      expect(result.success).toBe(true)
+      expect(result.data).toEqual([{ k: 1 }, { k: 2 }])
+    })
+
+    it('demotes a multi-block result whose leading block is an error', async () => {
+      mockCallTool.mockResolvedValue({
+        content: [
+          { type: 'text', text: 'Error: something went wrong' },
+          { type: 'text', text: 'trailing detail' },
+        ]
+      })
+
+      const { callTool } = await import('../../../lib/harness-patterns/mcp-client.server')
+
+      const result = await callTool('some_tool', {})
+
+      expect(result.success).toBe(false)
+      expect(result.error).toMatch(/^Error: something went wrong/)
+    })
   })
 
   describe('listTools', () => {

--- a/ui/src/__tests__/lib/stash-upload-service.test.ts
+++ b/ui/src/__tests__/lib/stash-upload-service.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Upload Service Tests (Issue #6 upload path)
+ *
+ * Covers MIME guessing and request parsing (JSON + multipart) for
+ * `POST /api/stash/upload`.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('../../lib/harness-patterns/assert.server', () => ({
+  assertServerOnImport: vi.fn(),
+  assertServer: vi.fn(),
+}))
+
+import {
+  guessMimeType,
+  parseUploadRequest,
+} from '../../lib/stash/upload-service.server'
+
+describe('upload-service (Issue #6)', () => {
+  describe('guessMimeType', () => {
+    it('maps known extensions', () => {
+      expect(guessMimeType('a.md')).toBe('text/markdown')
+      expect(guessMimeType('data.json')).toBe('application/json')
+      expect(guessMimeType('table.csv')).toBe('text/csv')
+    })
+    it('defaults to text/plain for unknown or missing extensions', () => {
+      expect(guessMimeType('README')).toBe('text/plain')
+      expect(guessMimeType('archive.weird')).toBe('text/plain')
+      expect(guessMimeType('trailing.')).toBe('text/plain')
+    })
+  })
+
+  describe('parseUploadRequest — JSON', () => {
+    it('parses a JSON body', async () => {
+      const req = new Request('http://x/api/stash/upload', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          sessionId: 's1',
+          filename: 'doc.md',
+          content: '# hi',
+        }),
+      })
+      const input = await parseUploadRequest(req)
+      expect(input).toMatchObject({
+        sessionId: 's1',
+        filename: 'doc.md',
+        mimeType: 'text/markdown',
+        content: '# hi',
+      })
+    })
+
+    it('infers a default filename + mime when omitted', async () => {
+      const req = new Request('http://x', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sessionId: 's1', content: 'plain' }),
+      })
+      const input = await parseUploadRequest(req)
+      expect(input.filename).toBe('upload.txt')
+      expect(input.mimeType).toBe('text/plain')
+    })
+
+    it('throws when content is missing', async () => {
+      const req = new Request('http://x', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sessionId: 's1' }),
+      })
+      await expect(parseUploadRequest(req)).rejects.toThrow(/content/i)
+    })
+
+    it('throws on non-JSON body when content-type is JSON', async () => {
+      const req = new Request('http://x', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: 'not json',
+      })
+      await expect(parseUploadRequest(req)).rejects.toThrow(/JSON|multipart/i)
+    })
+  })
+
+  describe('parseUploadRequest — multipart', () => {
+    // Build a raw multipart body so part headers (filename / Content-Type) are
+    // parsed faithfully — round-tripping a jsdom File through undici's FormData
+    // serialization drops those, which is a test-realm artifact, not our code.
+    const BOUNDARY = '----testboundary1234'
+    function multipart(
+      parts: Array<
+        | { name: string; value: string }
+        | { name: string; filename: string; type?: string; content: string }
+      >,
+    ): Request {
+      const body =
+        parts
+          .map((p) => {
+            if ('filename' in p) {
+              return (
+                `--${BOUNDARY}\r\n` +
+                `Content-Disposition: form-data; name="${p.name}"; filename="${p.filename}"\r\n` +
+                (p.type ? `Content-Type: ${p.type}\r\n` : '') +
+                `\r\n${p.content}\r\n`
+              )
+            }
+            return (
+              `--${BOUNDARY}\r\n` +
+              `Content-Disposition: form-data; name="${p.name}"\r\n\r\n${p.value}\r\n`
+            )
+          })
+          .join('') + `--${BOUNDARY}--\r\n`
+      return new Request('http://x/api/stash/upload', {
+        method: 'POST',
+        headers: { 'Content-Type': `multipart/form-data; boundary=${BOUNDARY}` },
+        body,
+      })
+    }
+
+    it('parses a file field and uses its name/type', async () => {
+      const req = multipart([
+        { name: 'sessionId', value: 's2' },
+        { name: 'file', filename: 'sheet.csv', type: 'text/csv', content: 'col1,col2\n1,2' },
+      ])
+      const input = await parseUploadRequest(req)
+      expect(input.sessionId).toBe('s2')
+      expect(input.filename).toBe('sheet.csv')
+      expect(input.mimeType).toBe('text/csv')
+      expect(input.content).toBe('col1,col2\n1,2')
+    })
+
+    it('throws when no file field is present', async () => {
+      const req = multipart([{ name: 'sessionId', value: 's2' }])
+      await expect(parseUploadRequest(req)).rejects.toThrow(/file/i)
+    })
+  })
+})

--- a/ui/src/components/ark-ui/DataStashPanel.tsx
+++ b/ui/src/components/ark-ui/DataStashPanel.tsx
@@ -11,15 +11,19 @@
  * Hovering shows the LLM summary (or a raw preview if no summary yet).
  */
 
-import { For, Show, createSignal, createMemo } from 'solid-js'
+import { For, Show, createSignal, createMemo, createResource } from 'solid-js'
+import { isServer } from 'solid-js/web'
 import { Tooltip } from '@ark-ui/solid/tooltip'
 import type { ContextEvent, ToolResultEventData } from '~/lib/harness-patterns'
+import type { StashDocumentMeta } from '~/lib/document-store.server'
 
 // ============================================================================
 // Types
 // ============================================================================
 
 export type StashAction = 'hide' | 'unhide' | 'archive' | 'unarchive'
+/** Document actions add `delete` (uploads are removable; tool results are not). */
+export type DocAction = StashAction | 'delete'
 
 export interface DataStashPanelProps {
   events: ContextEvent[]
@@ -76,6 +80,25 @@ function getRefLabel(tool: string, eventId: string): string {
   const skip = new Set(['read', 'write', 'get', 'set', 'list', 'create', 'delete', 'fetch', 'run', 'execute'])
   const key = parts.find(p => !skip.has(p)) ?? parts[0] ?? tool
   return `${key}:${shortId}`
+}
+
+/** Icon for an uploaded document, chosen from its MIME type / extension. */
+function getDocIcon(mimeType: string, filename: string): string {
+  const m = mimeType.toLowerCase()
+  const f = filename.toLowerCase()
+  if (m.includes('json') || f.endsWith('.json')) return 'i-mdi-code-json'
+  if (m.includes('csv') || m.includes('tab-separated') || f.endsWith('.csv')) return 'i-mdi-table-large'
+  if (m.includes('markdown') || f.endsWith('.md')) return 'i-mdi-language-markdown-outline'
+  if (m.includes('pdf') || f.endsWith('.pdf')) return 'i-mdi-file-pdf-box'
+  if (m.includes('html') || m.includes('xml')) return 'i-mdi-file-code-outline'
+  return 'i-mdi-file-document-outline'
+}
+
+/** Format a byte count compactly (e.g. 2.4 KB). */
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
 }
 
 // ============================================================================
@@ -357,10 +380,287 @@ const IconGallery = (props: { items: ToolResultItem[]; onAction: (id: string, ac
 )
 
 // ============================================================================
+// Document Chip — a single uploaded document (Issue #6 upload path)
+// ============================================================================
+
+const DocChip = (props: {
+  doc: StashDocumentMeta
+  onAction: (id: string, action: DocAction) => Promise<void>
+}) => {
+  const d = () => props.doc
+  const grayed = () => !!(d().hidden || d().archived)
+  const [loading, setLoading] = createSignal(false)
+  const [menuOpen, setMenuOpen] = createSignal(false)
+
+  const handle = async (action: DocAction) => {
+    setMenuOpen(false)
+    setLoading(true)
+    try {
+      await props.onAction(d().id, action)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const menuActions = (): { label: string; action: DocAction }[] => {
+    const base: { label: string; action: DocAction }[] = d().archived
+      ? [{ label: 'Unarchive', action: 'unarchive' }]
+      : d().hidden
+        ? [
+            { label: 'Unhide', action: 'unhide' },
+            { label: 'Archive', action: 'archive' },
+          ]
+        : [
+            { label: 'Hide', action: 'hide' },
+            { label: 'Archive', action: 'archive' },
+          ]
+    return [...base, { label: 'Delete', action: 'delete' }]
+  }
+
+  return (
+    <div style={{ position: 'relative', display: 'inline-block' }}>
+      {/* Native title tooltip — keeps the chip simple; Ark's Tooltip is used by
+          the tool-result chips above. */}
+      <div
+        title={`${d().filename}\n${d().mimeType} · ${formatBytes(d().size)}`}
+        flex="~ col"
+        items="center"
+        gap="1"
+        p="2"
+        w="16"
+        cursor="pointer"
+        rounded="lg"
+        bg={menuOpen() ? 'dark-bg-tertiary' : 'transparent hover:dark-bg-secondary'}
+        border={menuOpen() ? '1 dark-border-secondary' : '1 transparent hover:dark-border-primary'}
+        transition="all"
+        opacity={grayed() ? '35' : loading() ? '50' : '100'}
+        onClick={() => setMenuOpen(!menuOpen())}
+      >
+        <span
+          class={getDocIcon(d().mimeType, d().filename)}
+          style={{
+            width: '28px',
+            height: '28px',
+            color: grayed() ? '#52525b' : '#34d399',
+            transition: 'all 0.15s',
+          }}
+        />
+        <span
+          style={{
+            'font-family': '"Fira Code", ui-monospace, monospace',
+            'font-size': '9px',
+            color: grayed() ? '#52525b' : '#a1a1aa',
+            'text-align': 'center',
+            'word-break': 'break-all',
+            'line-height': '1.2',
+            'max-width': '60px',
+          }}
+        >
+          {truncate(d().filename, 18)}
+        </span>
+      </div>
+
+      <Show when={menuOpen()}>
+        <div
+          style={{
+            position: 'absolute',
+            top: '100%',
+            left: '50%',
+            transform: 'translateX(-50%)',
+            'z-index': '100',
+            background: '#1a1a24',
+            border: '1px solid #2a2a3a',
+            'border-radius': '6px',
+            padding: '4px',
+            'min-width': '100px',
+            'box-shadow': '0 4px 16px rgba(0,0,0,0.4)',
+          }}
+        >
+          <For each={menuActions()}>
+            {(btn) => (
+              <button
+                onClick={() => handle(btn.action)}
+                style={{
+                  display: 'block',
+                  width: '100%',
+                  padding: '5px 10px',
+                  'text-align': 'left',
+                  background: 'transparent',
+                  border: 'none',
+                  'border-radius': '4px',
+                  'font-size': '11px',
+                  color: btn.action === 'delete' ? '#f87171' : '#a1a1aa',
+                  cursor: 'pointer',
+                }}
+                onMouseEnter={(e) => (e.currentTarget.style.background = '#22222f')}
+                onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
+              >
+                {btn.label}
+              </button>
+            )}
+          </For>
+        </div>
+      </Show>
+
+      <Show when={menuOpen()}>
+        <div
+          style={{ position: 'fixed', inset: '0', 'z-index': '99' }}
+          onClick={() => setMenuOpen(false)}
+        />
+      </Show>
+    </div>
+  )
+}
+
+// ============================================================================
+// Upload Zone — file picker + drag-and-drop (Issue #6)
+// ============================================================================
+
+const UploadZone = (props: {
+  uploading: boolean
+  error: string | null
+  onFiles: (files: File[]) => void
+}) => {
+  const [dragOver, setDragOver] = createSignal(false)
+  let inputRef: HTMLInputElement | undefined
+
+  const pick = (list: FileList | null) => {
+    if (list && list.length > 0) props.onFiles(Array.from(list))
+  }
+
+  return (
+    <div p="3" flex="~ col" gap="2">
+      <div
+        onClick={() => inputRef?.click()}
+        onDragOver={(e) => {
+          e.preventDefault()
+          setDragOver(true)
+        }}
+        onDragLeave={() => setDragOver(false)}
+        onDrop={(e) => {
+          e.preventDefault()
+          setDragOver(false)
+          pick(e.dataTransfer?.files ?? null)
+        }}
+        flex="~ col"
+        items="center"
+        justify="center"
+        gap="1"
+        p="4"
+        rounded="lg"
+        cursor="pointer"
+        border={dragOver() ? '2 dashed neon-cyan/60' : '2 dashed dark-border-primary'}
+        bg={dragOver() ? 'cyber-800/40' : 'transparent hover:dark-bg-secondary'}
+        transition="all"
+      >
+        <span
+          class={props.uploading ? 'i-mdi-loading' : 'i-mdi-cloud-upload-outline'}
+          style={{
+            width: '24px',
+            height: '24px',
+            color: dragOver() ? '#22d3ee' : '#71717a',
+            ...(props.uploading ? { animation: 'spin 1s linear infinite' } : {}),
+          }}
+        />
+        <span text="xs dark-text-secondary">
+          {props.uploading ? 'Uploading…' : 'Drop a file or click to upload'}
+        </span>
+        <span text="xs dark-text-tertiary">Text, Markdown, JSON, CSV</span>
+        <input
+          ref={inputRef}
+          type="file"
+          multiple
+          style={{ display: 'none' }}
+          onChange={(e) => {
+            pick(e.currentTarget.files)
+            e.currentTarget.value = '' // allow re-selecting the same file
+          }}
+        />
+      </div>
+      <Show when={props.error}>
+        <div text="xs red-400" font="mono">
+          {props.error}
+        </div>
+      </Show>
+    </div>
+  )
+}
+
+// ============================================================================
 // Main Component
 // ============================================================================
 
+async function fetchDocuments(sessionId: string): Promise<StashDocumentMeta[]> {
+  const res = await fetch(`/api/stash/upload?sessionId=${encodeURIComponent(sessionId)}`)
+  if (!res.ok) return []
+  const body = (await res.json()) as { documents?: StashDocumentMeta[] }
+  return body.documents ?? []
+}
+
 export const DataStashPanel = (props: DataStashPanelProps) => {
+  // Uploaded documents live in Redis (Issue #6), separate from the tool_result
+  // events in `props.events`. Fetched on mount and refetched after mutations.
+  // Guarded against SSR — relative-URL fetch has no origin on the server.
+  const [documents, { refetch }] = createResource(
+    () => (isServer ? undefined : props.sessionId || undefined),
+    fetchDocuments,
+  )
+  const [uploading, setUploading] = createSignal(false)
+  const [uploadError, setUploadError] = createSignal<string | null>(null)
+
+  const uploadFiles = async (files: File[]) => {
+    if (!props.sessionId) {
+      setUploadError('Start a conversation before uploading')
+      return
+    }
+    setUploading(true)
+    setUploadError(null)
+    try {
+      for (const file of files) {
+        const form = new FormData()
+        form.set('sessionId', props.sessionId)
+        form.set('file', file)
+        const res = await fetch('/api/stash/upload', { method: 'POST', body: form })
+        if (!res.ok) {
+          const body = (await res.json().catch(() => ({}))) as { error?: string }
+          throw new Error(body.error ?? `Upload failed (${res.status})`)
+        }
+      }
+      await refetch()
+    } catch (err) {
+      setUploadError(err instanceof Error ? err.message : 'Upload failed')
+    } finally {
+      setUploading(false)
+    }
+  }
+
+  const handleDocAction = async (id: string, action: DocAction) => {
+    if (!props.sessionId) return
+    if (action === 'delete') {
+      await fetch(
+        `/api/stash/document/${encodeURIComponent(id)}?sessionId=${encodeURIComponent(props.sessionId)}`,
+        { method: 'DELETE' },
+      )
+    } else {
+      const patch =
+        action === 'hide'
+          ? { hidden: true }
+          : action === 'unhide'
+            ? { hidden: false }
+            : action === 'archive'
+              ? { archived: true, hidden: false }
+              : { archived: false }
+      await fetch(`/api/stash/document/${encodeURIComponent(id)}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sessionId: props.sessionId, ...patch }),
+      })
+    }
+    await refetch()
+  }
+
+  const docs = createMemo(() => documents() ?? [])
+
   const partitioned = createMemo(() => {
     const toolResults: ToolResultItem[] = props.events
       .filter(e => e.type === 'tool_result' && e.id)
@@ -388,10 +688,11 @@ export const DataStashPanel = (props: DataStashPanelProps) => {
     return { current, previous, archived }
   })
 
-  const totalCount = createMemo(() => {
+  const toolCount = createMemo(() => {
     const p = partitioned()
     return p.current.length + p.previous.length + p.archived.length
   })
+  const totalCount = createMemo(() => toolCount() + docs().length)
 
   return (
     <div flex="~ col" h="full" overflow="auto" bg="dark-bg-primary">
@@ -412,18 +713,33 @@ export const DataStashPanel = (props: DataStashPanelProps) => {
         <span text="xs dark-text-tertiary" font="mono">{totalCount()} items</span>
       </div>
 
-      <Show when={totalCount() === 0}>
-        <div flex="~ col" items="center" justify="center" p="8" text="dark-text-tertiary" gap="2">
+      {/* Uploads — file ingestion into the Redis-backed stash (Issue #6) */}
+      <div border="b dark-border-primary">
+        <div p="x-3 y-2" flex="~" items="center" gap="2">
+          <span text="xs dark-text-tertiary" font="medium">Uploads</span>
+          <span text="xs dark-text-tertiary" font="mono">({docs().length})</span>
+        </div>
+        <UploadZone uploading={uploading()} error={uploadError()} onFiles={uploadFiles} />
+        <Show when={docs().length > 0}>
+          <div flex="~ wrap" gap="2" p="x-3 y-2">
+            <For each={docs()}>
+              {(doc) => <DocChip doc={doc} onAction={handleDocAction} />}
+            </For>
+          </div>
+        </Show>
+      </div>
+
+      <Show when={toolCount() === 0}>
+        <div flex="~ col" items="center" justify="center" p="6" text="dark-text-tertiary" gap="2">
           <span
             class="i-mdi-package-variant-closed-remove"
-            style={{ width: '36px', height: '36px', color: '#3f3f46', opacity: '0.6' }}
+            style={{ width: '32px', height: '32px', color: '#3f3f46', opacity: '0.6' }}
           />
-          <span text="sm m-t-2">No tool results yet</span>
-          <span text="xs dark-text-tertiary">Run an agent to see data here</span>
+          <span text="xs m-t-1">No tool results yet — run an agent to see data here</span>
         </div>
       </Show>
 
-      <Show when={totalCount() > 0}>
+      <Show when={toolCount() > 0}>
         {/* Current Turn */}
         <Show when={partitioned().current.length > 0}>
           <div border="b dark-border-primary">

--- a/ui/src/lib/chunking.server.ts
+++ b/ui/src/lib/chunking.server.ts
@@ -1,0 +1,336 @@
+/**
+ * Document Chunking — Server Only (Issue #9)
+ *
+ * Splits a document's text into sized, overlapping chunks suitable for
+ * embedding (#8) and vector storage. Sits between document upload (#6) and the
+ * embedding step in the ingestion pipeline:
+ *
+ *   Upload → detect type → extract text → chunk(text) → embed(chunks) → index
+ *                                          ↑ this module
+ *
+ * Three strategies, all char-budget driven (the `ChunkConfig` is character
+ * based by design — token estimation lives elsewhere and would couple this
+ * pure utility to the harness):
+ *
+ *   - `fixed`     — sliding window of `maxChars` with `overlap`. Works on any
+ *                   text; the fallback when structure is absent.
+ *   - `sentence`  — split on sentence boundaries, greedily pack until `maxChars`.
+ *   - `paragraph` — split on blank lines, greedily pack until `maxChars`.
+ *
+ * Sentence/paragraph packing carries trailing units into the next chunk to
+ * realise `overlap`, and falls back to a fixed window for any single unit that
+ * alone exceeds `maxChars` (e.g. one giant paragraph). Every returned chunk
+ * satisfies `content === text.slice(startOffset, endOffset)` (CSV is the one
+ * documented exception — it prepends a repeated header).
+ *
+ * Pure and synchronous — no Redis, no MCP, no I/O. The `.server.ts` suffix is
+ * for consistency with the pipeline neighbours; nothing here is truly
+ * server-only, but keeping it server-side avoids shipping it to the client.
+ */
+
+import { assertServerOnImport } from './harness-patterns/assert.server'
+
+assertServerOnImport()
+
+// ============================================================================
+// Public types (Issue #9 contract)
+// ============================================================================
+
+export type ChunkStrategy = 'fixed' | 'sentence' | 'paragraph'
+
+export interface ChunkConfig {
+  /** Target chunk size in characters. */
+  maxChars: number
+  /** Overlap between adjacent chunks, in characters. Clamped to `< maxChars`. */
+  overlap: number
+  /** Splitting strategy. */
+  strategy: ChunkStrategy
+}
+
+export interface Chunk {
+  /** 0-based position of this chunk in the sequence. */
+  index: number
+  /** The chunk text. */
+  content: string
+  /** Inclusive start offset into the source text. */
+  startOffset: number
+  /** Exclusive end offset into the source text. */
+  endOffset: number
+  /** Optional per-chunk annotations (e.g. CSV header flag). */
+  metadata?: Record<string, unknown>
+}
+
+export const DEFAULT_CHUNK_CONFIG: ChunkConfig = {
+  maxChars: 1000,
+  overlap: 200,
+  strategy: 'paragraph',
+}
+
+// ============================================================================
+// Config normalisation
+// ============================================================================
+
+function normalizeConfig(config?: Partial<ChunkConfig>): ChunkConfig {
+  const maxChars = Math.max(1, Math.floor(config?.maxChars ?? DEFAULT_CHUNK_CONFIG.maxChars))
+  let overlap = Math.max(0, Math.floor(config?.overlap ?? DEFAULT_CHUNK_CONFIG.overlap))
+  // Overlap must stay strictly below maxChars or fixed-window stepping stalls.
+  if (overlap >= maxChars) overlap = maxChars - 1
+  return {
+    maxChars,
+    overlap,
+    strategy: config?.strategy ?? DEFAULT_CHUNK_CONFIG.strategy,
+  }
+}
+
+// ============================================================================
+// Strategy dispatch
+// ============================================================================
+
+/** Chunk `text` using the configured strategy (default: paragraph). */
+export function chunkText(text: string, config?: Partial<ChunkConfig>): Chunk[] {
+  const cfg = normalizeConfig(config)
+  switch (cfg.strategy) {
+    case 'fixed':
+      return chunkFixed(text, cfg)
+    case 'sentence':
+      return chunkBySentence(text, cfg)
+    case 'paragraph':
+    default:
+      return chunkByParagraph(text, cfg)
+  }
+}
+
+// ============================================================================
+// Fixed-window strategy
+// ============================================================================
+
+/** Sliding-window chunks of `maxChars` stepping by `maxChars - overlap`. */
+export function chunkFixed(text: string, config?: Partial<ChunkConfig>): Chunk[] {
+  const cfg = normalizeConfig(config)
+  return fixedWindows(text, cfg.maxChars, cfg.overlap, 0, 0)
+}
+
+function fixedWindows(
+  text: string,
+  maxChars: number,
+  overlap: number,
+  baseOffset: number,
+  startIndex: number,
+): Chunk[] {
+  const chunks: Chunk[] = []
+  if (text.length === 0) return chunks
+  const step = Math.max(1, maxChars - overlap)
+  let start = 0
+  let index = startIndex
+  while (start < text.length) {
+    const end = Math.min(start + maxChars, text.length)
+    chunks.push({
+      index: index++,
+      content: text.slice(start, end),
+      startOffset: baseOffset + start,
+      endOffset: baseOffset + end,
+    })
+    if (end >= text.length) break
+    start += step
+  }
+  return chunks
+}
+
+// ============================================================================
+// Sentence / paragraph strategies (unit packing)
+// ============================================================================
+
+interface Unit {
+  start: number
+  end: number
+}
+
+/** Sentence boundary: terminal punctuation + optional closing quotes + space. */
+const SENTENCE_SEP = /[.!?]+(?:["'’”)\]]+)?\s+/g
+/** Paragraph boundary: a blank line, absorbing surrounding whitespace. */
+const PARAGRAPH_SEP = /\n[ \t]*\n\s*/g
+
+/** Split prose into sentences, then greedily pack into `maxChars` chunks. */
+export function chunkBySentence(text: string, config?: Partial<ChunkConfig>): Chunk[] {
+  const cfg = normalizeConfig(config)
+  return packUnits(text, splitUnits(text, SENTENCE_SEP), cfg.maxChars, cfg.overlap)
+}
+
+/** Split on blank lines, then greedily pack paragraphs into `maxChars` chunks. */
+export function chunkByParagraph(text: string, config?: Partial<ChunkConfig>): Chunk[] {
+  const cfg = normalizeConfig(config)
+  return packUnits(text, splitUnits(text, PARAGRAPH_SEP), cfg.maxChars, cfg.overlap)
+}
+
+/**
+ * Cut `text` into contiguous units at each match of `separatorRe` (the
+ * separator belongs to the preceding unit, so units cover the whole string).
+ * Whitespace-only units are dropped.
+ */
+function splitUnits(text: string, separatorRe: RegExp): Unit[] {
+  const units: Unit[] = []
+  let start = 0
+  let m: RegExpExecArray | null
+  separatorRe.lastIndex = 0
+  while ((m = separatorRe.exec(text)) !== null) {
+    const end = m.index + m[0].length
+    if (end > start) units.push({ start, end })
+    start = end
+    if (m.index === separatorRe.lastIndex) separatorRe.lastIndex++ // guard zero-width
+  }
+  if (start < text.length) units.push({ start, end: text.length })
+  return units.filter((u) => text.slice(u.start, u.end).trim().length > 0)
+}
+
+/** Trim leading/trailing whitespace of a span, keeping offsets faithful. */
+function trimSpan(text: string, start: number, end: number): [number, number] {
+  let s = start
+  let e = end
+  while (s < e && /\s/.test(text[s])) s++
+  while (e > s && /\s/.test(text[e - 1])) e--
+  return [s, e]
+}
+
+/**
+ * Greedily pack `units` into chunks of at most `maxChars`, carrying trailing
+ * units forward to realise `overlap`. A single unit larger than `maxChars` is
+ * sub-split with a fixed window so no chunk silently blows the budget.
+ */
+function packUnits(text: string, units: Unit[], maxChars: number, overlap: number): Chunk[] {
+  const chunks: Chunk[] = []
+  let i = 0
+  while (i < units.length) {
+    // Extend the chunk while the span from this unit's start stays within budget.
+    let j = i + 1
+    while (j < units.length && units[j].end - units[i].start <= maxChars) j++
+
+    const spanStart = units[i].start
+    const spanEnd = units[j - 1].end
+
+    if (j === i + 1 && spanEnd - spanStart > maxChars) {
+      // Single oversized unit — sub-split with a fixed window.
+      const sub = fixedWindows(
+        text.slice(spanStart, spanEnd),
+        maxChars,
+        overlap,
+        spanStart,
+        chunks.length,
+      )
+      chunks.push(...sub)
+    } else {
+      const [s, e] = trimSpan(text, spanStart, spanEnd)
+      if (e > s) {
+        chunks.push({ index: chunks.length, content: text.slice(s, e), startOffset: s, endOffset: e })
+      }
+    }
+
+    if (j >= units.length) break
+
+    // Overlap: step back to re-include trailing units within `overlap` chars,
+    // always advancing by at least one unit to guarantee progress.
+    let nextI = j
+    if (overlap > 0) {
+      let k = j
+      while (k - 1 > i && spanEnd - units[k - 1].start <= overlap) k--
+      nextI = Math.max(k, i + 1)
+    }
+    i = nextI
+  }
+  // Renumber after any fixed-window sub-splits offset the running index.
+  return chunks.map((c, idx) => ({ ...c, index: idx }))
+}
+
+// ============================================================================
+// Type-aware entry point
+// ============================================================================
+
+/**
+ * Chunk a document by MIME type, picking a sensible strategy and pre-processing
+ * structured formats. Text/Markdown/JSON route through {@link chunkText}; CSV
+ * uses row-based chunking with a repeated header.
+ */
+export function chunkDocument(
+  content: string,
+  mimeType: string,
+  config?: Partial<ChunkConfig>,
+): Chunk[] {
+  const mime = mimeType.toLowerCase()
+  if (mime.includes('csv') || mime.includes('tab-separated')) {
+    return chunkCsv(content, config)
+  }
+  if (mime.includes('json')) {
+    // Pretty-print so the paragraph/fixed splitter has line structure to work
+    // with; fall back to the raw string if it isn't valid JSON.
+    let pretty = content
+    try {
+      pretty = JSON.stringify(JSON.parse(content), null, 2)
+    } catch {
+      /* not valid JSON — chunk as-is */
+    }
+    return chunkText(pretty, config)
+  }
+  return chunkText(content, config)
+}
+
+/**
+ * Row-based CSV chunking: groups data rows until `maxChars`, prepending the
+ * header row to each chunk so embeddings keep column context.
+ *
+ * Note: because the header is duplicated into every chunk, CSV chunk `content`
+ * is NOT a slice of the source — `startOffset`/`endOffset` describe the span of
+ * the *data rows* only, and `metadata.csvHeader` flags the prepend.
+ */
+export function chunkCsv(text: string, config?: Partial<ChunkConfig>): Chunk[] {
+  const cfg = normalizeConfig(config)
+  const isTsv = text.includes('\t') && !text.includes(',')
+  void isTsv // delimiter detection is informational; we split on full lines
+
+  // Offsets of each physical line.
+  const lines: { text: string; start: number; end: number }[] = []
+  {
+    let pos = 0
+    for (const raw of text.split('\n')) {
+      const start = pos
+      const end = pos + raw.length
+      lines.push({ text: raw, start, end })
+      pos = end + 1 // account for the consumed '\n'
+    }
+  }
+
+  const nonEmpty = lines.filter((l) => l.text.trim().length > 0)
+  if (nonEmpty.length === 0) return []
+
+  const header = nonEmpty[0]
+  const rows = nonEmpty.slice(1)
+  if (rows.length === 0) {
+    // Header only — emit it as a single chunk.
+    return [{ index: 0, content: header.text, startOffset: header.start, endOffset: header.end }]
+  }
+
+  const chunks: Chunk[] = []
+  let group: typeof rows = []
+  let groupChars = header.text.length
+
+  const flush = () => {
+    if (group.length === 0) return
+    const body = group.map((r) => r.text).join('\n')
+    chunks.push({
+      index: chunks.length,
+      content: `${header.text}\n${body}`,
+      startOffset: group[0].start,
+      endOffset: group[group.length - 1].end,
+      metadata: { csvHeader: true, rows: group.length },
+    })
+    group = []
+    groupChars = header.text.length
+  }
+
+  for (const row of rows) {
+    const add = row.text.length + 1
+    if (group.length > 0 && groupChars + add > cfg.maxChars) flush()
+    group.push(row)
+    groupChars += add
+  }
+  flush()
+  return chunks
+}

--- a/ui/src/lib/document-ingest.server.ts
+++ b/ui/src/lib/document-ingest.server.ts
@@ -1,0 +1,370 @@
+/**
+ * Document Ingestion — Server Only (ties #6 + #9 + #8 together)
+ *
+ * The capstone of the store → chunk → embed pipeline. Takes a stored
+ * {@link StashDocument} and makes it *searchable*:
+ *
+ *   chunkDocument(content)  →  embed(chunks)  →  Redis vector hashes + HNSW index
+ *
+ * and answers queries:
+ *
+ *   embedOne(query)  →  vector_search_hash  →  top-k chunks (with provenance)
+ *
+ * ── One embedding space per session corpus ────────────────────────────────
+ * Vectors are only comparable within one model (see `embeddings.server.ts`).
+ * This module makes that structural, not advisory:
+ *   - The Redis key prefix AND index name both encode the embedding space
+ *     (`provider_model_dim`), so a hash embedded with model A can never land in
+ *     model B's index — different prefix, different index, different `dim`.
+ *   - The session's space is recorded at `stash:space:{sessionId}`. Re-ingesting
+ *     with a *different* model throws (unless `allowSpaceChange`), and queries
+ *     are always embedded with the recorded model — so a search can never
+ *     compare across spaces.
+ *
+ * Redis is reached via the injectable MCP `callTool` (defaults to the real
+ * client) and embedding via an injectable embed fn, so the whole orchestrator
+ * is unit-testable without a live gateway or model server — mirroring
+ * `document-store.server.ts`.
+ */
+
+import { assertServerOnImport } from './harness-patterns/assert.server'
+import { callTool as defaultCallTool } from './harness-patterns/mcp-client.server'
+import {
+  DEFAULT_TTL_SECONDS,
+  redisWriteError,
+  type CallTool,
+  type StashDocument,
+} from './document-store.server'
+import { chunkDocument, type Chunk, type ChunkConfig } from './chunking.server'
+import {
+  embed as defaultEmbed,
+  embedOne as defaultEmbedOne,
+  assertSameSpace,
+  type EmbeddingConfig,
+  type EmbeddingResult,
+  type EmbeddingSpace,
+  type SingleEmbeddingResult,
+} from './embeddings.server'
+
+assertServerOnImport()
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface IngestOptions {
+  /** Chunking config override (strategy / maxChars / overlap). */
+  chunk?: Partial<ChunkConfig>
+  /** Embedding provider/model override. */
+  embedding?: EmbeddingConfig
+  /** TTL for the chunk hashes; defaults to the document TTL window. */
+  ttlSeconds?: number
+  /** Allow re-ingesting a session under a different embedding space (splits
+   *  the corpus — off by default to preserve comparability). */
+  allowSpaceChange?: boolean
+  /** Injected Redis MCP caller (tests). */
+  callTool?: CallTool
+  /** Injected embed fn (tests). */
+  embedFn?: (texts: string[], config?: EmbeddingConfig) => Promise<EmbeddingResult>
+}
+
+export interface IngestResult {
+  docId: string
+  sessionId: string
+  /** Number of chunks embedded + indexed. */
+  chunks: number
+  /** The embedding space this corpus is bound to. */
+  space: EmbeddingSpace
+  indexName: string
+  prefix: string
+}
+
+export interface SearchHit {
+  docId: string
+  source: string
+  chunkIndex: number
+  content: string
+  startOffset?: number
+  endOffset?: number
+  /** Vector distance (lower = closer) when the backend reports one. */
+  score?: number
+}
+
+export interface SearchOptions {
+  k?: number
+  /** Embedding override; provider/model are forced to the recorded space. */
+  embedding?: EmbeddingConfig
+  callTool?: CallTool
+  embedOneFn?: (text: string, config?: EmbeddingConfig) => Promise<SingleEmbeddingResult>
+}
+
+// ============================================================================
+// Key / index naming — the space is baked into both
+// ============================================================================
+
+const SPACE_KEY_PREFIX = 'stash:space'
+
+function sanitize(s: string): string {
+  return s.replace(/[^a-zA-Z0-9]+/g, '_').replace(/^_+|_+$/g, '')
+}
+
+/** `provider_model_dim` — equal tags ⇒ comparable vectors. */
+function spaceTag(space: EmbeddingSpace): string {
+  return `${space.provider}_${sanitize(space.model)}_${space.dimensions}`
+}
+
+export function indexNameFor(sessionId: string, space: EmbeddingSpace): string {
+  return `stash_idx_${sanitize(sessionId)}_${spaceTag(space)}`
+}
+
+export function prefixFor(sessionId: string, space: EmbeddingSpace): string {
+  return `stashvec:${sessionId}:${spaceTag(space)}:`
+}
+
+function chunkKey(prefix: string, docId: string, chunkIndex: number): string {
+  return `${prefix}${docId}:${chunkIndex}`
+}
+
+function spaceKey(sessionId: string): string {
+  return `${SPACE_KEY_PREFIX}:${sessionId}`
+}
+
+// ============================================================================
+// Embedding-space bookkeeping
+// ============================================================================
+
+/** Read the embedding space a session's corpus was built with, if any. */
+export async function getEmbeddingSpace(
+  sessionId: string,
+  callTool: CallTool = defaultCallTool,
+): Promise<EmbeddingSpace | null> {
+  const res = await callTool('json_get', { name: spaceKey(sessionId), path: '$' })
+  if (!res.success || res.data == null) return null
+  let value: unknown = res.data
+  if (typeof value === 'string') {
+    try {
+      value = JSON.parse(value)
+    } catch {
+      return null
+    }
+  }
+  if (Array.isArray(value)) value = value[0]
+  if (value == null || typeof value !== 'object') return null
+  const s = value as Partial<EmbeddingSpace>
+  if (!s.provider || !s.model || typeof s.dimensions !== 'number') return null
+  return { provider: s.provider, model: s.model, dimensions: s.dimensions }
+}
+
+async function recordSpace(
+  callTool: CallTool,
+  sessionId: string,
+  space: EmbeddingSpace,
+  ttl: number,
+): Promise<void> {
+  await callTool('json_set', {
+    name: spaceKey(sessionId),
+    path: '$',
+    value: JSON.stringify(space),
+    expire_seconds: ttl,
+  })
+}
+
+// ============================================================================
+// Ingest
+// ============================================================================
+
+/**
+ * Chunk → embed → index a stored document into Redis for similarity search.
+ *
+ * @throws if the session already has a different embedding space (and
+ *         `allowSpaceChange` is not set), or if Redis writes fail.
+ */
+export async function ingestDocument(
+  doc: StashDocument,
+  opts: IngestOptions = {},
+): Promise<IngestResult> {
+  const callTool = opts.callTool ?? defaultCallTool
+  const embedFn = opts.embedFn ?? defaultEmbed
+  const ttl = opts.ttlSeconds ?? DEFAULT_TTL_SECONDS
+
+  const chunks: Chunk[] = chunkDocument(doc.content, doc.mimeType, opts.chunk)
+  const { vectors, ...space } = await embedFn(
+    chunks.map((c) => c.content),
+    opts.embedding,
+  )
+
+  // Enforce one model per session corpus.
+  const existing = await getEmbeddingSpace(doc.sessionId, callTool)
+  if (existing && !opts.allowSpaceChange) {
+    assertSameSpace(existing, space)
+  }
+
+  const indexName = indexNameFor(doc.sessionId, space)
+  const prefix = prefixFor(doc.sessionId, space)
+  await ensureVectorIndex(callTool, indexName, prefix, space.dimensions)
+
+  for (let i = 0; i < chunks.length; i++) {
+    const c = chunks[i]
+    const key = chunkKey(prefix, doc.id, c.index)
+
+    const setVec = await callTool('set_vector_in_hash', { name: key, vector: vectors[i] })
+    const vecErr = redisWriteError(setVec)
+    if (vecErr) {
+      throw new Error(`Failed to store vector for chunk ${c.index}: ${vecErr}`)
+    }
+
+    const fields: Array<[string, string | number]> = [
+      ['content', c.content],
+      ['doc_id', doc.id],
+      ['session_id', doc.sessionId],
+      ['source', doc.filename],
+      ['chunk_index', c.index],
+      ['start_offset', c.startOffset],
+      ['end_offset', c.endOffset],
+      ['model', space.model],
+      ['provider', space.provider],
+      ['dim', space.dimensions],
+    ]
+    for (let f = 0; f < fields.length; f++) {
+      const [k, v] = fields[f]
+      // Set the key TTL on the final field write (TTL is per-key; HSET on an
+      // existing key preserves it, so one expiring write covers the whole hash).
+      await callTool('hset', {
+        name: key,
+        key: k,
+        value: v,
+        ...(f === fields.length - 1 ? { expire_seconds: ttl } : {}),
+      })
+    }
+  }
+
+  await recordSpace(callTool, doc.sessionId, space, ttl)
+
+  return {
+    docId: doc.id,
+    sessionId: doc.sessionId,
+    chunks: chunks.length,
+    space,
+    indexName,
+    prefix,
+  }
+}
+
+/** Create the HNSW index for a (session, space), tolerating "already exists". */
+async function ensureVectorIndex(
+  callTool: CallTool,
+  indexName: string,
+  prefix: string,
+  dim: number,
+): Promise<void> {
+  const res = await callTool('create_vector_index_hash', {
+    index_name: indexName,
+    prefix,
+    dim,
+    distance_metric: 'COSINE',
+  })
+  // The Redis MCP returns a string; an existing index surfaces as an error-ish
+  // message rather than a thrown exception. Only a hard failure that is NOT an
+  // "already exists" should propagate.
+  const err = redisWriteError(res)
+  if (err && !/exist/i.test(err)) {
+    throw new Error(`Failed to create vector index ${indexName}: ${err}`)
+  }
+}
+
+// ============================================================================
+// Search
+// ============================================================================
+
+/**
+ * Embed `query` with the session's recorded model and KNN-search its index.
+ * Returns [] when the session has no ingested corpus yet.
+ *
+ * The query is always embedded with the *recorded* provider/model, and
+ * {@link assertSameSpace} re-checks dimensionality — a search can never compare
+ * vectors across embedding spaces.
+ */
+export async function searchDocuments(
+  sessionId: string,
+  query: string,
+  opts: SearchOptions = {},
+): Promise<SearchHit[]> {
+  const callTool = opts.callTool ?? defaultCallTool
+  const embedOneFn = opts.embedOneFn ?? defaultEmbedOne
+
+  const recorded = await getEmbeddingSpace(sessionId, callTool)
+  if (!recorded) return []
+
+  const q = await embedOneFn(query, {
+    ...opts.embedding,
+    provider: recorded.provider,
+    model: recorded.model,
+    dimensions: recorded.dimensions,
+  })
+  assertSameSpace(recorded, { provider: q.provider, model: q.model, dimensions: q.dimensions })
+
+  const res = await callTool('vector_search_hash', {
+    index_name: indexNameFor(sessionId, recorded),
+    query_vector: q.vector,
+    k: opts.k ?? 5,
+    return_fields: [
+      'content',
+      'doc_id',
+      'source',
+      'chunk_index',
+      'start_offset',
+      'end_offset',
+    ],
+  })
+  if (!res.success || res.data == null) return []
+  return parseSearchHits(res.data)
+}
+
+/**
+ * Tolerant parser for `vector_search_hash` output. The Redis MCP returns "a
+ * list of matched documents"; field names vary slightly by version, so this
+ * accepts a few shapes and skips anything it can't read rather than throwing.
+ */
+function parseSearchHits(data: unknown): SearchHit[] {
+  let rows: unknown = data
+  if (typeof rows === 'string') {
+    try {
+      rows = JSON.parse(rows)
+    } catch {
+      return []
+    }
+  }
+  // Some versions wrap results under a key; unwrap common shapes.
+  if (rows && typeof rows === 'object' && !Array.isArray(rows)) {
+    const obj = rows as Record<string, unknown>
+    rows = obj.results ?? obj.documents ?? obj.matches ?? []
+  }
+  if (!Array.isArray(rows)) return []
+
+  const hits: SearchHit[] = []
+  for (const row of rows) {
+    if (!row || typeof row !== 'object') continue
+    const r = row as Record<string, unknown>
+    const content = str(r.content)
+    if (content == null) continue
+    hits.push({
+      docId: str(r.doc_id) ?? '',
+      source: str(r.source) ?? '',
+      chunkIndex: num(r.chunk_index) ?? 0,
+      content,
+      startOffset: num(r.start_offset),
+      endOffset: num(r.end_offset),
+      score: num(r.score ?? r.distance ?? r.__vector_score),
+    })
+  }
+  return hits
+}
+
+function str(v: unknown): string | undefined {
+  return typeof v === 'string' ? v : typeof v === 'number' ? String(v) : undefined
+}
+function num(v: unknown): number | undefined {
+  if (typeof v === 'number') return v
+  if (typeof v === 'string' && v.trim() !== '' && Number.isFinite(Number(v))) return Number(v)
+  return undefined
+}

--- a/ui/src/lib/document-ingest.server.ts
+++ b/ui/src/lib/document-ingest.server.ts
@@ -129,6 +129,35 @@ function spaceKey(sessionId: string): string {
   return `${SPACE_KEY_PREFIX}:${sessionId}`
 }
 
+/**
+ * Encode a chunk's content+provenance as an opaque, non-JSON string. The MCP
+ * gateway auto-parses JSON-looking string arguments into objects (so a JSON
+ * `hset` value is rejected as a dict, and a chunk that is itself valid JSON
+ * would be mangled). `b64:`-prefixed base64 sidesteps both.
+ */
+function encodeMeta(obj: Record<string, unknown>): string {
+  return 'b64:' + Buffer.from(JSON.stringify(obj), 'utf8').toString('base64')
+}
+
+/** Inverse of {@link encodeMeta}; tolerant of an already-object or plain-JSON value. */
+export function decodeMeta(raw: unknown): Record<string, unknown> {
+  if (raw && typeof raw === 'object') return raw as Record<string, unknown>
+  if (typeof raw !== 'string') return {}
+  let s = raw
+  if (s.startsWith('b64:')) {
+    try {
+      s = Buffer.from(s.slice(4), 'base64').toString('utf8')
+    } catch {
+      return {}
+    }
+  }
+  try {
+    return JSON.parse(s) as Record<string, unknown>
+  } catch {
+    return {}
+  }
+}
+
 // ============================================================================
 // Embedding-space bookkeeping
 // ============================================================================
@@ -203,39 +232,39 @@ export async function ingestDocument(
   const prefix = prefixFor(doc.sessionId, space)
   await ensureVectorIndex(callTool, indexName, prefix, space.dimensions)
 
-  for (let i = 0; i < chunks.length; i++) {
-    const c = chunks[i]
+  // Write each chunk in just TWO round-trips: the vector (must be a packed
+  // float blob, so set_vector_in_hash) plus a single JSON `meta` field holding
+  // the content AND provenance. The gateway runs the redis MCP over one serial
+  // stdio pipe, so call count is the ingest cost and concurrent writes only
+  // queue up and time out — keep it minimal and sequential. TTL is set on the
+  // meta write (per-key; it covers the whole hash).
+  for (let idx = 0; idx < chunks.length; idx++) {
+    const c = chunks[idx]
     const key = chunkKey(prefix, doc.id, c.index)
 
-    const setVec = await callTool('set_vector_in_hash', { name: key, vector: vectors[i] })
+    const setVec = await callTool('set_vector_in_hash', { name: key, vector: vectors[idx] })
     const vecErr = redisWriteError(setVec)
-    if (vecErr) {
-      throw new Error(`Failed to store vector for chunk ${c.index}: ${vecErr}`)
-    }
+    if (vecErr) throw new Error(`Failed to store vector for chunk ${c.index}: ${vecErr}`)
 
-    const fields: Array<[string, string | number]> = [
-      ['content', c.content],
-      ['doc_id', doc.id],
-      ['session_id', doc.sessionId],
-      ['source', doc.filename],
-      ['chunk_index', c.index],
-      ['start_offset', c.startOffset],
-      ['end_offset', c.endOffset],
-      ['model', space.model],
-      ['provider', space.provider],
-      ['dim', space.dimensions],
-    ]
-    for (let f = 0; f < fields.length; f++) {
-      const [k, v] = fields[f]
-      // Set the key TTL on the final field write (TTL is per-key; HSET on an
-      // existing key preserves it, so one expiring write covers the whole hash).
-      await callTool('hset', {
-        name: key,
-        key: k,
-        value: v,
-        ...(f === fields.length - 1 ? { expire_seconds: ttl } : {}),
-      })
-    }
+    // base64 the JSON blob: the gateway auto-parses JSON-looking string args
+    // into objects (hset then rejects the dict), and a raw chunk could itself
+    // be valid JSON — so encode to an opaque string. The `b64:` prefix makes it
+    // unambiguously non-JSON. Decoded in parseSearchHits.
+    const meta = encodeMeta({
+      content: c.content,
+      doc_id: doc.id,
+      session_id: doc.sessionId,
+      source: doc.filename,
+      chunk_index: c.index,
+      start_offset: c.startOffset,
+      end_offset: c.endOffset,
+      model: space.model,
+      provider: space.provider,
+      dim: space.dimensions,
+    })
+    const metaRes = await callTool('hset', { name: key, key: 'meta', value: meta, expire_seconds: ttl })
+    const metaErr = redisWriteError(metaRes)
+    if (metaErr) throw new Error(`Failed to store chunk ${c.index} meta: ${metaErr}`)
   }
 
   await recordSpace(callTool, doc.sessionId, space, ttl)
@@ -307,14 +336,9 @@ export async function searchDocuments(
     index_name: indexNameFor(sessionId, recorded),
     query_vector: q.vector,
     k: opts.k ?? 5,
-    return_fields: [
-      'content',
-      'doc_id',
-      'source',
-      'chunk_index',
-      'start_offset',
-      'end_offset',
-    ],
+    // Content + provenance travel in a single JSON `meta` field (see ingest);
+    // ask for flat names too in case a backend version flattens them.
+    return_fields: ['meta', 'content', 'doc_id', 'source', 'chunk_index'],
   })
   if (!res.success || res.data == null) return []
   return parseSearchHits(res.data)
@@ -345,15 +369,17 @@ function parseSearchHits(data: unknown): SearchHit[] {
   for (const row of rows) {
     if (!row || typeof row !== 'object') continue
     const r = row as Record<string, unknown>
-    const content = str(r.content)
+    // Content + provenance live in the base64 `meta` field; fall back to flat.
+    const meta = decodeMeta(r.meta)
+    const content = str(meta.content) ?? str(r.content)
     if (content == null) continue
     hits.push({
-      docId: str(r.doc_id) ?? '',
-      source: str(r.source) ?? '',
-      chunkIndex: num(r.chunk_index) ?? 0,
+      docId: str(meta.doc_id) ?? str(r.doc_id) ?? '',
+      source: str(meta.source) ?? str(r.source) ?? '',
+      chunkIndex: num(meta.chunk_index) ?? num(r.chunk_index) ?? 0,
       content,
-      startOffset: num(r.start_offset),
-      endOffset: num(r.end_offset),
+      startOffset: num(meta.start_offset) ?? num(r.start_offset),
+      endOffset: num(meta.end_offset) ?? num(r.end_offset),
       score: num(r.score ?? r.distance ?? r.__vector_score),
     })
   }

--- a/ui/src/lib/document-store.server.ts
+++ b/ui/src/lib/document-store.server.ts
@@ -152,6 +152,32 @@ function unwrapJsonGet(data: unknown): unknown {
   return value
 }
 
+/**
+ * The Redis MCP server reports some command-level failures (auth errors,
+ * WRONGTYPE, misconfiguration) as a *normal text payload* with `success: true`
+ * — the MCP transport succeeded, but the Redis command did not. The shared
+ * `callTool` only demotes `"<Name> Error:"`-prefixed strings, so a write that
+ * actually failed otherwise looks like a stored document. Detect that shape on
+ * writes so a failed write surfaces instead of silently "succeeding".
+ *
+ * Returns the error text when the result indicates a Redis-level failure, else
+ * null. Conservative on success payloads: a RedisJSON SET returns `"OK"`, SADD
+ * returns a count — neither matches these patterns.
+ */
+export function redisWriteError(result: ToolCallResult): string | null {
+  if (!result.success) return result.error ?? 'unknown error'
+  const candidates: unknown[] = [result.data]
+  if (result.data && typeof result.data === 'object' && 'result' in result.data) {
+    candidates.push((result.data as { result?: unknown }).result)
+  }
+  for (const c of candidates) {
+    if (typeof c === 'string' && (/^error\b/i.test(c.trim()) || /\b(NO)?AUTH\b/.test(c) || /WRONGTYPE|misconfigur/i.test(c))) {
+      return c
+    }
+  }
+  return null
+}
+
 // ============================================================================
 // Store
 // ============================================================================
@@ -193,16 +219,21 @@ export async function storeDocument(
     value: JSON.stringify(doc),
     expire_seconds: ttl,
   })
-  if (!set.success) {
-    throw new Error(`Failed to store document: ${set.error ?? 'unknown error'}`)
+  const setErr = redisWriteError(set)
+  if (setErr) {
+    throw new Error(`Failed to store document: ${setErr}`)
   }
 
   // Register in the per-session index, refreshing its TTL to outlive the docs.
-  await callTool('sadd', {
+  const idx = await callTool('sadd', {
     name: indexKey(doc.sessionId),
     value: doc.id,
     expire_seconds: ttl,
   })
+  const idxErr = redisWriteError(idx)
+  if (idxErr) {
+    throw new Error(`Failed to index document: ${idxErr}`)
+  }
 
   return doc
 }
@@ -302,8 +333,9 @@ export async function setDocumentFlags(
     value: JSON.stringify(doc),
     expire_seconds: DEFAULT_TTL_SECONDS,
   })
-  if (!set.success) {
-    throw new Error(`Failed to update document: ${set.error ?? 'unknown error'}`)
+  const setErr = redisWriteError(set)
+  if (setErr) {
+    throw new Error(`Failed to update document: ${setErr}`)
   }
   return doc
 }

--- a/ui/src/lib/document-store.server.ts
+++ b/ui/src/lib/document-store.server.ts
@@ -133,6 +133,50 @@ function byteLength(str: string): number {
 }
 
 /**
+ * Coerce a `smembers` result into a string[] of ids. The Redis MCP may hand the
+ * set back as a real array, a JSON string (`'["a","b"]'`), a double-encoded
+ * string, or wrapped in `{ result: [...] }` — only some of which survive
+ * `callTool`'s single JSON.parse. `getDocument` already tolerates this for
+ * RedisJSON via {@link unwrapJsonGet}; `listDocuments` needs the same robustness
+ * (a strict `Array.isArray` check silently dropped every uploaded doc against
+ * the live gateway).
+ */
+function parseSetMembers(data: unknown): string[] {
+  let value: unknown = data
+  // Unwrap up to a couple layers of JSON-string encoding. A bare, non-JSON
+  // scalar is a single set member returned as one text block (the live MCP
+  // returns one text block per member, so callTool yields a string for a
+  // 1-member set and an array for N members).
+  for (let i = 0; i < 3 && typeof value === 'string'; i++) {
+    const s = value.trim()
+    if (!s) return []
+    if (!/^[[{"]/.test(s)) return [s]
+    try {
+      value = JSON.parse(s)
+    } catch {
+      return [s]
+    }
+  }
+  // Some MCP shapes wrap the array in an object.
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    const obj = value as Record<string, unknown>
+    let inner = obj.result ?? obj.members ?? obj.data
+    if (typeof inner === 'string') {
+      try {
+        inner = JSON.parse(inner)
+      } catch {
+        /* leave as-is */
+      }
+    }
+    value = inner
+  }
+  if (Array.isArray(value)) {
+    return value.filter((m): m is string => typeof m === 'string')
+  }
+  return typeof value === 'string' && value.trim() ? [value.trim()] : []
+}
+
+/**
  * RedisJSON returns the value at `$` wrapped in a single-element array
  * (`["...stringified..."]` or `[{...}]`), and the MCP layer may hand it back
  * either parsed or as a JSON string. Normalise to the contained value.
@@ -280,9 +324,9 @@ export async function listDocuments(
   callTool: CallTool = defaultCallTool,
 ): Promise<StashDocumentMeta[]> {
   const members = await callTool('smembers', { name: indexKey(sessionId) })
-  if (!members.success || !Array.isArray(members.data)) return []
+  if (!members.success) return []
 
-  const ids = members.data.filter((m): m is string => typeof m === 'string')
+  const ids = parseSetMembers(members.data)
   const out: StashDocumentMeta[] = []
 
   for (const id of ids) {

--- a/ui/src/lib/document-store.server.ts
+++ b/ui/src/lib/document-store.server.ts
@@ -1,0 +1,362 @@
+/**
+ * Document Store — Server Only (Issue #6)
+ *
+ * Redis-backed persistence for user-uploaded Data Stash documents.
+ *
+ * Documents live alongside tool results in the Data Stash and are referenced
+ * by the agent across turns via the same `ref:<id>` mechanism (see
+ * `simpleLoop.server.ts` → `PriorResult` / `resolveRefs`). This module owns
+ * only the *storage* layer: write/read/list/delete a document and toggle its
+ * stash flags. Chunking (#9) and embedding (#8) build on top of the returned
+ * `StashDocument` shape — they never re-implement Redis access.
+ *
+ * Storage layout (RedisJSON, one document per key):
+ *
+ *   stash:doc:{sessionId}:{docId}   →  JSON blob (StashDocument)
+ *   stash:docs:{sessionId}          →  SET of docIds for the session (index)
+ *
+ * Each document key carries a configurable TTL via `expire` so stale uploads
+ * don't accumulate. The index set is refreshed with the same TTL on every
+ * write so a fully-expired session leaves no dangling index.
+ *
+ * Redis is reached through the MCP Gateway's `callTool`. The MCP tool param
+ * quirks (see CLAUDE.md → "Redis MCP Tool Parameters") are encapsulated here:
+ *   - json_set / json_get: `name` is the Redis key, `path` the JSON path
+ *   - expire:              `name` + `expire_seconds`
+ *   - sadd / smembers / srem: `name` is the SET key
+ *   - delete:              `key` (note: not `name`)
+ */
+
+import { assertServerOnImport } from './harness-patterns/assert.server'
+import { callTool as defaultCallTool } from './harness-patterns/mcp-client.server'
+import type { ToolCallResult } from './harness-patterns/types'
+import type { PriorResult } from '../../baml_client/types'
+
+assertServerOnImport()
+
+// ============================================================================
+// Types — the public contract chunking (#9) and embedding (#8) consume
+// ============================================================================
+
+/** Metadata stored alongside the document content. */
+export interface StashDocumentMeta {
+  /** Stable per-session document id (also the `ref:<id>` target). */
+  id: string
+  /** Session that owns this document. */
+  sessionId: string
+  /** Original filename as uploaded. */
+  filename: string
+  /** MIME type, e.g. `text/plain`, `application/json`, `text/csv`. */
+  mimeType: string
+  /** Content size in bytes (UTF-8). */
+  size: number
+  /** Upload timestamp (epoch ms). */
+  uploadedAt: number
+  /** Hidden from LLM context (mirrors tool-result stash semantics). */
+  hidden?: boolean
+  /** Moved to the Archived section (also excluded from LLM context). */
+  archived?: boolean
+}
+
+/** A stored document: metadata + its (already text-extracted) content. */
+export interface StashDocument extends StashDocumentMeta {
+  /**
+   * Text content of the document. Upstream callers (the upload route) are
+   * responsible for extracting text from binary formats (PDF, etc.) before
+   * storing — this layer treats `content` as opaque UTF-8 text.
+   */
+  content: string
+}
+
+/** Input for {@link storeDocument}. `id` and `uploadedAt` are minted here. */
+export interface StoreDocumentInput {
+  sessionId: string
+  filename: string
+  mimeType: string
+  content: string
+  /** Override the generated id (e.g. for deterministic tests). */
+  id?: string
+  /** TTL override in seconds; falls back to {@link DEFAULT_TTL_SECONDS}. */
+  ttlSeconds?: number
+}
+
+// ============================================================================
+// Configuration
+// ============================================================================
+
+/** Default document TTL: 7 days. Keeps uploads around across a working
+ *  session without letting them accumulate forever. */
+export const DEFAULT_TTL_SECONDS = 7 * 24 * 60 * 60
+
+/**
+ * Maximum stored content size (bytes). Redis values can be far larger, but
+ * uploads beyond this are rejected here to protect the LLM context budget —
+ * the chunking/embedding pipeline (#9/#8) is the path for large documents, not
+ * full inlining. Callers can raise this per-call once that pipeline lands.
+ */
+export const MAX_CONTENT_BYTES = 5 * 1024 * 1024 // 5 MiB
+
+const DOC_KEY_PREFIX = 'stash:doc'
+const INDEX_KEY_PREFIX = 'stash:docs'
+
+/** A `callTool`-shaped function. Injectable so the store is unit-testable
+ *  without a live MCP gateway (tests pass a stub; prod uses the MCP client). */
+export type CallTool = (
+  name: string,
+  args: Record<string, unknown>,
+) => Promise<ToolCallResult>
+
+// ============================================================================
+// Key helpers
+// ============================================================================
+
+function docKey(sessionId: string, docId: string): string {
+  return `${DOC_KEY_PREFIX}:${sessionId}:${docId}`
+}
+
+function indexKey(sessionId: string): string {
+  return `${INDEX_KEY_PREFIX}:${sessionId}`
+}
+
+function newDocId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID()
+  }
+  // Fallback for non-secure contexts (mirrors session-id.ts rationale).
+  return `doc-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`
+}
+
+function byteLength(str: string): number {
+  return typeof Buffer !== 'undefined'
+    ? Buffer.byteLength(str, 'utf8')
+    : new TextEncoder().encode(str).length
+}
+
+/**
+ * RedisJSON returns the value at `$` wrapped in a single-element array
+ * (`["...stringified..."]` or `[{...}]`), and the MCP layer may hand it back
+ * either parsed or as a JSON string. Normalise to the contained value.
+ */
+function unwrapJsonGet(data: unknown): unknown {
+  let value: unknown = data
+  if (typeof value === 'string') {
+    try {
+      value = JSON.parse(value)
+    } catch {
+      return undefined
+    }
+  }
+  if (Array.isArray(value)) {
+    return value.length > 0 ? value[0] : undefined
+  }
+  return value
+}
+
+// ============================================================================
+// Store
+// ============================================================================
+
+/**
+ * Persist an uploaded document in Redis and register it in the session index.
+ * Returns the stored document (with its minted `id` and `uploadedAt`).
+ *
+ * @throws if the content exceeds {@link MAX_CONTENT_BYTES} or Redis rejects
+ *         the write — callers surface this as a 4xx/5xx on the upload route.
+ */
+export async function storeDocument(
+  input: StoreDocumentInput,
+  callTool: CallTool = defaultCallTool,
+): Promise<StashDocument> {
+  const size = byteLength(input.content)
+  if (size > MAX_CONTENT_BYTES) {
+    throw new Error(
+      `Document too large: ${size} bytes exceeds limit of ${MAX_CONTENT_BYTES} bytes`,
+    )
+  }
+
+  const doc: StashDocument = {
+    id: input.id ?? newDocId(),
+    sessionId: input.sessionId,
+    filename: input.filename,
+    mimeType: input.mimeType,
+    size,
+    uploadedAt: Date.now(),
+    content: input.content,
+  }
+
+  const ttl = input.ttlSeconds ?? DEFAULT_TTL_SECONDS
+  const key = docKey(doc.sessionId, doc.id)
+
+  const set = await callTool('json_set', {
+    name: key,
+    path: '$',
+    value: JSON.stringify(doc),
+    expire_seconds: ttl,
+  })
+  if (!set.success) {
+    throw new Error(`Failed to store document: ${set.error ?? 'unknown error'}`)
+  }
+
+  // Register in the per-session index, refreshing its TTL to outlive the docs.
+  await callTool('sadd', {
+    name: indexKey(doc.sessionId),
+    value: doc.id,
+    expire_seconds: ttl,
+  })
+
+  return doc
+}
+
+// ============================================================================
+// Read
+// ============================================================================
+
+/** Retrieve a full document (content + metadata), or null if absent/expired. */
+export async function getDocument(
+  sessionId: string,
+  docId: string,
+  callTool: CallTool = defaultCallTool,
+): Promise<StashDocument | null> {
+  const res = await callTool('json_get', {
+    name: docKey(sessionId, docId),
+    path: '$',
+  })
+  if (!res.success || res.data == null) return null
+
+  const value = unwrapJsonGet(res.data)
+  if (value == null || typeof value !== 'object') return null
+  return value as StashDocument
+}
+
+/** Retrieve a document's metadata without its content. */
+export async function getDocumentMeta(
+  sessionId: string,
+  docId: string,
+  callTool: CallTool = defaultCallTool,
+): Promise<StashDocumentMeta | null> {
+  const doc = await getDocument(sessionId, docId, callTool)
+  if (!doc) return null
+  return stripContent(doc)
+}
+
+/**
+ * List metadata for every (non-expired) document in a session. Documents whose
+ * keys have expired but linger in the index are pruned from the index as a
+ * side-effect, so the index self-heals.
+ */
+export async function listDocuments(
+  sessionId: string,
+  callTool: CallTool = defaultCallTool,
+): Promise<StashDocumentMeta[]> {
+  const members = await callTool('smembers', { name: indexKey(sessionId) })
+  if (!members.success || !Array.isArray(members.data)) return []
+
+  const ids = members.data.filter((m): m is string => typeof m === 'string')
+  const out: StashDocumentMeta[] = []
+
+  for (const id of ids) {
+    const doc = await getDocument(sessionId, id, callTool)
+    if (doc) {
+      out.push(stripContent(doc))
+    } else {
+      // Key expired/missing — drop the stale index entry.
+      await callTool('srem', { name: indexKey(sessionId), value: id })
+    }
+  }
+
+  // Newest first, matching the conversations list ordering.
+  out.sort((a, b) => b.uploadedAt - a.uploadedAt)
+  return out
+}
+
+// ============================================================================
+// Mutate flags (hide / unhide / archive / unarchive)
+// ============================================================================
+
+/**
+ * Patch a document's stash flags in place (hide/archive), preserving its TTL.
+ * Mirrors `enrichToolResult` semantics for tool results so the existing
+ * DataStashPanel actions apply uniformly to uploads. Returns the updated
+ * document, or null if it no longer exists.
+ */
+export async function setDocumentFlags(
+  sessionId: string,
+  docId: string,
+  patch: { hidden?: boolean; archived?: boolean },
+  callTool: CallTool = defaultCallTool,
+): Promise<StashDocument | null> {
+  const doc = await getDocument(sessionId, docId, callTool)
+  if (!doc) return null
+
+  if (patch.hidden !== undefined) doc.hidden = patch.hidden
+  if (patch.archived !== undefined) doc.archived = patch.archived
+
+  // Rewriting via json_set at `$` would clear any existing expiry, so we
+  // re-apply a TTL. There is no `ttl` tool on the Redis MCP surface to read the
+  // remaining time, so we refresh to the default window — a flag edit signals
+  // the document is still in use, making a fresh window reasonable.
+  const key = docKey(sessionId, docId)
+  const set = await callTool('json_set', {
+    name: key,
+    path: '$',
+    value: JSON.stringify(doc),
+    expire_seconds: DEFAULT_TTL_SECONDS,
+  })
+  if (!set.success) {
+    throw new Error(`Failed to update document: ${set.error ?? 'unknown error'}`)
+  }
+  return doc
+}
+
+// ============================================================================
+// Delete
+// ============================================================================
+
+/** Remove a document from Redis and from the session index. Idempotent. */
+export async function deleteDocument(
+  sessionId: string,
+  docId: string,
+  callTool: CallTool = defaultCallTool,
+): Promise<void> {
+  // `delete` uses `key` (not `name`) — see CLAUDE.md Redis quirks.
+  await callTool('delete', { key: docKey(sessionId, docId) })
+  await callTool('srem', { name: indexKey(sessionId), value: docId })
+}
+
+// ============================================================================
+// Agent-facing adapter — surface a document as a PriorResult / ref
+// ============================================================================
+
+/**
+ * Convert a stored document into the `PriorResult` shape simpleLoop already
+ * uses for tool results, so uploads can be passed through `turns_previous_runs`
+ * and expanded via `ref:<id>` without touching the harness-patterns layer.
+ *
+ * `summary` is a short, deterministic preview here; the embedding/summarization
+ * pipeline (#8) can replace it with a model-authored summary later.
+ */
+export function toPriorResult(
+  doc: StashDocumentMeta & { content?: string },
+  previewChars = 200,
+): PriorResult {
+  const preview = doc.content
+    ? doc.content.slice(0, previewChars).replace(/\s+/g, ' ').trim() +
+      (doc.content.length > previewChars ? '…' : '')
+    : `${doc.filename} (${doc.mimeType}, ${doc.size} bytes)`
+  return {
+    ref_id: doc.id,
+    tool: `upload:${doc.filename}`,
+    summary: preview,
+    expanded_in_turn: null,
+  }
+}
+
+// ============================================================================
+// Internal helpers
+// ============================================================================
+
+function stripContent(doc: StashDocument): StashDocumentMeta {
+  const { content: _content, ...meta } = doc
+  void _content
+  return meta
+}

--- a/ui/src/lib/embeddings.server.ts
+++ b/ui/src/lib/embeddings.server.ts
@@ -1,0 +1,286 @@
+/**
+ * Embeddings — Server Only (Issue #8)
+ *
+ * Provider-pluggable text embedding for the ingestion pipeline. Turns chunk
+ * text (#9) into vectors that get stored in Redis for similarity search (#6).
+ *
+ * ── Comparability is the whole point ──────────────────────────────────────
+ * Vectors are only comparable when produced by the *same* model. Cosine
+ * similarity between a vector from Qwen3-Embedding-0.6B and one from a Nemotron
+ * model is meaningless — different vector spaces, often different dimensions.
+ *
+ * Therefore this module does **NOT** do the BAML-style silent runtime fallback
+ * across providers. The provider+model is a deliberate, configured property of
+ * an *embedding space* (and thus of a whole vector index / corpus). If the
+ * chosen provider fails, we throw — we never quietly re-embed with a different
+ * model that would poison the index. Use {@link assertSameSpace} to enforce
+ * that a query embedding matches the index it searches.
+ *
+ * ── Providers ─────────────────────────────────────────────────────────────
+ *   - `local`      (dev default) — `llama-server --embedding` on :8090 serving
+ *                  Qwen3-Embedding-0.6B over the OpenAI-compatible
+ *                  `POST /v1/embeddings`. (Distinct from `pnpm dev:llama`, which
+ *                  serves a *chat* model on :8080.)
+ *   - `openrouter` (prod / fallback you opt into) — OpenRouter's
+ *                  `/v1/embeddings`. Requires `OPENROUTER_API_KEY`.
+ *
+ * Both speak the OpenAI embeddings wire format, so one client handles both.
+ * `embed()` returns the vectors *with* their `{ provider, model, dimensions }`
+ * so callers can tag the index and detect mismatches — that metadata travelling
+ * with the vectors is what makes the comparability guard enforceable.
+ */
+
+import { assertServerOnImport } from './harness-patterns/assert.server'
+
+assertServerOnImport()
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type EmbeddingProvider = 'local' | 'openrouter'
+
+export interface EmbeddingConfig {
+  /** Provider; defaults to `EMBEDDINGS_PROVIDER` env or `'local'`. */
+  provider?: EmbeddingProvider
+  /** Model id override. */
+  model?: string
+  /** OpenAI-compatible base URL (no trailing `/embeddings`). */
+  baseUrl?: string
+  /** API key; defaults from env per provider (none needed for local). */
+  apiKey?: string
+  /** Requested output dimensions (only honoured by models that support it). */
+  dimensions?: number
+  /** Max texts per HTTP request (server batch-size guard). Default 64. */
+  batchSize?: number
+  /** Injectable fetch for tests. Defaults to global `fetch`. */
+  fetchImpl?: typeof fetch
+}
+
+/** The identity of an embedding space — what makes two vectors comparable. */
+export interface EmbeddingSpace {
+  provider: EmbeddingProvider
+  model: string
+  dimensions: number
+}
+
+/** Vectors plus the space they belong to. */
+export interface EmbeddingResult extends EmbeddingSpace {
+  vectors: number[][]
+}
+
+/** A single embedding plus its space. */
+export interface SingleEmbeddingResult extends EmbeddingSpace {
+  vector: number[]
+}
+
+interface ResolvedConfig {
+  provider: EmbeddingProvider
+  baseUrl: string
+  model: string
+  apiKey?: string
+  dimensions?: number
+  batchSize: number
+  fetchImpl: typeof fetch
+}
+
+// ============================================================================
+// Defaults
+// ============================================================================
+
+const LOCAL_DEFAULT_URL = 'http://localhost:8090/v1'
+const LOCAL_DEFAULT_MODEL = 'Qwen3-Embedding-0.6B'
+const OPENROUTER_URL = 'https://openrouter.ai/api/v1'
+const OPENROUTER_DEFAULT_MODEL = 'nvidia/llama-nemotron-embed-vl-1b-v2:free'
+const DEFAULT_BATCH_SIZE = 64
+
+function stripTrailingSlash(url: string): string {
+  return url.replace(/\/+$/, '')
+}
+
+// ============================================================================
+// Config resolution — provider chosen explicitly, never as a silent fallback
+// ============================================================================
+
+function resolveConfig(config?: EmbeddingConfig): ResolvedConfig {
+  const provider =
+    config?.provider ??
+    (process.env.EMBEDDINGS_PROVIDER as EmbeddingProvider | undefined) ??
+    'local'
+
+  if (provider !== 'local' && provider !== 'openrouter') {
+    throw new Error(`Unknown embedding provider: ${String(provider)}`)
+  }
+
+  const common = {
+    dimensions: config?.dimensions,
+    batchSize: Math.max(1, config?.batchSize ?? DEFAULT_BATCH_SIZE),
+    fetchImpl: config?.fetchImpl ?? fetch,
+  }
+
+  if (provider === 'local') {
+    return {
+      provider,
+      baseUrl: stripTrailingSlash(
+        config?.baseUrl ?? process.env.EMBEDDINGS_LOCAL_URL ?? LOCAL_DEFAULT_URL,
+      ),
+      model: config?.model ?? process.env.EMBEDDINGS_LOCAL_MODEL ?? LOCAL_DEFAULT_MODEL,
+      apiKey: config?.apiKey, // llama-server needs none
+      ...common,
+    }
+  }
+
+  // openrouter
+  const apiKey = config?.apiKey ?? process.env.OPENROUTER_API_KEY
+  if (!apiKey) {
+    throw new Error(
+      'OPENROUTER_API_KEY is required for the openrouter embedding provider',
+    )
+  }
+  return {
+    provider,
+    baseUrl: stripTrailingSlash(config?.baseUrl ?? OPENROUTER_URL),
+    model: config?.model ?? OPENROUTER_DEFAULT_MODEL,
+    apiKey,
+    ...common,
+  }
+}
+
+// ============================================================================
+// Embedding
+// ============================================================================
+
+/**
+ * Embed an array of texts. Batches large inputs to respect server limits.
+ * Returns vectors tagged with their `{ provider, model, dimensions }`.
+ *
+ * @throws if the provider/config is invalid, the HTTP request fails, the
+ *         response is malformed, or the returned vectors are inconsistent in
+ *         dimensionality (which would silently break similarity search).
+ */
+export async function embed(
+  texts: string[],
+  config?: EmbeddingConfig,
+): Promise<EmbeddingResult> {
+  const cfg = resolveConfig(config)
+  if (texts.length === 0) {
+    return { provider: cfg.provider, model: cfg.model, dimensions: cfg.dimensions ?? 0, vectors: [] }
+  }
+
+  const vectors: number[][] = []
+  for (let i = 0; i < texts.length; i += cfg.batchSize) {
+    const batch = texts.slice(i, i + cfg.batchSize)
+    vectors.push(...(await requestEmbeddings(cfg, batch)))
+  }
+
+  const dimensions = vectors[0]?.length ?? 0
+  for (const v of vectors) {
+    if (v.length !== dimensions) {
+      throw new Error(
+        `Inconsistent embedding dimensions from ${cfg.model}: got ${v.length}, expected ${dimensions}`,
+      )
+    }
+  }
+  if (cfg.dimensions != null && dimensions !== cfg.dimensions) {
+    throw new Error(
+      `Model ${cfg.model} returned ${dimensions}-dim vectors but ${cfg.dimensions} were requested`,
+    )
+  }
+
+  return { provider: cfg.provider, model: cfg.model, dimensions, vectors }
+}
+
+/** Convenience: embed a single text and return its vector + space. */
+export async function embedOne(
+  text: string,
+  config?: EmbeddingConfig,
+): Promise<SingleEmbeddingResult> {
+  const res = await embed([text], config)
+  return {
+    provider: res.provider,
+    model: res.model,
+    dimensions: res.dimensions,
+    vector: res.vectors[0],
+  }
+}
+
+async function requestEmbeddings(cfg: ResolvedConfig, batch: string[]): Promise<number[][]> {
+  let res: Response
+  try {
+    res = await cfg.fetchImpl(`${cfg.baseUrl}/embeddings`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(cfg.apiKey ? { Authorization: `Bearer ${cfg.apiKey}` } : {}),
+      },
+      body: JSON.stringify({
+        model: cfg.model,
+        input: batch,
+        ...(cfg.dimensions ? { dimensions: cfg.dimensions } : {}),
+      }),
+    })
+  } catch (err) {
+    const hint =
+      cfg.provider === 'local'
+        ? ` (is llama-server --embedding running at ${cfg.baseUrl}?)`
+        : ''
+    throw new Error(
+      `Embedding request to ${cfg.provider} failed: ${err instanceof Error ? err.message : String(err)}${hint}`,
+    )
+  }
+
+  if (!res.ok) {
+    throw new Error(
+      `Embedding request to ${cfg.provider} failed: ${res.status} ${await safeText(res)}`,
+    )
+  }
+
+  const json = (await res.json()) as { data?: Array<{ embedding?: number[]; index?: number }> }
+  if (!json || !Array.isArray(json.data)) {
+    throw new Error(`Unexpected embeddings response shape from ${cfg.provider}`)
+  }
+  // Preserve input order (OpenAI returns `index`; sort defensively).
+  return json.data
+    .slice()
+    .sort((a, b) => (a.index ?? 0) - (b.index ?? 0))
+    .map((d) => {
+      if (!Array.isArray(d.embedding)) {
+        throw new Error(`Embedding item missing an "embedding" array (${cfg.provider})`)
+      }
+      return d.embedding
+    })
+}
+
+async function safeText(res: Response): Promise<string> {
+  try {
+    return (await res.text()).slice(0, 500)
+  } catch {
+    return '<no body>'
+  }
+}
+
+// ============================================================================
+// Comparability guard — the same-model-per-corpus invariant
+// ============================================================================
+
+/** Stable id for an embedding space; equal ids ⇒ comparable vectors. */
+export function embeddingSpaceId(space: EmbeddingSpace): string {
+  return `${space.provider}:${space.model}:${space.dimensions}`
+}
+
+/**
+ * Throw unless `actual` belongs to the same embedding space as `expected`.
+ * Use when inserting into or querying a vector index that was built with a
+ * known space — mixing models silently returns garbage rankings.
+ */
+export function assertSameSpace(expected: EmbeddingSpace, actual: EmbeddingSpace): void {
+  if (embeddingSpaceId(expected) !== embeddingSpaceId(actual)) {
+    throw new Error(
+      `Embedding space mismatch: this corpus was built with ` +
+        `${embeddingSpaceId(expected)}, but the new embedding is ` +
+        `${embeddingSpaceId(actual)}. Vectors from different models are not ` +
+        `comparable — re-embed the corpus with one model, or query with the ` +
+        `model the index was built with.`,
+    )
+  }
+}

--- a/ui/src/lib/harness-patterns/README.md
+++ b/ui/src/lib/harness-patterns/README.md
@@ -1063,7 +1063,7 @@ harness-patterns/
 ├── tools.server.ts         # Tools() — groups MCP tools by namespace
 ├── harness.server.ts       # harness(), resumeHarness(), continueSession() — all accept onEvent? callback
 ├── routing.server.ts       # BAML router integration (routeMessageOp)
-├── mcp-client.server.ts    # callTool(), listTools(); demotes `"<ToolName> Error:"` text results to `success:false` (issue #50)
+├── mcp-client.server.ts    # callTool(), listTools(); demotes `"<ToolName> Error:"` text results to `success:false` (issue #50); aggregates multi-text-block results into an array (single block stays scalar) so multi-value tools like Redis `smembers`/`lrange` don't drop all but the first element
 ├── baml-adapters.server.ts # Adapter factories: createLoopControllerAdapter, createNeo4jController, createActorControllerAdapter, createCriticAdapter, describeToolResultOp, etc.
 ├── summarize.server.ts     # scheduleSummarization() — background tool result summarization via DescribeFallback
 ├── token-budget.server.ts  # trimToFit(), getContextWindow(), estimateTokens() — rolling context window

--- a/ui/src/lib/harness-patterns/mcp-client.server.ts
+++ b/ui/src/lib/harness-patterns/mcp-client.server.ts
@@ -114,17 +114,42 @@ export async function callTool(
   try {
     const result = await withReconnect((c) => c.callTool({ name, arguments: args }));
 
-    // Extract text content
+    // Extract text content. Some MCP servers return ONE text block PER element
+    // (Redis `smembers`/`lrange`, search-style tools); the previous `.find`
+    // kept only the first block and silently dropped the rest. Collect all text
+    // blocks: a single block keeps its scalar shape (unchanged — preserves
+    // `json_get` and every existing single-value tool); multiple blocks become
+    // an array. Only the previously-lossy multi-block case changes behavior.
     if (result.content && Array.isArray(result.content)) {
-      const textContent = result.content.find((c) => c.type === 'text');
-      if (textContent && 'text' in textContent) {
-        const demoted = demoteErrorString(textContent.text);
+      const textItems = result.content.filter(
+        (c): c is { type: 'text'; text: string } =>
+          c.type === 'text' && typeof (c as { text?: unknown }).text === 'string'
+      );
+
+      if (textItems.length === 1) {
+        const { text } = textItems[0];
+        const demoted = demoteErrorString(text);
         if (demoted) return demoted;
         try {
-          return { success: true, data: JSON.parse(textContent.text) };
+          return { success: true, data: JSON.parse(text) };
         } catch {
-          return { success: true, data: textContent.text };
+          return { success: true, data: text };
         }
+      }
+
+      if (textItems.length > 1) {
+        // A failure is still reported as a single leading block in practice, so
+        // check the first block before treating this as a multi-value success.
+        const demoted = demoteErrorString(textItems[0].text);
+        if (demoted) return demoted;
+        const data = textItems.map((t) => {
+          try {
+            return JSON.parse(t.text);
+          } catch {
+            return t.text;
+          }
+        });
+        return { success: true, data };
       }
     }
 

--- a/ui/src/lib/stash/http.server.ts
+++ b/ui/src/lib/stash/http.server.ts
@@ -1,0 +1,54 @@
+/**
+ * Data Stash HTTP helpers — Server Only
+ *
+ * Shared auth + response helpers for the Data Stash upload routes
+ * (`/api/stash/upload`, `/api/stash/document/:id`). Mirrors the auth posture
+ * of the existing `routes/api/stash.ts` (dev-bypass aware) so the upload path
+ * and the hide/archive path gate access the same way.
+ */
+
+import { assertServerOnImport } from '../harness-patterns/assert.server'
+import { getAuthenticatedUser } from '../auth/server'
+import { BYPASS_USER, isBypassEnabled } from '../auth/dev-bypass'
+
+assertServerOnImport()
+
+/** Resolve the current user id, honouring the dev-bypass switch. */
+export async function requireUserId(): Promise<string> {
+  if (isBypassEnabled()) return BYPASS_USER.id
+  return (await getAuthenticatedUser()).id
+}
+
+/** JSON response with the right content-type. */
+export function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+/**
+ * Run a handler with an authenticated user id, returning a 401 JSON response
+ * if authentication fails. Keeps each route handler free of the try/catch
+ * auth boilerplate.
+ *
+ * Note: documents are keyed by `sessionId` (an unguessable UUID) and access is
+ * gated on authentication. Per-session ownership verification (as `stash.ts`
+ * does via `loadSession`) is intentionally not enforced here because uploads
+ * can precede the session's first persisted turn; layer it on if uploads are
+ * ever guaranteed post-session-creation.
+ */
+export async function withUser(
+  fn: (userId: string) => Promise<Response>,
+): Promise<Response> {
+  let userId: string
+  try {
+    userId = await requireUserId()
+  } catch (err) {
+    return json(
+      { error: err instanceof Error ? err.message : 'Unauthorized' },
+      401,
+    )
+  }
+  return fn(userId)
+}

--- a/ui/src/lib/stash/upload-service.server.ts
+++ b/ui/src/lib/stash/upload-service.server.ts
@@ -1,0 +1,99 @@
+/**
+ * Data Stash Upload Service — Server Only
+ *
+ * Request-parsing for the `POST /api/stash/upload` route, kept separate from
+ * the route handler so it is unit-testable without spinning up the router.
+ *
+ * Two intake shapes are supported:
+ *   - `multipart/form-data` with a `file` field (+ optional `sessionId`) — the
+ *     browser file-picker / drag-drop path.
+ *   - `application/json` `{ sessionId, filename, mimeType, content, ttlSeconds? }`
+ *     — the programmatic path (and what #89 / the sandbox lane can call).
+ *
+ * Both yield a {@link StoreDocumentInput} for `document-store.server.ts`. Binary
+ * formats (PDF, xlsx, …) are decoded as UTF-8 text here — true text extraction
+ * is left to the caller, matching the document-store contract ("`content` is
+ * opaque UTF-8 text").
+ */
+
+import { assertServerOnImport } from '../harness-patterns/assert.server'
+import type { StoreDocumentInput } from '../document-store.server'
+
+assertServerOnImport()
+
+/** Extension → MIME fallback for uploads that arrive without a usable type. */
+const MIME_BY_EXT: Record<string, string> = {
+  txt: 'text/plain',
+  md: 'text/markdown',
+  markdown: 'text/markdown',
+  json: 'application/json',
+  csv: 'text/csv',
+  tsv: 'text/tab-separated-values',
+  html: 'text/html',
+  htm: 'text/html',
+  xml: 'application/xml',
+  yaml: 'application/yaml',
+  yml: 'application/yaml',
+  log: 'text/plain',
+}
+
+/** Best-effort MIME from a filename extension; defaults to `text/plain`. */
+export function guessMimeType(filename: string): string {
+  const dot = filename.lastIndexOf('.')
+  if (dot < 0 || dot === filename.length - 1) return 'text/plain'
+  const ext = filename.slice(dot + 1).toLowerCase()
+  return MIME_BY_EXT[ext] ?? 'text/plain'
+}
+
+/**
+ * Parse an upload request body into a {@link StoreDocumentInput}.
+ * @throws Error (message safe to surface as a 400) on malformed input.
+ */
+export async function parseUploadRequest(
+  request: Request,
+): Promise<StoreDocumentInput> {
+  const contentType = request.headers.get('content-type') ?? ''
+
+  if (contentType.includes('multipart/form-data')) {
+    const form = await request.formData()
+    const file = form.get('file')
+    // Duck-type rather than `instanceof File`: the runtime and test (jsdom)
+    // realms can hand back File objects from different constructors, so an
+    // instanceof check is unreliable. A Blob/File exposes async `text()`.
+    if (file == null || typeof file === 'string' || typeof (file as Blob).text !== 'function') {
+      throw new Error('multipart upload requires a "file" field')
+    }
+    const blob = file as File
+    const sessionId = String(form.get('sessionId') ?? '').trim()
+    const filename = blob.name || 'upload'
+    const ttlRaw = form.get('ttlSeconds')
+    const ttlSeconds =
+      ttlRaw != null && ttlRaw !== '' ? Number(ttlRaw) : undefined
+    return {
+      sessionId,
+      filename,
+      mimeType: blob.type || guessMimeType(filename),
+      content: await blob.text(),
+      ...(Number.isFinite(ttlSeconds) ? { ttlSeconds } : {}),
+    }
+  }
+
+  // Default: JSON body.
+  let body: Partial<StoreDocumentInput>
+  try {
+    body = (await request.json()) as Partial<StoreDocumentInput>
+  } catch {
+    throw new Error('Request body must be JSON or multipart/form-data')
+  }
+  if (typeof body.content !== 'string') {
+    throw new Error('content (string) is required')
+  }
+  const filename = body.filename?.trim() || 'upload.txt'
+  return {
+    sessionId: String(body.sessionId ?? '').trim(),
+    filename,
+    mimeType: body.mimeType?.trim() || guessMimeType(filename),
+    content: body.content,
+    ...(typeof body.ttlSeconds === 'number' ? { ttlSeconds: body.ttlSeconds } : {}),
+  }
+}

--- a/ui/src/routes/api/stash/document/[id].ts
+++ b/ui/src/routes/api/stash/document/[id].ts
@@ -1,0 +1,63 @@
+/**
+ * Data Stash single-document API (Issue #6)
+ *
+ *   GET    /api/stash/document/:id?sessionId  — full document (content + meta)
+ *   DELETE /api/stash/document/:id?sessionId  — remove from Redis + index
+ *   PATCH  /api/stash/document/:id            — toggle hide/archive flags
+ *                                               body: { sessionId, hidden?, archived? }
+ *
+ * Documents are keyed by (sessionId, id); the session is supplied as a query
+ * param (GET/DELETE) or in the JSON body (PATCH).
+ */
+
+import type { APIEvent } from '@solidjs/start/server'
+import {
+  getDocument,
+  deleteDocument,
+  setDocumentFlags,
+} from '../../../../lib/document-store.server'
+import { json, withUser } from '../../../../lib/stash/http.server'
+
+function sessionParam(event: APIEvent): string | null {
+  return new URL(event.request.url).searchParams.get('sessionId')
+}
+
+export async function GET(event: APIEvent) {
+  return withUser(async () => {
+    const sessionId = sessionParam(event)
+    if (!sessionId) return json({ error: 'sessionId is required' }, 400)
+    const doc = await getDocument(sessionId, event.params.id)
+    if (!doc) return json({ error: 'Document not found' }, 404)
+    return json({ document: doc })
+  })
+}
+
+export async function DELETE(event: APIEvent) {
+  return withUser(async () => {
+    const sessionId = sessionParam(event)
+    if (!sessionId) return json({ error: 'sessionId is required' }, 400)
+    await deleteDocument(sessionId, event.params.id)
+    return json({ ok: true })
+  })
+}
+
+export async function PATCH(event: APIEvent) {
+  return withUser(async () => {
+    let body: { sessionId?: string; hidden?: boolean; archived?: boolean }
+    try {
+      body = await event.request.json()
+    } catch {
+      return json({ error: 'Request body must be JSON' }, 400)
+    }
+    if (!body.sessionId) return json({ error: 'sessionId is required' }, 400)
+
+    const updated = await setDocumentFlags(body.sessionId, event.params.id, {
+      hidden: body.hidden,
+      archived: body.archived,
+    })
+    if (!updated) return json({ error: 'Document not found' }, 404)
+    const { content: _content, ...meta } = updated
+    void _content
+    return json({ ok: true, document: meta })
+  })
+}

--- a/ui/src/routes/api/stash/ingest.ts
+++ b/ui/src/routes/api/stash/ingest.ts
@@ -1,0 +1,49 @@
+/**
+ * Data Stash Ingest API (#8/#9)
+ *
+ *   POST /api/stash/ingest  — chunk → embed → index a stored document for search
+ *     body: { sessionId, docId, chunk?, embedding?, allowSpaceChange? }
+ *
+ * Ingestion is an explicit step (not auto-run on upload): it requires an
+ * embedding backend (local llama-server :8090 by default) and binds the
+ * session's corpus to one embedding model. See document-ingest.server.ts.
+ */
+
+import type { APIEvent } from '@solidjs/start/server'
+import { getDocument } from '../../../lib/document-store.server'
+import { ingestDocument } from '../../../lib/document-ingest.server'
+import { json, withUser } from '../../../lib/stash/http.server'
+
+export async function POST(event: APIEvent) {
+  return withUser(async () => {
+    let body: {
+      sessionId?: string
+      docId?: string
+      chunk?: Record<string, unknown>
+      embedding?: Record<string, unknown>
+      allowSpaceChange?: boolean
+    }
+    try {
+      body = await event.request.json()
+    } catch {
+      return json({ error: 'Request body must be JSON' }, 400)
+    }
+    if (!body.sessionId || !body.docId) {
+      return json({ error: 'sessionId and docId are required' }, 400)
+    }
+
+    const doc = await getDocument(body.sessionId, body.docId)
+    if (!doc) return json({ error: 'Document not found' }, 404)
+
+    try {
+      const result = await ingestDocument(doc, {
+        chunk: body.chunk,
+        embedding: body.embedding,
+        allowSpaceChange: body.allowSpaceChange,
+      })
+      return json({ ok: true, ...result })
+    } catch (err) {
+      return json({ error: err instanceof Error ? err.message : 'Ingest failed' }, 500)
+    }
+  })
+}

--- a/ui/src/routes/api/stash/search.ts
+++ b/ui/src/routes/api/stash/search.ts
@@ -1,0 +1,32 @@
+/**
+ * Data Stash Search API (#8)
+ *
+ *   GET /api/stash/search?sessionId=&q=&k=  — KNN similarity over a session's
+ *     ingested chunks. The query is embedded with the same model the corpus was
+ *     ingested with (enforced in document-ingest.server.ts); returns [] when
+ *     nothing has been ingested for the session.
+ */
+
+import type { APIEvent } from '@solidjs/start/server'
+import { searchDocuments } from '../../../lib/document-ingest.server'
+import { json, withUser } from '../../../lib/stash/http.server'
+
+export async function GET(event: APIEvent) {
+  return withUser(async () => {
+    const url = new URL(event.request.url)
+    const sessionId = url.searchParams.get('sessionId')
+    const q = url.searchParams.get('q')
+    const kRaw = url.searchParams.get('k')
+    if (!sessionId || !q) {
+      return json({ error: 'sessionId and q are required' }, 400)
+    }
+    const k = kRaw && Number.isFinite(Number(kRaw)) ? Number(kRaw) : undefined
+
+    try {
+      const hits = await searchDocuments(sessionId, q, { k })
+      return json({ hits })
+    } catch (err) {
+      return json({ error: err instanceof Error ? err.message : 'Search failed' }, 500)
+    }
+  })
+}

--- a/ui/src/routes/api/stash/upload.ts
+++ b/ui/src/routes/api/stash/upload.ts
@@ -1,0 +1,55 @@
+/**
+ * Data Stash Upload API (Issue #6)
+ *
+ *   POST /api/stash/upload          — store an uploaded document in Redis
+ *   GET  /api/stash/upload?sessionId — list a session's uploaded documents (meta)
+ *
+ * Storage is delegated to `document-store.server.ts`; this route only handles
+ * intake (multipart or JSON), auth, and shaping the HTTP response. Companion
+ * routes for a single document live in `stash/document/[id].ts`.
+ */
+
+import type { APIEvent } from '@solidjs/start/server'
+import {
+  storeDocument,
+  listDocuments,
+} from '../../../lib/document-store.server'
+import { parseUploadRequest } from '../../../lib/stash/upload-service.server'
+import { json, withUser } from '../../../lib/stash/http.server'
+
+export async function POST(event: APIEvent) {
+  return withUser(async () => {
+    let input
+    try {
+      input = await parseUploadRequest(event.request)
+    } catch (err) {
+      return json(
+        { error: err instanceof Error ? err.message : 'Invalid upload' },
+        400,
+      )
+    }
+    if (!input.sessionId) return json({ error: 'sessionId is required' }, 400)
+
+    try {
+      const doc = await storeDocument(input)
+      // Return metadata only — the client already has the content it uploaded,
+      // and full inlining bloats the response.
+      const { content: _content, ...meta } = doc
+      void _content
+      return json({ ok: true, document: meta }, 201)
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Upload failed'
+      // Size-limit rejections from the store map to 413; everything else 500.
+      return json({ error: msg }, /too large/i.test(msg) ? 413 : 500)
+    }
+  })
+}
+
+export async function GET(event: APIEvent) {
+  return withUser(async () => {
+    const sessionId = new URL(event.request.url).searchParams.get('sessionId')
+    if (!sessionId) return json({ error: 'sessionId is required' }, 400)
+    const documents = await listDocuments(sessionId)
+    return json({ documents })
+  })
+}


### PR DESCRIPTION
The full Data Stash ingestion pipeline: users can upload documents, which are stored in Redis, chunked, embedded, and made searchable — and surfaced in the panel UI.

## What's included

**#6 — Redis-backed storage + upload path**
- `document-store.server.ts` — RedisJSON document storage (CRUD, TTL, session index), hardened so Redis command-level failures (AUTH/WRONGTYPE returned as success-text) surface instead of silently "succeeding", and `listDocuments` tolerant of the live gateway's `smembers` shapes.
- `POST/GET /api/stash/upload`, `GET/DELETE/PATCH /api/stash/document/[id]` — the net-new upload path (multipart + JSON), `lib/stash/` for parsing + auth helpers.
- `DataStashPanel.tsx` — drag-drop/file-picker upload + document chips (hide/archive/delete).

**#9 — chunking** (`chunking.server.ts`): fixed / sentence / paragraph strategies (overlap, oversized-unit fallback) + MIME-aware routing (CSV row-grouping, JSON pretty-print). Default: paragraph, 1000 chars, 200 overlap.

**#8 — embeddings** (`embeddings.server.ts`): provider-pluggable — local llama-server (`:8090`, Qwen3) default + OpenRouter selectable. **No silent cross-model fallback**; `embed()` returns `{provider, model, dimensions}` and `assertSameSpace()` enforces comparability. One model per session corpus is structural (encoded in the index name + key prefix).

**Ingest/search capstone** (`document-ingest.server.ts`, `/api/stash/ingest`, `/api/stash/search`): chunk → embed → Redis HNSW index, then KNN query embedded with the corpus's recorded model. Writes are 2 Redis calls/chunk (vector + base64 `meta`) — minimal because the gateway runs the redis MCP over serial stdio.

**Harness fix** (`mcp-client.server.ts`): `callTool` now aggregates multiple text content blocks into an array instead of keeping only the first — multi-value Redis tools (`smembers`, `lrange`, search) were silently dropping all but the first element. Single-block behavior is unchanged. *Note: this touches the same file as the sandbox ALS dispatch but a different (result-parsing) section — conflict-free.*

**Docs** (`docs/DATA_STASH.md` + INDEX/CLAUDE/UI_ARCHITECTURE/READMEs): pipeline architecture, API routes, Redis storage model, the one-model-per-corpus rule, and the redis-stack + local-embedder requirements / gateway quirks.

## Verification
- `pnpm exec tsc --noEmit`: no new errors (26, == main baseline).
- `pnpm test:run`: **803 pass** (+54 new across chunking/embeddings/ingest/upload/redis-error).
- **Live, full pipeline** (gateway + local Qwen3 embedder, 1024d): upload → store → list → get → hide → delete, and chunk → embed → HNSW index → **KNN search** all round-trip.
- **KNN verified by hand**: e.g. *"graph database for relationships"* → Neo4j chunk (cosine distance 0.17) ranked above the Redis chunk (0.49); *"which port does the gateway use"* → the :8811 chunk. Also ingested + searched the real 23-chunk `docs/MCP_GATEWAY.md` with topically-correct hits, redis stable. (Ranking is decent-not-perfect — Qwen3-0.6B is a small model. The live-KNN check is by eye; unit tests use a fake `vector_search_hash`.)

## Environment note (infra, not code)
redis-stack's **arm64 `redisearch.so` SIGILL-crashes** on the Apple-Silicon/colima dev VM during vector ops (a CPU instruction the VM doesn't expose) — both `7.4.0-v8` and `7.2.0-v13`. RedisJSON/store is unaffected; only RediSearch. **Workaround that works:** run the redis service as `platform: linux/amd64` (emulated) via a git-ignored `docker-compose.override.yml` — verified stable, full KNN pipeline round-trips. Long-term cleaner fix: colima CPU passthrough (`--vm-type vz`). #89's `/work` materialization only needs store/retrieve, so it isn't blocked by this regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)