### PR TITLE
fix(code-mode): synth URL fidelity, critic provenance, script-output hints

### DIFF
--- a/ui/baml_src/actorCritic.baml
+++ b/ui/baml_src/actorCritic.baml
@@ -116,6 +116,25 @@ function Critic(
     1. Does the output contain the needed information?
     2. Is the data complete enough to form a response?
     3. Did errors prevent answering the intent?
+    4. PROVENANCE: if a result carries a `_source` field (e.g.
+       {"server": ..., "tool": ...}), check it came from the source the intent
+       asks for. When the intent names a specific store ("the neo4j db", "the
+       memory graph", a particular API) and `_source.server` is a DIFFERENT
+       store, the result is NOT sufficient — the answer came from the wrong
+       place. Steer the actor to scope to the correct server rather than
+       accepting it. (No `_source` field? Skip this check.)
+    5. TRUTHFULNESS over completeness: a truthful empty or negative result that
+       faithfully answers the intent IS sufficient. If the correct source
+       genuinely holds no matching data, accept that — do NOT loop demanding
+       results that don't exist; that only pressures the actor into fabricating.
+       An honest "nothing found" beats an invented answer.
+
+    On a DEGENERATE result (wrong store, a blocked/bot-detected fetch, or output
+    that looks invented), steer the actor toward a valid alternative source via
+    suggested_approach — don't reject sound work, and don't accept fabrication.
+
+    Don't be a pedantic QA gate: minor formatting or stylistic gaps are not
+    grounds for another loop when the substantive information is present.
 
     IF SUFFICIENT: set is_sufficient=true, explain why. Leave suggested_approach null.
     IF NOT SUFFICIENT: set is_sufficient=false, explain what is missing, provide specific guidance.

--- a/ui/baml_src/synthesizer.baml
+++ b/ui/baml_src/synthesizer.baml
@@ -40,6 +40,20 @@ function Synthesize(
     {{ _.role("user") }}
     Synthesize the above into a helpful response.
 
+    FIDELITY — do not fabricate:
+    - Cite ONLY links/URLs that appear verbatim in the TOOL EXECUTION results
+      above. Never invent, guess, or substitute a URL — do NOT replace a blocked
+      or missing page with a "related" link the results don't contain (e.g. a
+      docs homepage or a schema.org link). If a result carries no URL for an
+      item, say so plainly; don't supply one.
+    - If a result includes a URL but the page could not be fetched (a 403 /
+      Forbidden / "could not fetch" / error appears in place of the content),
+      STILL show that original URL and note it couldn't be fetched. Do not drop
+      it and do not swap in a different link.
+    - Every name, number, and fact in your response must trace to the results
+      above. When the data is missing, empty, or negative, report that honestly
+      rather than filling the gap.
+
     GUIDELINES:
     - Be concise but informative
     - Highlight key findings and relationships

--- a/ui/src/__tests__/agents/code-mode-fidelity.test.ts
+++ b/ui/src/__tests__/agents/code-mode-fidelity.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Code Mode Agent — refinement themes (synth fidelity, critic provenance,
+ * script-hygiene guidance). See the `code-mode-refinement` lane.
+ *
+ * Captured failure (.harness-logs/context-verywell.json): a code-mode script
+ * returned 3 nodes with web summaries; one page 403'd. The synth DROPPED the
+ * real `verywellmind.com` URL and FABRICATED `schema.org` / `neo4j docs` links
+ * that never appeared in the tool result.
+ *
+ * Two behavioral guards here:
+ *  1. (Theme 3) the output-shape / script-hygiene guidance reaches the actor
+ *     prompt (search/fetch return TEXT, never JSON.parse; keep the URL on a
+ *     failed fetch).
+ *  2. (Theme 1) the real URLs — including the 403'd one — are present in the
+ *     `turns` the synthesizer receives, so the prompt's FIDELITY rule has the
+ *     genuine links to cite instead of inventing substitutes.
+ *
+ * Plus prompt-content guards that the FIDELITY / PROVENANCE / TRUTHFULNESS
+ * rules stay on the committed BAML templates.
+ *
+ * Isolated from code-mode.test.ts (mirrors code-mode-catalog.test.ts) so this
+ * file can mock getServerCatalog's deps without disturbing that file's queues.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { readFileSync, existsSync } from 'node:fs'
+import path from 'node:path'
+import { mockAction, mockCriticResult } from '../mocks/baml'
+import { mockCallTool, mockListTools } from '../mocks/mcp'
+
+const META = ['mcp-find', 'mcp-add', 'code-mode', 'mcp-exec']
+const NEO4J = ['read_neo4j_cypher', 'write_neo4j_cypher', 'get_neo4j_schema']
+const mockToolSets = { code: [...META], all: [...META] }
+
+// Mirrors the shape of .harness-logs/context-verywell.json's winning turn:
+// one URL fetched fine, one 403'd (URL still present), one with no URL.
+const VERYWELL_PAYLOAD = {
+  _source: { tool: 'read_neo4j_cypher', server: 'neo4j-cypher' },
+  summaries: [
+    {
+      url: 'https://redis.io/tutorials/what-is-redis/',
+      node: 'Redis',
+      degree: 17,
+      summary: 'What is Redis? In-memory data structure store used as a database, cache, and message broker.',
+    },
+    {
+      url: 'https://www.verywellmind.com/what-is-a-schema-2795873',
+      node: 'Schema',
+      degree: 12,
+      summary: "Error: Could not access the webpage (Client error '403 Forbidden' for url 'https://www.verywellmind.com/what-is-a-schema-2795873')",
+    },
+    {
+      url: null,
+      node: 'Animal',
+      degree: 10,
+      summary: 'No results were found for your search query.',
+    },
+  ],
+}
+
+vi.mock('../../lib/harness-patterns/assert.server', () => ({
+  assertServerOnImport: vi.fn(),
+}))
+
+const callToolMock = mockCallTool({
+  responses: {
+    'code-mode': { tool_name: 'code-mode-neo4j_web_analysis' },
+    'code-mode-neo4j_web_analysis': VERYWELL_PAYLOAD,
+  },
+})
+
+vi.mock('../../lib/harness-patterns/mcp-client.server', () => ({
+  callTool: callToolMock,
+  listTools: mockListTools([...NEO4J, ...META]),
+}))
+
+const actorController = vi.fn()
+const critic = vi.fn()
+const router = vi.fn()
+const synthesize = vi.fn()
+
+vi.mock('../../../baml_client', () => ({
+  b: {
+    LoopController: vi.fn(),
+    ActorController: actorController,
+    Critic: critic,
+    Router: router,
+    Synthesize: synthesize,
+    ResultDescribe: vi.fn(async () => ''),
+  },
+}))
+
+vi.mock('@boundaryml/baml', () => {
+  class MockCollector {
+    last = { rawLlmResponse: 'raw', usage: { inputTokens: 10, outputTokens: 5 }, calls: [{ httpRequest: { body: {} } }] }
+    constructor(_name?: string) {}
+  }
+  class BamlValidationError extends Error {}
+  return { Collector: MockCollector, BamlValidationError }
+})
+
+vi.mock('../../lib/harness-patterns/tools.server', () => ({
+  Tools: vi.fn(async () => mockToolSets),
+  ToolsFrom: vi.fn(() => mockToolSets),
+  inferServer: (n: string) => n,
+}))
+
+vi.mock('../../lib/harness-client/session.server', () => ({
+  loadSession: vi.fn(async () => null),
+}))
+vi.mock('../../lib/harness-client/request-user.server', () => ({
+  getRequestUserId: vi.fn(() => null),
+  runWithUserId: (_uid: string, fn: () => Promise<unknown>) => fn(),
+}))
+
+describe('code-mode agent — synth fidelity + script-hygiene guidance', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    router.mockResolvedValue({ intent: 'query the neo4j db', needs_tool: true, route: 'code_mode', response: '' })
+    // One actor turn: invoke a code-mode-* tool that returns the payload.
+    // Matches dynamicToolPattern /^code-mode-/ so the loop dispatches it.
+    actorController.mockResolvedValue(
+      mockAction({
+        reasoning: 'Run the analysis script against neo4j-cypher + web_search.',
+        tool_name: 'code-mode-neo4j_web_analysis',
+        tool_args: JSON.stringify({ script: 'return out;' }),
+      }),
+    )
+    critic.mockResolvedValue(mockCriticResult({ is_sufficient: true }))
+    synthesize.mockResolvedValue('done')
+  })
+
+  afterEach(() => {
+    vi.resetModules()
+  })
+
+  it('folds the output-shape / script-hygiene guidance into the actor context (Theme 3)', async () => {
+    const { codeModeAgent } = await import('../../lib/harness-client/examples/code-mode.server')
+    const { harness } = await import('../../lib/harness-patterns/harness.server')
+
+    const patterns = await codeModeAgent.createPatterns('test-session')
+    const agent = harness(...patterns)
+    await agent('Fetch the 3 most connected nodes in the neo4j db and summarize web pages.')
+
+    expect(actorController).toHaveBeenCalled()
+    // ActorController(user_message, intent, tools, attempts, context, …) → ctx is arg[4].
+    const context = actorController.mock.calls[0][4] as string
+    // search/fetch return text, not JSON — the recurring JSON.parse turn-burner.
+    expect(context).toContain('JSON.parse')
+    expect(context).toContain('TEXT')
+    // Keep the URL on a failed fetch — the bridge to synth fidelity.
+    expect(context).toContain('fetch_content')
+  })
+
+  it('passes the real URLs (incl. the 403\'d one) into the synthesizer turns (Theme 1)', async () => {
+    const { codeModeAgent } = await import('../../lib/harness-client/examples/code-mode.server')
+    const { harness } = await import('../../lib/harness-patterns/harness.server')
+
+    const patterns = await codeModeAgent.createPatterns('test-session')
+    const agent = harness(...patterns)
+    await agent('Fetch the 3 most connected nodes in the neo4j db, summarize each, and link the page.')
+
+    // Synthesize(userMessage, intent, turns, hasError, errorMessage) → turns is arg[2].
+    expect(synthesize).toHaveBeenCalledTimes(1)
+    const turnsArg = synthesize.mock.calls[0][2] as unknown[]
+    const turnsJson = JSON.stringify(turnsArg)
+
+    // The fetched page's URL is in view.
+    expect(turnsJson).toContain('https://redis.io/tutorials/what-is-redis/')
+    // The 403'd page's ORIGINAL URL is still in view — the synth must cite it
+    // (with a "couldn't fetch" note), not drop it or substitute a link.
+    expect(turnsJson).toContain('https://www.verywellmind.com/what-is-a-schema-2795873')
+    expect(turnsJson).toContain('403')
+    // Provenance the critic checks is present too.
+    expect(turnsJson).toContain('neo4j-cypher')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Prompt-content guards: the refinement rules must stay on the committed BAML
+// templates. process.cwd() is the `ui/` dir, so baml_src is one level up
+// (mirrors server-catalog.server.ts / baml-adapters.server.ts path resolution).
+// ---------------------------------------------------------------------------
+
+function readBamlSrc(file: string): string {
+  const candidates = [
+    path.resolve(process.cwd(), '..', 'baml_src', file),
+    path.resolve(process.cwd(), 'baml_src', file),
+  ]
+  const found = candidates.find((p) => existsSync(p))
+  if (!found) throw new Error(`baml_src/${file} not found (cwd=${process.cwd()})`)
+  return readFileSync(found, 'utf8')
+}
+
+describe('code-mode refinement — BAML prompt guardrails', () => {
+  it('Synthesize carries the FIDELITY block (cite-only-real-URLs, keep URL on fetch fail)', () => {
+    const src = readBamlSrc('synthesizer.baml')
+    expect(src).toContain('FIDELITY')
+    expect(src).toContain('verbatim')
+    // Never invent/substitute links; keep the original URL on a failed fetch.
+    expect(src).toMatch(/never invent|do NOT replace|substitute/i)
+    expect(src).toMatch(/could not be fetched|couldn't be fetched|403/i)
+  })
+
+  it('Critic consumes _source provenance and accepts truthful-empty results', () => {
+    const src = readBamlSrc('actorCritic.baml')
+    expect(src).toContain('_source')
+    expect(src).toContain('PROVENANCE')
+    expect(src).toContain('TRUTHFULNESS')
+    // Steers on degenerate results rather than being a pedantic gate.
+    expect(src).toMatch(/pedantic/i)
+  })
+})

--- a/ui/src/lib/harness-client/examples/code-mode.server.ts
+++ b/ui/src/lib/harness-client/examples/code-mode.server.ts
@@ -91,12 +91,25 @@ The kg-agent gateway exposes a "code-mode" factory tool. Use it to:
    (multiple tool calls + transforms + aggregations) instead of one
    round-trip per operation — that is the leverage.
 
-5. RECORD PROVENANCE. Have each script return
+5. TOOL OUTPUT SHAPES & SCRIPT HYGIENE. Inside a script every tool returns a
+   STRING. Graph/Cypher reads (read_neo4j_cypher, get_neo4j_schema, read_graph,
+   search_nodes) return JSON strings — JSON.parse is safe. Web search (search)
+   and fetch_content return human-readable TEXT, not JSON — NEVER JSON.parse
+   them; pull URLs/snippets out with plain string ops. Prefer .indexOf() /
+   .slice() / .split() / .includes() over regex literals: backslash escaping
+   inside the script string is the #1 cause of "Unexpected token" failures.
+   Wrap every fetch_content in try/catch; on failure KEEP the page's URL in the
+   output with a short "could not fetch" note — never drop the URL (the answer
+   still needs the link).
+
+6. RECORD PROVENANCE. Have each script return
    { _source: { server, tool }, result: ... } so the answer can be verified
    against the store the user asked for.
 
-6. LET THE CRITIC DECIDE COMPLETION. You don't need a Return tool — the
-   critic evaluates each result and ends the loop when sufficient.
+7. LET THE CRITIC DECIDE COMPLETION. You don't need a Return tool — the
+   critic evaluates each result and ends the loop when sufficient. A truthful
+   empty result (the store really has no match) is a complete answer — report
+   it honestly instead of inventing data to look complete.
 `.trim();
 
 /**
@@ -134,7 +147,7 @@ const CODE_MODE_FEW_SHOTS: FewShot[] = [
   {
     user: "Find the 2 most-connected nodes in the knowledge graph and search the web for related tech for each.",
     reasoning:
-      "Two servers (memory + web_search) in one script: read graph → count degree from relations → pick top-2 → loop a web search per name. ONE factory tool, ONE script — not four round-trips.",
+      "Two servers (memory + web_search) in one script: read graph → count degree from relations → pick top-2 → web search per name. search() returns TEXT, so pull the first link out with string ops (no JSON.parse, no regex). ONE factory tool, ONE script — not four round-trips.",
     tool: "code-mode-graph_web_analysis",
     args: JSON.stringify({
       script: [
@@ -142,8 +155,14 @@ const CODE_MODE_FEW_SHOTS: FewShot[] = [
         "const deg = new Map();",
         "for (const r of g.relations) { deg.set(r.from, (deg.get(r.from)||0)+1); deg.set(r.to, (deg.get(r.to)||0)+1); }",
         "const top2 = [...deg.entries()].sort((a,b)=>b[1]-a[1]).slice(0,2).map(([n])=>n);",
-        "const out = { _source: { server: 'memory', tool: 'read_graph' }, top_nodes: top2, searches: {} };",
-        "for (const name of top2) { out.searches[name] = await search({query: name + ' related technologies'}); }",
+        "const out = { _source: { server: 'memory', tool: 'read_graph' }, top_nodes: top2, results: [] };",
+        "for (const name of top2) {",
+        "  const text = await search({ query: name + ' related technologies' });",
+        "  // search returns TEXT — extract the first link with string ops, never JSON.parse",
+        "  const at = text.indexOf('http');",
+        "  const url = at >= 0 ? text.slice(at).split(' ')[0].split('\\n')[0] : null;",
+        "  out.results.push({ node: name, url, snippet: text.slice(0, 500) });",
+        "}",
         "return out;",
       ].join("\n"),
     }),

--- a/ui/src/lib/harness-client/examples/code_mode_actor_critic.md
+++ b/ui/src/lib/harness-client/examples/code_mode_actor_critic.md
@@ -55,14 +55,17 @@ Three additions to the generic `ActorController` BAML function
 
 ### What the guidance teaches
 
-The prelude covers four behaviors, in priority order:
+`CODE_MODE_ACTOR_GUIDANCE` covers seven behaviors, in priority order:
 
 | # | Rule | Why it's there |
 |---|---|---|
 | 1 | Factory protocol: `code-mode {name, servers}` → `code-mode-<name>({script})` | Without this the actor doesn't know the factory step exists and tries `mcp-exec` as a shim. |
-| 2 | Write ONE script that batches multiple operations server-side | The failure case (`hallucination-code-mode.json`) was the actor calling `code-mode-<name>` with `return read_graph({})` — a one-liner that dumped data instead of doing the full pipeline. |
-| 3 | Skip `mcp-find` / `mcp-add` for tools already in `AVAILABLE TOOLS` | The user's per-conversation allowlist pre-loads tools; rediscovery wastes turns. |
-| 4 | Return when done or near budget exhaustion | Combined with the `BUDGET:` line from Decision 3, this lets the actor wrap partial work into a final answer instead of being cut off mid-thought. |
+| 2 | Scope to ENABLED SERVERS — don't re-`mcp-add` an already-enabled server | `mcp-add` can fail a missing-secret check even when the server already works; the up-front catalog (Theme 1) names the servers to scope directly. |
+| 3 | Pick the right store (neo4j-cypher vs memory) and never substitute the other | The original failure (`context-neo4j-vs-memory.json`) queried the near-empty `memory` graph when the user asked for "the neo4j db". |
+| 4 | Write ONE script that batches multiple operations server-side | The failure case (`hallucination-code-mode.json`) was the actor calling `code-mode-<name>` with `return read_graph({})` — a one-liner that dumped data instead of doing the full pipeline. |
+| 5 | Tool output shapes & script hygiene: Cypher/graph reads return JSON; **search/fetch return TEXT — never `JSON.parse` them**; prefer string ops over regex; wrap `fetch_content` in try/catch and keep the URL on failure | The recurring turn-burners (`context-verywell.json` turns 2–3, `context-neo4j-nosecrets.json` turn 7): `JSON.parse` of non-JSON search text, and `^`/`\s` regex escaping breaking inside the JSON-encoded script string. Keeping the URL on a failed fetch also feeds the synthesizer the real link. |
+| 6 | Record provenance: return `{ _source: { server, tool }, result }` | Lets the critic verify the answer came from the store the user asked for (Theme 2) and gives downstream patterns a checkable origin. |
+| 7 | Let the critic decide completion; a truthful empty result is a complete answer | Post-P0 there is no `Return` tool — the critic owns the exit. Inventing data to "look done" is the failure this guards against. |
 
 ---
 
@@ -133,6 +136,35 @@ invented confident-but-fake content over incomplete tool results (see
 Error scoping is naturally bounded by the synthesizer's own view window —
 see the "Error scoping" note in
 [`ui/src/lib/harness-patterns/README.md`](../../harness-patterns/README.md).
+
+### Synthesizer fidelity (no invented links)
+
+The `Synthesize` prompt (`baml_src/synthesizer.baml`) carries a **FIDELITY**
+block: cite only URLs that appear verbatim in the tool results, and on a fetch
+failure keep the original URL with a "couldn't fetch" note rather than dropping
+it or substituting a "related" link. This addresses `context-verywell.json`,
+where a page returned `403 Forbidden`, the synth dropped the real
+`verywellmind.com` URL, and fabricated `schema.org` / `neo4j docs` links absent
+from the results. The block lives on the shared `Synthesize` function (it's a
+universally good anti-hallucination guardrail); the script-side half is item 5
+of `CODE_MODE_ACTOR_GUIDANCE` (keep the URL in the output on a failed fetch), so
+the link is still in the synthesizer's view to cite.
+
+## Critic: provenance & truthfulness
+
+The `Critic` prompt (`baml_src/actorCritic.baml`) consumes the `{_source}` the
+actor emits (item 6 above):
+
+- **Provenance** — if a result carries `_source`, the critic checks it came from
+  the store the intent names; a result from the wrong store (memory when the
+  user asked for neo4j) is rejected *with steering* toward the right server, not
+  accepted. Guards the `context-neo4j-vs-memory.json` false-accept. The check is
+  conditional on a `_source` field being present, so other actorCritic agents
+  (`guardrailed-agent`, the sandbox agents) are unaffected.
+- **Truthfulness over completeness** — a truthful empty/negative result is
+  sufficient; the critic won't loop demanding data that doesn't exist (which
+  only pressures the actor to fabricate). It steers on degenerate results
+  (wrong store, bot-blocked fetch) rather than acting as a pedantic QA gate.
 
 ---
 


### PR DESCRIPTION
## Summary

Refinement pass on the **code-mode agent** now that reachability is solved (#90, merged). Three captured runs surfaced quality gaps once the agent reaches the right store:

- **`context-verywell.json`** — a fetched page returned `403 Forbidden`; the synthesizer **dropped the real URL** (`verywellmind.com/...`) and **fabricated** substitute links (`schema.org`, `neo4j docs`) absent from the tool result.
- **`context-neo4j-vs-memory.json`** — the critic accepted an answer from the `memory` store when the user asked for *"the neo4j db"*.
- **`context-verywell` / `context-neo4j-nosecrets`** — JS turns burned on `JSON.parse` of non-JSON search text and regex backslash-escaping (`Unexpected token ^`).

## Changes

**Theme 1 — Synthesizer fidelity** (`baml_src/synthesizer.baml`)
- `FIDELITY` block on the shared `Synthesize`: cite only URLs present **verbatim** in the tool results; on a fetch failure **keep the original URL** + a "couldn't fetch" note; never invent or substitute links.

**Theme 2 — Critic provenance & truthfulness** (`baml_src/actorCritic.baml`)
- Consumes the `{_source}` the actor emits: verifies the answer's store matches the intent (conditional on `_source` being present, so the other actorCritic agents — guardrailed, sandbox — are unaffected).
- Accepts a truthful empty/negative result as sufficient; steers on degenerate results rather than acting as a pedantic QA gate.

**Theme 3 — Loop/script ergonomics** (`code-mode.server.ts`)
- Actor-guidance item: search/fetch return **TEXT not JSON** (never `JSON.parse`), prefer string ops over regex (the `^`/`\s` escaping turn-burner), wrap `fetch_content` in try/catch and **keep the URL on failure** (feeds the synth the real link).
- Few-shot **B** reworked to demonstrate text → URL string extraction.

**Docs / tests**
- `code_mode_actor_critic.md`: guidance table + fidelity/provenance sections.
- `code-mode-fidelity.test.ts` (4 tests): guidance reaches the actor; the real URLs (incl. the 403'd one) reach the synth turns; prompt-content guards on the BAML templates.

## Design note — shared prompts

The FIDELITY / provenance rules live on the **shared, task-agnostic** `Synthesize` / `Critic` BAML functions, not a code-mode fork — they're universal anti-hallucination guardrails, and per-agent behavior stays composed via `context`/config/custom closures (which are untouched; `title-generator`'s custom `synthesize` closure is unaffected). Structural pattern composability is unchanged (zero TypeScript pattern-code edits).

## Verification

- **730 pass** (726 baseline + 4 new). `pnpm baml-generate` run; `tsc` clean on touched files (26 pre-existing errors in untouched files).
- Branch is based on a commit already in `main`, so the diff is exactly these 5 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)