### PR TITLE
feat(data-stash): split panel into Your Uploads vs Agent Findings

### DIFF
--- a/docs/UI_ARCHITECTURE.md
+++ b/docs/UI_ARCHITECTURE.md
@@ -371,7 +371,7 @@ Tabbed right panel. **Context manager is the default tab.** Uses `lazyMount` + `
 | Memory | Graph visualization for Memory MCP entities |
 | All (Turn Explorer) | Turn-based graph explorer — select specific turns, color-coded |
 | **Context manager** *(default)* | Event timeline + LLM call detail |
-| Data | Data Stash — document upload (drag-drop/picker) + tool-result icons, with hide/archive/delete. See [DATA_STASH.md](DATA_STASH.md) for the upload→chunk→embed→search pipeline. |
+| Data | Data Stash — two collapsible groups: **Your Uploads** (drag-drop/picker + document chips) and **Agent Findings** (tool-result icons by turn), each with hide/archive/delete. See [DATA_STASH.md](DATA_STASH.md) for the upload→chunk→embed→search pipeline. |
 | Tools | MCP tool configuration via `ToolsPanel` |
 
 **Conversation Sync toggle:** The Neo4j and Memory graph tabs have a ⏸/▶ "Sync" button (cyan when live, amber when paused). Implemented in `GraphTabContent` via a `syncEnabled` signal. When paused, the current element list is snapshotted into `frozenElements` and passed to `GraphVisualization` instead of live `props.elements`. Resuming restores the live feed.

--- a/ui/src/components/ark-ui/DataStashPanel.tsx
+++ b/ui/src/components/ark-ui/DataStashPanel.tsx
@@ -713,12 +713,9 @@ export const DataStashPanel = (props: DataStashPanelProps) => {
         <span text="xs dark-text-tertiary" font="mono">{totalCount()} items</span>
       </div>
 
-      {/* Uploads — file ingestion into the Redis-backed stash (Issue #6) */}
-      <div border="b dark-border-primary">
-        <div p="x-3 y-2" flex="~" items="center" gap="2">
-          <span text="xs dark-text-tertiary" font="medium">Uploads</span>
-          <span text="xs dark-text-tertiary" font="mono">({docs().length})</span>
-        </div>
+      {/* ── Your Uploads ── user-provided documents (Redis-backed, Issue #6).
+          Always available (the drop zone needs to be reachable with 0 docs). */}
+      <CollapsibleSection title="Your Uploads" count={docs().length} defaultOpen={true}>
         <UploadZone uploading={uploading()} error={uploadError()} onFiles={uploadFiles} />
         <Show when={docs().length > 0}>
           <div flex="~ wrap" gap="2" p="x-3 y-2">
@@ -727,22 +724,23 @@ export const DataStashPanel = (props: DataStashPanelProps) => {
             </For>
           </div>
         </Show>
-      </div>
+      </CollapsibleSection>
 
-      <Show when={toolCount() === 0}>
-        <div flex="~ col" items="center" justify="center" p="6" text="dark-text-tertiary" gap="2">
-          <span
-            class="i-mdi-package-variant-closed-remove"
-            style={{ width: '32px', height: '32px', color: '#3f3f46', opacity: '0.6' }}
-          />
-          <span text="xs m-t-1">No tool results yet — run an agent to see data here</span>
-        </div>
-      </Show>
+      {/* ── Agent Findings ── tool results the agent produced (neo4j, web, …). */}
+      <CollapsibleSection title="Agent Findings" count={toolCount()} defaultOpen={true}>
+        <Show when={toolCount() === 0}>
+          <div flex="~ col" items="center" justify="center" p="6" text="dark-text-tertiary" gap="2">
+            <span
+              class="i-mdi-flask-empty-outline"
+              style={{ width: '28px', height: '28px', color: '#3f3f46', opacity: '0.6' }}
+            />
+            <span text="xs m-t-1">No tool results yet — run an agent to see data here</span>
+          </div>
+        </Show>
 
-      <Show when={toolCount() > 0}>
         {/* Current Turn */}
         <Show when={partitioned().current.length > 0}>
-          <div border="b dark-border-primary">
+          <div>
             <div p="x-3 y-2" flex="~" items="center" gap="2">
               <span text="xs dark-text-tertiary" font="medium">Current Turn</span>
               <span text="xs dark-text-tertiary" font="mono">({partitioned().current.length})</span>
@@ -772,7 +770,7 @@ export const DataStashPanel = (props: DataStashPanelProps) => {
             <IconGallery items={partitioned().archived} onAction={props.onStashAction} />
           </CollapsibleSection>
         </Show>
-      </Show>
+      </CollapsibleSection>
     </div>
   )
 }


### PR DESCRIPTION
Makes the two origins of Data Stash content explicit, per discussion: **what the user uploaded** vs **what the agent found** (neo4j, web search, etc.).

## Change
The panel now has two collapsible top-level groups (replacing the implicit uploads-on-top / tool-results-below layout):

```
Data Stash · N items
 ▾ Your Uploads (n)      ← drop zone + document chips (user-provided)
 ▾ Agent Findings (n)    ← tool results the agent produced
      Current Turn (n)
      ▸ Previous Turns (n)
      ▸ Archived (n)
```

- **Your Uploads** is always present (the drop zone must be reachable at 0 docs).
- **Agent Findings** wraps the existing Current/Previous/Archived subsections; empty state shown when there are no tool results.

Pure layout/grouping change — `CollapsibleSection` / `UploadZone` / `DocChip` / `IconGallery` are reused unchanged.

## Verification
- `pnpm exec tsc --noEmit`: 26 (== main baseline, no new errors).
- `pnpm test:run`: **803 pass**.
- Verified at the code/type level; sub-components are unchanged & proven. Not pixel-verified — happy to attach a screenshot if wanted.

Follow-up to #92. Next: revisit the Semantic Cache agent (shares the Redis vector path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)