### PR TITLE
Durable session workspaces: /work ⇄ DataStash artifact sync (#89)

### DIFF
--- a/docs/DATA_STASH.md
+++ b/docs/DATA_STASH.md
@@ -28,6 +28,7 @@ query ─────────────────────── embe
 | `POST /api/stash/upload` | Store a document (multipart `file`, or JSON `{sessionId, filename, content}`) |
 | `GET /api/stash/upload?sessionId=` | List a session's documents (metadata) |
 | `GET /api/stash/document/:id?sessionId=` | Fetch a document (content + metadata) |
+| `GET /api/stash/document/:id?sessionId=&download` | Stream the raw file (base64 decoded for binary) with `Content-Disposition` (#89) |
 | `DELETE /api/stash/document/:id?sessionId=` | Remove a document + its index entry |
 | `PATCH /api/stash/document/:id` | Toggle `hidden` / `archived` (`{sessionId, hidden?, archived?}`) |
 | `POST /api/stash/ingest` | Chunk → embed → index a stored doc (`{sessionId, docId, chunk?, embedding?}`) |
@@ -37,13 +38,13 @@ Auth follows the existing posture (dev-bypass aware; see `lib/auth/dev-bypass.ts
 
 ## Storage model (Redis)
 
-- **Document**: RedisJSON blob at `stash:doc:{sessionId}:{docId}`, TTL default 7 days. `content` is opaque UTF-8 text (binary extraction is the upstream caller's job — not done yet).
+- **Document**: RedisJSON blob at `stash:doc:{sessionId}:{docId}`, TTL default 7 days. `content` is UTF-8 text by default; binary files (xlsx, pdf, images) are stored with `encoding: 'base64'` and `size` = the original (decoded) byte count (#89). Binary content is byte-faithful but **not** semantically searchable — `POST /api/stash/ingest` rejects base64 docs (chunking/embedding is text-only).
 - **Session index**: a Redis SET `stash:docs:{sessionId}` of doc ids (self-healing — stale entries pruned on list).
 - **Chunk**: a Redis HASH `stashvec:{sessionId}:{spaceTag}:{docId}:{chunkIndex}` with `vector` (float blob) + `meta` (base64 of a JSON `{content, doc_id, source, chunk_index, offsets, model, provider, dim}`). 2 writes/chunk.
 - **Vector index**: a RediSearch HNSW index per `(session, embedding-space)`; `dim` matches the embedding model.
 - **Embedding space**: recorded at `stash:space:{sessionId}` as `{provider, model, dimensions}`.
 
-`MAX_CONTENT_BYTES` = 5 MiB. Accepts any text-decodable file; the picker hints Text/Markdown/JSON/CSV (no hard allow-list — binaries decode as garbage today).
+`MAX_CONTENT_BYTES` = 5 MiB (applies to the original bytes, base64 or not). Text files store verbatim; recognized binary types are base64-encoded by the upload service (`isTextMime` decides). Text remains the path for anything you want to search; binary is for byte-faithful round-trips (e.g. the sandbox `/work` flow, #89).
 
 ## Chunking (#9)
 
@@ -72,5 +73,5 @@ llama-server --embedding -m models/Qwen3-Embedding-0.6B-Q8_0.gguf --port 8090 --
 
 ## Relationships
 
-- **#89** (sandbox `/work` ⇄ DataStash artifact sync) builds on the store/retrieve path (`getDocument` / `toPriorResult`); it does not require vector search.
+- **#89** (sandbox `/work` ⇄ DataStash artifact sync) builds on the store/retrieve path (`storeDocument` / `getDocument` / `listDocuments`) and added the base64 `encoding` field + the `?download` route for byte-faithful binaries. It does not require vector search. Mechanism: [`docs/sandbox-plan.md → Durable workspaces`](sandbox-plan.md#durable-workspaces-89).
 - Distinct from **#17** (RDF/OWL → Neo4j): this is documents → Redis + vectors.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -41,7 +41,7 @@ Source-level index: see [ui/README.md](../ui/README.md#documentation-index).
 
 | Document | Description |
 |----------|-------------|
-| [DATA_STASH.md](DATA_STASH.md) | Document upload → chunk → embed → search pipeline (#6/#9/#8): modules, API routes, Redis storage model, embedding-space rule, redis-stack + local-embedder requirements |
+| [DATA_STASH.md](DATA_STASH.md) | Document upload → chunk → embed → search pipeline (#6/#9/#8): modules, API routes, Redis storage model (incl. base64 binary, #89), embedding-space rule, redis-stack + local-embedder requirements |
 
 ---
 
@@ -51,7 +51,8 @@ Source-level index: see [ui/README.md](../ui/README.md#documentation-index).
 |----------|-------------|
 | [DOCKER_COMPOSE.md](DOCKER_COMPOSE.md) | Neo4j, MCP Gateway, Redis service configuration |
 | [MCP_GATEWAY.md](MCP_GATEWAY.md) | MCP Gateway reference, CLI, troubleshooting |
-| [sandbox-plan.md](sandbox-plan.md) | Sandbox compute plan — `withSandbox` wrapper, attachment model, MCP-in-VM architecture, backend interface (Docker + Firecracker), substrate options, failure modes |
+| [sandbox-plan.md](sandbox-plan.md) | Sandbox compute plan — `withSandbox` wrapper, attachment model, MCP-in-VM architecture, durable workspaces (`syncWorkspace`, #89), backend interface (Docker + Firecracker), substrate options, failure modes |
+| [sandbox/README.md](sandbox/README.md) | Sandbox debugging — identify/inspect/reap containers, `/work` durable-workspace layout, `.harness-logs` jq recipes |
 
 **Key config files:**
 - `docker-compose.yaml` — service orchestration

--- a/docs/sandbox-plan.md
+++ b/docs/sandbox-plan.md
@@ -58,6 +58,8 @@ Auto is the default. The wrapper's runtime context — re-entries within a sessi
 
 **Vocabulary:** we use *attachment* rather than *scope* because `Scope` is already a concept on UnifiedContext / View. The two are unrelated.
 
+**Workspace persistence vs. attachment lifetime.** The attachment keeps a VM *live* between turns, so `/work` survives turn-to-turn while the container exists — but a container is disposable (idle eviction, warm-pool `reset`, process restart all destroy it). For state that must outlive the container, add `syncWorkspace: true` to an `{ id }` sandbox: the session's stored documents are restored into `/work/in` on first boot and `/work/out` deliverables are promoted back to the DataStash on each turn's exit. See [Durable workspaces](#durable-workspaces-89).
+
 ---
 
 ## Architecture: MCP-in-VM
@@ -256,9 +258,33 @@ Tools the agent does **not** see in v0:
 
 8. withSandbox exits → backend.reset() → VM returns to the warm pool
    (or stays attached if id was explicit and session is alive).
+   With syncWorkspace, anything the actor wrote under /work/out is first
+   promoted to the DataStash, so the result survives the VM (see below).
 ```
 
-Same shape works for document extraction, format conversion, dataset profiling — the conversation changes, the wrapper doesn't.
+Same shape works for document extraction, format conversion, dataset profiling — the conversation changes, the wrapper doesn't. When the input file was *uploaded* (rather than written by the actor), `syncWorkspace` restores it from the DataStash into `/work/in` automatically on the next session, so the user can leave and come back to it.
+
+---
+
+## Durable workspaces (#89)
+
+A container is disposable; the workspace shouldn't be. The 5-minute-class idle window, warm-pool `reset`, and process restarts all destroy `/work`, so anything written there is lost once the live attachment goes away. [#89](https://github.com/mknw/harness-playground/issues/89) decouples the two: **`/work` stays ephemeral scratch; the DataStash is the durable store.** Opt in per agent with `withSandbox({ id, sessionId, syncWorkspace: true })` (the Sandbox · Session agent does).
+
+**Workspace layout (the contract the agent is taught):**
+
+| Path | Role | Lifetime |
+|------|------|----------|
+| `/work/in` | Uploads + prior deliverables, **restored on first boot** of each session's container. | Durable (DataStash). Read-only by convention. |
+| `/work/out` | Files the agent wants kept. **Promoted to the DataStash on every turn exit.** | Durable (DataStash). |
+| `/work` (elsewhere) | Scratch. | Ephemeral — gone when the container recycles. |
+
+**Mechanism** (`ui/src/lib/sandbox/work-artifacts.server.ts` + `work-sync.server.ts`):
+
+- **Hydrate** — on first boot only (tracked by `Attachment.isFirstBoot`), `listDocuments(sessionId)` → write each into `/work/in`. Reused live attachments skip this, so a multi-turn session doesn't re-hydrate every turn.
+- **Promote** — snapshot `/work/out` (in-VM `sha256sum`) at turn entry, diff at exit, and `storeDocument` each new/changed file. Runs in a `finally`, so deliverables are saved even if the turn throws. Deletions are ignored (promotion never removes stored docs).
+- **Binary-faithful** — text files store verbatim; everything else (xlsx, pdf, images) moves as base64 staged through a `.b64` text file (the in-VM filesystem MCP is text-only) and is stored with `encoding: 'base64'`. See [DATA_STASH.md → Storage model](DATA_STASH.md#storage-model-redis).
+
+**Boundaries.** Only the `{ id }` path syncs; anonymous (`withSandbox({})`) and one-shot (`{ fresh: true }`) sandboxes have no session identity and are untouched. Sync requires the MCP gateway (the DataStash lives in Redis). The window in which a *live* container is reused before falling back to hydrate-from-store is the warm-cache horizon — see `idleEvictMs` in [Settings](#settings).
 
 ---
 
@@ -377,7 +403,7 @@ Devs working specifically on `FirecrackerBackend` bugs opt into Lima / UTM / Orb
 | `sandbox.globalCap` | 16 | Max concurrent sandbox VMs across all sessions |
 | `sandbox.perSessionCap` | 4 | Max concurrent sandbox VMs per session |
 | `sandbox.warmPool.base` | 1–2 | Pre-booted VMs of the base flavor |
-| `sandbox.idleEvictMs` | 300_000 | Idle time before warm-pool VM destroyed |
+| `sandbox.idleEvictMs` | 3_600_000 | Idle time before a parked VM is destroyed. With durable workspaces (#89) this is only the *warm-cache* horizon — instant reuse of the live container within the window; beyond it, the next turn re-hydrates `/work/in` from the DataStash. Was 300_000 before #89. |
 | `sandbox.defaultTimeoutSec` | 60 | Per-tool-call wall-clock cap |
 | `sandbox.defaultMemoryMB` | 512 | Per-VM memory cap |
 | `sandbox.defaultEgress` | `'mcp-only'` | Default egress profile |
@@ -409,8 +435,8 @@ Each step de-risks the next.
 - Dedicated `sandbox_python` MCP tool (Jupyter-shaped, REPL state across calls).
 - Rootfs flavor catalog (#78): Polars, PyPDF, sentence-transformers, etc.
 - Rust shell-exec MCP server (replaces JS) if cold-start becomes felt.
-- DataStash → sandbox flow: auto-mount referenced entries, or explicit `sandbox_fetch_stash(id, path)` tool.
-- UI-initiated file uploads into a running sandbox.
+- ~~DataStash → sandbox flow: auto-mount referenced entries~~ — **landed in #89** as `syncWorkspace`: stored docs hydrate into `/work/in`, `/work/out` deliverables promote back. Still v1+: *selective* hydration (only `withReferences`-selected entries, vs. the whole session set), an explicit `sandbox_publish` tool (vs. the `/work/out` convention; needs an actorCritic synthetic-tool layer), and version/lineage UI.
+- UI-initiated file uploads into a *running* sandbox (today an upload lands in the DataStash and reaches `/work/in` on the next session boot, not mid-session).
 
 **v2: `backgroundSession` primitive.**
 

--- a/docs/sandbox/README.md
+++ b/docs/sandbox/README.md
@@ -55,6 +55,29 @@ The `/work` directory is the agent's workspace — files written via
 Inspecting it is the fastest way to confirm "did the agent actually write
 what it claimed to write?".
 
+### Durable workspace (`syncWorkspace`, [#89](https://github.com/mknw/harness-playground/issues/89))
+
+For agents that opt in (e.g. **Sandbox · Session**), `/work` has a convention:
+
+| Path | Meaning |
+|------|---------|
+| `/work/in`  | Uploads + prior deliverables, restored from the DataStash on first boot. |
+| `/work/out` | Files the agent wants kept — promoted to the DataStash on each turn exit. |
+| `/work/*`   | Scratch, lost when the container recycles. |
+
+```sh
+docker exec sbx-xxxx ls -la /work/in /work/out   # what was restored / will persist
+```
+
+The durable copy lives in Redis, not the container. Inspect it via the MCP
+gateway (keys `stash:doc:<sessionId>:*`, index `stash:docs:<sessionId>`) or the
+DataStash side panel. Binary deliverables (xlsx, pdf, images) are stored
+base64-encoded (`encoding: 'base64'`) and downloadable from the panel; a
+`GET /api/stash/document/:id?sessionId=…&download` streams the decoded bytes.
+A promoted file lists in the DataStash panel alongside uploads (same
+`GET /api/stash/upload?sessionId=` document list) — it is a stored document,
+not a synthetic `tool_result`. See [`docs/DATA_STASH.md`](../DATA_STASH.md).
+
 ## Reap leftovers
 
 The harness calls `--rm` so a stop auto-removes, and on graceful shutdown the
@@ -80,9 +103,16 @@ anything else. Same command is in
 
 After light use you'll typically see **0 or 1 anonymous warm-pool VM** plus
 **one VM per active session id**. The lazy idle sweep destroys parked entries
-~5 min after last use, but only fires on the next sandbox action — see issue
+~1 h after last use (the `idleEvictMs` warm-cache horizon; was 5 min before
+[#89](https://github.com/mknw/harness-playground/issues/89)), but only fires on
+the next sandbox action — see issue
 [#82](https://github.com/mknw/harness-playground/issues/82) for the
 timer-driven follow-up if dormant accumulation becomes an issue.
+
+Losing the VM no longer loses the work: agents that opt into durable workspaces
+(`syncWorkspace: true`, e.g. **Sandbox · Session**) restore prior files into
+`/work/in` on the next boot and promote `/work/out` deliverables to the
+DataStash each turn — see below.
 
 ## Inspecting an agent run after the fact
 

--- a/ui/README.md
+++ b/ui/README.md
@@ -43,6 +43,7 @@ src/
 │   ├── embeddings.server.ts     # Data Stash: provider-pluggable embeddings (#8)
 │   ├── document-ingest.server.ts # Data Stash: chunk→embed→HNSW index + KNN search
 │   ├── stash/                   # Data Stash upload HTTP helpers (parse + auth). See docs/DATA_STASH.md
+│   ├── sandbox/                 # Compute sandbox: withSandbox, Docker backend, warm pool, durable /work⇄DataStash sync (#89). See docs/sandbox-plan.md
 │   ├── settings.ts            # HarnessSettings type, defaults, MODEL_CONTEXT_WINDOWS
 │   ├── settings-store.ts      # Client-side reactive store (localStorage persistence)
 │   ├── settings-context.server.ts # Request-scoped settings via AsyncLocalStorage

--- a/ui/src/__tests__/lib/document-store.test.ts
+++ b/ui/src/__tests__/lib/document-store.test.ts
@@ -390,4 +390,43 @@ describe('document-store (Issue #6)', () => {
       expect(pr.summary).toContain('text/csv')
     })
   })
+
+  describe('base64 encoding (#89)', () => {
+    it('stores binary content with encoding=base64 and size = decoded bytes', async () => {
+      const bytes = Buffer.from([0x50, 0x4b, 0x03, 0x04, 0xff, 0x00]) // 6 raw bytes
+      const b64 = bytes.toString('base64')
+      const doc = await storeDocument(
+        { sessionId: 's1', filename: 'sheet.xlsx', mimeType: 'application/vnd.x', content: b64, encoding: 'base64' },
+        fake.callTool,
+      )
+      expect(doc.encoding).toBe('base64')
+      expect(doc.content).toBe(b64)
+      // size reflects the ORIGINAL bytes, not the larger base64 string.
+      expect(doc.size).toBe(bytes.length)
+      expect(doc.size).toBeLessThan(b64.length)
+    })
+
+    it('round-trips a stored binary doc unchanged via getDocument', async () => {
+      const bytes = Buffer.from([1, 2, 3, 250, 251, 252])
+      const b64 = bytes.toString('base64')
+      const stored = await storeDocument(
+        { sessionId: 's1', filename: 'x.bin', mimeType: 'application/octet-stream', content: b64, encoding: 'base64' },
+        fake.callTool,
+      )
+      const got = await getDocument('s1', stored.id, fake.callTool)
+      expect(got?.encoding).toBe('base64')
+      expect(Buffer.from(got!.content, 'base64').equals(bytes)).toBe(true)
+    })
+
+    it('toPriorResult uses a metadata preview for binary (never slices base64)', () => {
+      const b64 = Buffer.from([0x89, 0x50, 0x4e, 0x47]).toString('base64')
+      const pr = toPriorResult({
+        id: 'doc-9', sessionId: 's1', filename: 'chart.png', mimeType: 'image/png',
+        size: 4, uploadedAt: Date.now(), encoding: 'base64', content: b64,
+      })
+      expect(pr.summary).toContain('chart.png')
+      expect(pr.summary).toContain('image/png')
+      expect(pr.summary).not.toContain(b64)
+    })
+  })
 })

--- a/ui/src/__tests__/lib/sandbox/work-artifacts.test.ts
+++ b/ui/src/__tests__/lib/sandbox/work-artifacts.test.ts
@@ -1,0 +1,136 @@
+/**
+ * work-artifacts tests — hydrate (store → /work/in) and promote
+ * (/work/out → store), with the document store mocked and a simulated `/work`
+ * transport. Verifies routing (which docs land where), the text/binary encoding
+ * decision, and that promotion only stores files changed since the baseline.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createHash } from 'node:crypto'
+
+vi.mock('../../../lib/harness-patterns/assert.server', () => ({
+  assertServerOnImport: vi.fn(),
+}))
+
+vi.mock('../../../lib/document-store.server', () => ({
+  listDocuments: vi.fn(),
+  getDocument: vi.fn(),
+  storeDocument: vi.fn(async () => ({})),
+}))
+
+import type { McpTransport } from '../../../lib/sandbox/types'
+import type { ToolCallResult } from '../../../lib/harness-patterns/types'
+import { listDocuments, getDocument, storeDocument } from '../../../lib/document-store.server'
+import { hydrateWorkspace, promoteOutputs } from '../../../lib/sandbox/work-artifacts.server'
+
+const unq = (s: string): string => s.replace(/^'|'$/g, '').replace(/'\\''/g, "'")
+function bashOk(stdout = ''): ToolCallResult {
+  return { success: true, data: { stdout, stderr: '', exit_code: 0, timed_out: false } }
+}
+
+function makeFsTransport() {
+  const fs = new Map<string, string>()
+  const runBash = (cmd: string): ToolCallResult => {
+    let m = /^base64 -d (\S+) > (\S+) && rm -f (\S+)$/.exec(cmd)
+    if (m) {
+      fs.set(unq(m[2]), Buffer.from(fs.get(unq(m[1])) ?? '', 'base64').toString('latin1'))
+      fs.delete(unq(m[3]))
+      return bashOk()
+    }
+    m = /^base64 -w 0 (\S+) > (\S+)$/.exec(cmd)
+    if (m) {
+      fs.set(unq(m[2]), Buffer.from(fs.get(unq(m[1])) ?? '', 'latin1').toString('base64'))
+      return bashOk()
+    }
+    m = /cd (\S+) && find \. -type f/.exec(cmd)
+    if (m) {
+      const dir = unq(m[1]).replace(/\/$/, '')
+      const lines: string[] = []
+      for (const [p, content] of fs) {
+        if (p.startsWith(dir + '/')) {
+          const hash = createHash('sha256').update(Buffer.from(content, 'latin1')).digest('hex')
+          lines.push(`${hash}  ./${p.slice(dir.length + 1)}`)
+        }
+      }
+      return bashOk(lines.join('\n'))
+    }
+    return bashOk()
+  }
+  const transport: McpTransport = {
+    vmId: 'vm',
+    toolNames: async () => [],
+    listTools: async () => [],
+    ownsTool: (n) => n.startsWith('sandbox_'),
+    close: async () => {},
+    callTool: async (name, args): Promise<ToolCallResult> => {
+      if (name === 'sandbox_write') {
+        fs.set(args.path as string, args.content as string)
+        return { success: true, data: 'ok' }
+      }
+      if (name === 'sandbox_read') {
+        const p = args.path as string
+        return fs.has(p) ? { success: true, data: fs.get(p) } : { success: false, data: null, error: 'nf' }
+      }
+      if (name === 'sandbox_bash') return runBash(args.command as string)
+      return { success: false, data: null, error: 'unknown' }
+    },
+  }
+  return { transport, fs }
+}
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('hydrateWorkspace', () => {
+  it('writes visible docs into /work/in (text verbatim, binary decoded) and skips hidden/archived', async () => {
+    vi.mocked(listDocuments).mockResolvedValue([
+      { id: 'd1', sessionId: 's', filename: 'data.csv', mimeType: 'text/csv', size: 3, uploadedAt: 1 },
+      { id: 'd2', sessionId: 's', filename: 'sheet.xlsx', mimeType: 'application/vnd…', size: 4, uploadedAt: 2, encoding: 'base64' },
+      { id: 'd3', sessionId: 's', filename: 'old.txt', mimeType: 'text/plain', size: 1, uploadedAt: 3, hidden: true },
+    ] as never)
+    const xlsxBytes = Buffer.from([0x50, 0x4b, 0x03, 0x04]) // "PK.." zip/xlsx magic
+    vi.mocked(getDocument).mockImplementation(async (_s, id) => {
+      if (id === 'd1') return { id: 'd1', sessionId: 's', filename: 'data.csv', mimeType: 'text/csv', size: 3, uploadedAt: 1, content: 'a,b' } as never
+      if (id === 'd2') return { id: 'd2', sessionId: 's', filename: 'sheet.xlsx', mimeType: 'x', size: 4, uploadedAt: 2, encoding: 'base64', content: xlsxBytes.toString('base64') } as never
+      return null
+    })
+
+    const { transport, fs } = makeFsTransport()
+    const n = await hydrateWorkspace(transport, 's', (async () => ({ success: true, data: null })) as never)
+
+    expect(n).toBe(2) // d3 skipped (hidden)
+    expect(fs.get('/work/in/data.csv')).toBe('a,b')
+    expect(fs.get('/work/in/sheet.xlsx')).toBe(xlsxBytes.toString('latin1'))
+    expect(fs.has('/work/in/old.txt')).toBe(false)
+    // getDocument never fetched the hidden doc.
+    expect(vi.mocked(getDocument)).not.toHaveBeenCalledWith('s', 'd3', expect.anything())
+  })
+})
+
+describe('promoteOutputs', () => {
+  it('stores only files new/changed since baseline, with correct text/binary encoding', async () => {
+    const { transport, fs } = makeFsTransport()
+    // report.csv is new; chart.png is new binary; notes.md is unchanged vs baseline.
+    fs.set('/work/out/report.csv', 'x,y\n1,2')
+    fs.set('/work/out/notes.md', '# unchanged')
+    const pngBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47])
+    fs.set('/work/out/chart.png', pngBytes.toString('latin1'))
+
+    const notesHash = createHash('sha256').update(Buffer.from('# unchanged', 'latin1')).digest('hex')
+    const baseline = new Map([['notes.md', notesHash]])
+
+    const promoted = await promoteOutputs(transport, 's', baseline, (async () => ({ success: true, data: null })) as never)
+
+    expect(promoted.sort()).toEqual(['chart.png', 'report.csv'])
+    const calls = vi.mocked(storeDocument).mock.calls.map((c) => c[0])
+    const csv = calls.find((c) => c.filename === 'report.csv')!
+    const png = calls.find((c) => c.filename === 'chart.png')!
+    expect(csv.mimeType).toBe('text/csv')
+    expect(csv.encoding).toBeUndefined()
+    expect(csv.content).toBe('x,y\n1,2')
+    expect(png.mimeType).toBe('image/png')
+    expect(png.encoding).toBe('base64')
+    expect(Buffer.from(png.content, 'base64').equals(pngBytes)).toBe(true)
+    // notes.md (unchanged) was not promoted.
+    expect(calls.find((c) => c.filename === 'notes.md')).toBeUndefined()
+  })
+})

--- a/ui/src/__tests__/lib/sandbox/work-sync.test.ts
+++ b/ui/src/__tests__/lib/sandbox/work-sync.test.ts
@@ -1,0 +1,139 @@
+/**
+ * work-sync tests — host ⇄ /work file movement over a simulated transport.
+ *
+ * The fake transport implements a tiny in-VM filesystem plus exactly the bash
+ * command shapes work-sync emits (mkdir, base64 -d/-w 0 redirects, sha256sum
+ * find), so text and binary round-trips and the /work/out diff are exercised
+ * end-to-end without a real container.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { createHash } from 'node:crypto'
+
+vi.mock('../../../lib/harness-patterns/assert.server', () => ({
+  assertServerOnImport: vi.fn(),
+}))
+
+import type { McpTransport } from '../../../lib/sandbox/types'
+import type { ToolCallResult } from '../../../lib/harness-patterns/types'
+import {
+  writeWorkFile,
+  readWorkFile,
+  listWorkFiles,
+  diffWorkFiles,
+} from '../../../lib/sandbox/work-sync.server'
+
+/** Strip the single-quoting `shq()` applies. */
+const unq = (s: string): string => s.replace(/^'|'$/g, '').replace(/'\\''/g, "'")
+
+function bashOk(stdout = ''): ToolCallResult {
+  return { success: true, data: { stdout, stderr: '', exit_code: 0, timed_out: false } }
+}
+
+/** In-memory fs (path → content; binary stored as a latin1 byte string). */
+function makeFsTransport() {
+  const fs = new Map<string, string>()
+
+  const runBash = (cmd: string): ToolCallResult => {
+    let m = /^base64 -d (\S+) > (\S+) && rm -f (\S+)$/.exec(cmd)
+    if (m) {
+      const b64 = fs.get(unq(m[1])) ?? ''
+      fs.set(unq(m[2]), Buffer.from(b64, 'base64').toString('latin1'))
+      fs.delete(unq(m[3]))
+      return bashOk()
+    }
+    m = /^base64 -w 0 (\S+) > (\S+)$/.exec(cmd)
+    if (m) {
+      const content = fs.get(unq(m[1])) ?? ''
+      fs.set(unq(m[2]), Buffer.from(content, 'latin1').toString('base64'))
+      return bashOk()
+    }
+    m = /cd (\S+) && find \. -type f/.exec(cmd)
+    if (m) {
+      const dir = unq(m[1]).replace(/\/$/, '')
+      const lines: string[] = []
+      for (const [p, content] of fs) {
+        if (p.startsWith(dir + '/')) {
+          const rel = p.slice(dir.length + 1)
+          const hash = createHash('sha256').update(Buffer.from(content, 'latin1')).digest('hex')
+          lines.push(`${hash}  ./${rel}`)
+        }
+      }
+      return bashOk(lines.join('\n'))
+    }
+    return bashOk() // mkdir -p / rm -f / anything else → no-op success
+  }
+
+  const transport: McpTransport = {
+    vmId: 'vm-test',
+    toolNames: async () => ['sandbox_read', 'sandbox_write', 'sandbox_bash'],
+    listTools: async () => [],
+    ownsTool: (n) => n.startsWith('sandbox_'),
+    close: async () => {},
+    callTool: async (name, args): Promise<ToolCallResult> => {
+      if (name === 'sandbox_write') {
+        fs.set(args.path as string, args.content as string)
+        return { success: true, data: 'ok' }
+      }
+      if (name === 'sandbox_read') {
+        const p = args.path as string
+        return fs.has(p)
+          ? { success: true, data: fs.get(p) }
+          : { success: false, data: null, error: 'not found' }
+      }
+      if (name === 'sandbox_bash') return runBash(args.command as string)
+      return { success: false, data: null, error: `unknown tool ${name}` }
+    },
+  }
+  return { transport, fs }
+}
+
+describe('work-sync: text round-trip', () => {
+  it('writes and reads utf8 verbatim', async () => {
+    const { transport, fs } = makeFsTransport()
+    await writeWorkFile(transport, '/work/in/notes.md', '# hello\nworld\n', 'utf8')
+    expect(fs.get('/work/in/notes.md')).toBe('# hello\nworld\n')
+    expect(await readWorkFile(transport, '/work/in/notes.md', 'utf8')).toBe('# hello\nworld\n')
+  })
+})
+
+describe('work-sync: binary round-trip', () => {
+  it('preserves raw bytes through base64 staging', async () => {
+    const { transport, fs } = makeFsTransport()
+    // Bytes that are NOT valid UTF-8 — the whole point of base64.
+    const original = Buffer.from([0xff, 0xd8, 0xff, 0x00, 0x01, 0x7f, 0x80]).toString('base64')
+    await writeWorkFile(transport, '/work/in/img.bin', original, 'base64')
+    // Staged .b64 was cleaned up after decode.
+    expect(fs.has('/work/in/img.bin.b64')).toBe(false)
+    const back = await readWorkFile(transport, '/work/in/img.bin', 'base64')
+    expect(back).toBe(original)
+  })
+})
+
+describe('work-sync: listWorkFiles + diff', () => {
+  it('hashes files and detects new/changed since a baseline', async () => {
+    const { transport } = makeFsTransport()
+    await writeWorkFile(transport, '/work/out/a.txt', 'hello', 'utf8')
+    const baseline = await listWorkFiles(transport, '/work/out')
+    expect([...baseline.keys()]).toEqual(['a.txt'])
+
+    await writeWorkFile(transport, '/work/out/b.txt', 'world', 'utf8')
+    await writeWorkFile(transport, '/work/out/a.txt', 'hello again', 'utf8') // changed
+    const current = await listWorkFiles(transport, '/work/out')
+
+    expect(diffWorkFiles(baseline, current).sort()).toEqual(['a.txt', 'b.txt'])
+  })
+
+  it('returns empty for an unchanged tree', async () => {
+    const { transport } = makeFsTransport()
+    await writeWorkFile(transport, '/work/out/x.csv', 'a,b,c', 'utf8')
+    const snap = await listWorkFiles(transport, '/work/out')
+    expect(diffWorkFiles(snap, snap)).toEqual([])
+  })
+
+  it('ignores deletions (promotion never removes stored docs)', () => {
+    const baseline = new Map([['gone.txt', 'h1'], ['keep.txt', 'h2']])
+    const current = new Map([['keep.txt', 'h2']])
+    expect(diffWorkFiles(baseline, current)).toEqual([])
+  })
+})

--- a/ui/src/__tests__/lib/stash-upload-service.test.ts
+++ b/ui/src/__tests__/lib/stash-upload-service.test.ts
@@ -14,6 +14,7 @@ vi.mock('../../lib/harness-patterns/assert.server', () => ({
 
 import {
   guessMimeType,
+  isTextMime,
   parseUploadRequest,
 } from '../../lib/stash/upload-service.server'
 
@@ -131,6 +132,46 @@ describe('upload-service (Issue #6)', () => {
     it('throws when no file field is present', async () => {
       const req = multipart([{ name: 'sessionId', value: 's2' }])
       await expect(parseUploadRequest(req)).rejects.toThrow(/file/i)
+    })
+
+    it('base64-encodes a binary file and sets encoding (#89)', async () => {
+      const req = multipart([
+        { name: 'sessionId', value: 's2' },
+        { name: 'file', filename: 'doc.pdf', type: 'application/pdf', content: '%PDF-1.4 fake' },
+      ])
+      const input = await parseUploadRequest(req)
+      expect(input.mimeType).toBe('application/pdf')
+      expect(input.encoding).toBe('base64')
+      expect(Buffer.from(input.content, 'base64').toString('utf8')).toBe('%PDF-1.4 fake')
+    })
+  })
+
+  describe('isTextMime / binary JSON (#89)', () => {
+    it('classifies text vs binary mimetypes', () => {
+      expect(isTextMime('text/csv')).toBe(true)
+      expect(isTextMime('application/json')).toBe(true)
+      expect(isTextMime('application/ld+json')).toBe(true)
+      expect(isTextMime('application/pdf')).toBe(false)
+      expect(isTextMime('application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')).toBe(false)
+      expect(isTextMime('image/png')).toBe(false)
+    })
+
+    it('passes through encoding=base64 on the JSON path', async () => {
+      const b64 = Buffer.from([1, 2, 3, 255]).toString('base64')
+      const req = new Request('http://x/api/stash/upload', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          sessionId: 's1',
+          filename: 'x.bin',
+          mimeType: 'application/octet-stream',
+          content: b64,
+          encoding: 'base64',
+        }),
+      })
+      const input = await parseUploadRequest(req)
+      expect(input.encoding).toBe('base64')
+      expect(input.content).toBe(b64)
     })
   })
 })

--- a/ui/src/components/ark-ui/DataStashPanel.tsx
+++ b/ui/src/components/ark-ui/DataStashPanel.tsx
@@ -22,8 +22,9 @@ import type { StashDocumentMeta } from '~/lib/document-store.server'
 // ============================================================================
 
 export type StashAction = 'hide' | 'unhide' | 'archive' | 'unarchive'
-/** Document actions add `delete` (uploads are removable; tool results are not). */
-export type DocAction = StashAction | 'delete'
+/** Document actions add `delete` (removable) and `download` (fetch the raw
+ *  file — base64-decoded for binary via the `?download` route). */
+export type DocAction = StashAction | 'delete' | 'download'
 
 export interface DataStashPanelProps {
   events: ContextEvent[]
@@ -414,7 +415,7 @@ const DocChip = (props: {
             { label: 'Hide', action: 'hide' },
             { label: 'Archive', action: 'archive' },
           ]
-    return [...base, { label: 'Delete', action: 'delete' }]
+    return [{ label: 'Download', action: 'download' as DocAction }, ...base, { label: 'Delete', action: 'delete' }]
   }
 
   return (
@@ -636,6 +637,18 @@ export const DataStashPanel = (props: DataStashPanelProps) => {
 
   const handleDocAction = async (id: string, action: DocAction) => {
     if (!props.sessionId) return
+    if (action === 'download') {
+      // Stream the raw file via the ?download route (binary is base64-decoded
+      // server-side). Anchor-click so the Content-Disposition filename is used.
+      const a = document.createElement('a')
+      a.href = `/api/stash/document/${encodeURIComponent(id)}?sessionId=${encodeURIComponent(props.sessionId)}&download`
+      a.download = ''
+      a.rel = 'noopener'
+      document.body.appendChild(a)
+      a.click()
+      a.remove()
+      return
+    }
     if (action === 'delete') {
       await fetch(
         `/api/stash/document/${encodeURIComponent(id)}?sessionId=${encodeURIComponent(props.sessionId)}`,

--- a/ui/src/lib/document-store.server.ts
+++ b/ui/src/lib/document-store.server.ts
@@ -56,6 +56,14 @@ export interface StashDocumentMeta {
   hidden?: boolean
   /** Moved to the Archived section (also excluded from LLM context). */
   archived?: boolean
+  /**
+   * Content encoding. `'utf8'` (default, omitted) → `content` is literal text.
+   * `'base64'` → `content` is base64 of the original binary bytes (xlsx, pdf,
+   * images); decode before use. `size` is always the ORIGINAL byte count.
+   * Added for the sandbox `/work` round-trip (#89) — binary deliverables need
+   * byte-faithful storage, which the text-only upload path could not provide.
+   */
+  encoding?: 'utf8' | 'base64'
 }
 
 /** A stored document: metadata + its (already text-extracted) content. */
@@ -78,6 +86,11 @@ export interface StoreDocumentInput {
   id?: string
   /** TTL override in seconds; falls back to {@link DEFAULT_TTL_SECONDS}. */
   ttlSeconds?: number
+  /**
+   * Content encoding; defaults to `'utf8'`. Set `'base64'` when `content` is
+   * base64-encoded binary (the size limit then applies to the decoded bytes).
+   */
+  encoding?: 'utf8' | 'base64'
 }
 
 // ============================================================================
@@ -130,6 +143,16 @@ function byteLength(str: string): number {
   return typeof Buffer !== 'undefined'
     ? Buffer.byteLength(str, 'utf8')
     : new TextEncoder().encode(str).length
+}
+
+/** Decoded byte count of a base64 string (server-only — Buffer always present;
+ *  whitespace-tolerant fallback otherwise). Used so the size limit and stored
+ *  `size` reflect the ORIGINAL bytes, not the ≈33%-larger base64 string. */
+function base64ByteLength(b64: string): number {
+  if (typeof Buffer !== 'undefined') return Buffer.from(b64, 'base64').length
+  const clean = b64.replace(/[^A-Za-z0-9+/]/g, '')
+  const padding = b64.endsWith('==') ? 2 : b64.endsWith('=') ? 1 : 0
+  return Math.max(0, Math.floor((clean.length * 3) / 4) - padding)
 }
 
 /**
@@ -237,7 +260,11 @@ export async function storeDocument(
   input: StoreDocumentInput,
   callTool: CallTool = defaultCallTool,
 ): Promise<StashDocument> {
-  const size = byteLength(input.content)
+  const encoding = input.encoding ?? 'utf8'
+  // `size` is the ORIGINAL byte count: for base64 that's the decoded length
+  // (the limit applies to the real file, not the larger encoded string).
+  const size =
+    encoding === 'base64' ? base64ByteLength(input.content) : byteLength(input.content)
   if (size > MAX_CONTENT_BYTES) {
     throw new Error(
       `Document too large: ${size} bytes exceeds limit of ${MAX_CONTENT_BYTES} bytes`,
@@ -252,6 +279,8 @@ export async function storeDocument(
     size,
     uploadedAt: Date.now(),
     content: input.content,
+    // Omit when utf8 so existing docs/tests stay byte-identical.
+    ...(encoding === 'base64' ? { encoding } : {}),
   }
 
   const ttl = input.ttlSeconds ?? DEFAULT_TTL_SECONDS
@@ -415,7 +444,10 @@ export function toPriorResult(
   doc: StashDocumentMeta & { content?: string },
   previewChars = 200,
 ): PriorResult {
-  const preview = doc.content
+  // Base64 (binary) content is not human-readable — fall back to a metadata
+  // preview rather than slicing the encoded blob into the summary.
+  const isBinary = doc.encoding === 'base64'
+  const preview = doc.content && !isBinary
     ? doc.content.slice(0, previewChars).replace(/\s+/g, ' ').trim() +
       (doc.content.length > previewChars ? '…' : '')
     : `${doc.filename} (${doc.mimeType}, ${doc.size} bytes)`

--- a/ui/src/lib/harness-client/examples/README.md
+++ b/ui/src/lib/harness-client/examples/README.md
@@ -1384,11 +1384,18 @@ time, no per-pattern wiring. See `sandbox-demo.server.ts`.
 ### 11. Sandbox · Session (`withSandbox({ id })` persistent + xterm)
 
 **Servers**: none (same as Sandbox Demo)
-**Patterns**: `[compactIntent, withSandbox({ id: sessionId })(actorCritic), synth]`
+**Patterns**: `[compactIntent, withSandbox({ id: sessionId, syncWorkspace: true })(actorCritic), synth]`
 **Use case**: A persistent workspace shared with the **interactive Shell
 terminal** in the Terminal panel. Agent writes a file → user can `cat` it in
 the Shell; same VM. The `id` keys the attachment to the conversation in
 `AttachmentTable`; the `PtyManager` keys on the same `sessionId`.
+
+With `syncWorkspace: true` ([#89](https://github.com/mknw/harness-playground/issues/89))
+the workspace is **durable across sessions**, not just turns: stored documents
+are restored into `/work/in` on first boot and `/work/out` deliverables are
+promoted to the DataStash each turn — so an uploaded spreadsheet survives idle
+eviction, restart, and next-day reconnects. The layout contract + mechanism
+live in [`docs/sandbox-plan.md → Durable workspaces`](../../../../docs/sandbox-plan.md#durable-workspaces-89).
 
 Composes any actor-style pattern with id-addressable attachment. Because this
 agent is **router-less**, `compactIntent` runs first ([#83](https://github.com/mknw/harness-playground/issues/83)

--- a/ui/src/lib/harness-client/examples/sandbox-session.server.ts
+++ b/ui/src/lib/harness-client/examples/sandbox-session.server.ts
@@ -28,10 +28,17 @@ import type { AgentConfig } from "../registry.server";
 import type { FewShot } from "../../../../baml_client/types";
 
 const SANDBOX_SESSION_GUIDANCE = `
-You have a PERSISTENT Linux sandbox for this conversation. Files, installed
-packages, and shell state under /work survive across turns, and you share
-this workspace with the user's interactive terminal — they may inspect or
-edit files you create, and you can pick up where a previous turn left off.
+You have a PERSISTENT Linux sandbox for this conversation, shared with the
+user's interactive terminal. Within a session, files under /work persist across
+turns. Across sessions, only the durable folders below survive.
+
+Workspace layout:
+- /work/in  — uploads and files you saved in earlier sessions are RESTORED here
+              at the start of each session. Look here for the user's inputs.
+- /work/out — write any file the user should KEEP (a report, an updated
+              spreadsheet, generated data) here. Files in /work/out are saved to
+              the Data Stash and restored into /work/in next time.
+- /work     — anything else is scratch; it is cleared when the sandbox recycles.
 
 Available tools (all run inside the sandbox VM):
 - sandbox_bash: run a shell command. Python 3 is available.
@@ -39,12 +46,12 @@ Available tools (all run inside the sandbox VM):
 - sandbox_list / sandbox_search: inspect the working directory.
 
 Guidance:
-1. Build incrementally — reuse files and results from earlier turns instead
-   of recreating them. Check what's already in /work before starting fresh.
+1. Build incrementally — check /work/in and /work for files from earlier turns
+   before recreating anything.
 2. For anything computational, run code in the sandbox rather than guessing.
-3. When a task asks for a FILE, actually write it with sandbox_write (don't
-   just compute the answer with a throwaway python3 -c). The user can inspect
-   /work in their terminal, so the file is the deliverable.
+3. When a task produces a FILE the user should keep, write it to /work/out
+   (don't just compute the answer with a throwaway python3 -c). That file is the
+   deliverable and is what persists to the Data Stash.
 4. Let the critic decide completion — you don't need a Return tool. Focus on
    producing the right tool call; the critic ends the loop when the result is
    sufficient.
@@ -98,6 +105,10 @@ async function createPatterns(sessionId: string): Promise<ConfiguredPattern<Sess
     sessionId,
     rootfs: "base",
     egress: "mcp-only",
+    // Durable workspace (#89): hydrate the conversation's stored documents into
+    // /work/in on first boot, promote /work/out deliverables back to the Data
+    // Stash each turn — so uploads/outputs survive idle eviction and reconnects.
+    syncWorkspace: true,
   })(loop);
 
   const synth = synthesizer<SessionData>({

--- a/ui/src/lib/sandbox/attachment-table.server.ts
+++ b/ui/src/lib/sandbox/attachment-table.server.ts
@@ -30,6 +30,14 @@ export interface Attachment {
   readonly transport: McpTransport
   refCount: number
   lastUsedAt: number
+  /**
+   * True until the workspace has been hydrated into this (fresh) container.
+   * Set `true` on first boot; the `withSandbox` wrapper hydrates `/work` from
+   * the document store once and flips it to `false` so subsequent same-session
+   * turns (which reuse this live attachment) don't re-hydrate (#89). A reconnect
+   * after idle eviction boots a fresh container → new attachment → `true` again.
+   */
+  isFirstBoot: boolean
 }
 
 export interface AttachmentTableConfig {
@@ -84,6 +92,7 @@ export class AttachmentTable {
         transport,
         refCount: 1,
         lastUsedAt: Date.now(),
+        isFirstBoot: true,
       }
       this.table.set(id, att)
       return att

--- a/ui/src/lib/sandbox/with-sandbox.server.ts
+++ b/ui/src/lib/sandbox/with-sandbox.server.ts
@@ -24,6 +24,7 @@ import { DockerBackend } from './docker-backend.server'
 import { runWithSandbox } from './scope.server'
 import { SandboxScheduler } from './scheduler.server'
 import { WarmPool } from './warm-pool.server'
+import { hydrateWorkspace, snapshotOutputs, promoteOutputs } from './work-artifacts.server'
 import type { ComputeBackend, RootfsId, RuntimeConfig } from './types'
 import type {
   ConfiguredPattern,
@@ -62,6 +63,14 @@ export interface WithSandboxConfig {
   scheduler?: SandboxScheduler
   /** Attachment table override. Defaults to a process-shared instance. */
   attachments?: AttachmentTable
+  /**
+   * Durable workspace sync (#89). When true (id-addressable path only), the
+   * session's stored documents are hydrated into `/work/in` on first boot and
+   * new/changed files under `/work/out` are promoted back to the document store
+   * on each turn's exit. Off by default — opt in per agent (Sandbox · Session
+   * does). Requires the MCP gateway (document store lives in Redis).
+   */
+  syncWorkspace?: boolean
 }
 
 // Process-shared singletons, lazily constructed from DEFAULT_SETTINGS. Cap
@@ -147,6 +156,7 @@ export function withSandbox(config?: WithSandboxConfig) {
     const sessionId = config?.sessionId ?? 'default'
     const id = config?.id
     const fresh = config?.fresh === true
+    const syncWorkspace = config?.syncWorkspace === true
 
     const fn = async (
       scope: PatternScope<T>,
@@ -172,6 +182,8 @@ export function withSandbox(config?: WithSandboxConfig) {
             scope,
             view,
             pattern,
+            sessionId,
+            syncWorkspace,
           )
         }
         if (fresh) {
@@ -253,13 +265,39 @@ async function runWithIdAttachment<T>(
   scope: PatternScope<T>,
   view: EventView,
   pattern: ConfiguredPattern<T>,
+  sessionId: string,
+  syncWorkspace: boolean,
 ): Promise<PatternScope<T>> {
   if (fresh) {
     await attachments.destroyById(id).catch(() => {})
   }
   const att = await attachments.acquire(id, rootfs, runtime)
   try {
-    return await runWithSandbox(att.transport, () => pattern.fn(scope, view))
+    // Without workspace sync (the default), run the pattern directly — no
+    // document-store / extra transport traffic. Keeps plain `{ id }` sandboxes
+    // (and their tests) free of the persistence machinery.
+    if (!syncWorkspace) {
+      return await runWithSandbox(att.transport, () => pattern.fn(scope, view))
+    }
+    return await runWithSandbox(att.transport, async () => {
+      // First boot of a fresh container → restore the session's stored
+      // documents into /work/in. Reused live attachments skip this (#89).
+      if (att.isFirstBoot) {
+        await hydrateWorkspace(att.transport, sessionId).catch(() => {})
+        att.isFirstBoot = false
+      }
+      // Promote only what THIS turn produces: snapshot /work/out before the
+      // turn, diff after. In `finally` so deliverables are saved even if the
+      // pattern throws.
+      const baseline = await snapshotOutputs(att.transport).catch(
+        () => new Map<string, string>(),
+      )
+      try {
+        return await pattern.fn(scope, view)
+      } finally {
+        await promoteOutputs(att.transport, sessionId, baseline).catch(() => {})
+      }
+    })
   } finally {
     attachments.release(att)
   }

--- a/ui/src/lib/sandbox/work-artifacts.server.ts
+++ b/ui/src/lib/sandbox/work-artifacts.server.ts
@@ -1,0 +1,120 @@
+/**
+ * work-artifacts — bridge the durable document store and a sandbox `/work` (#89).
+ *
+ *   hydrateWorkspace : on first boot, write the session's stored documents into
+ *                      `/work/in` so the agent can operate on prior uploads /
+ *                      earlier deliverables.
+ *   snapshotOutputs  : hash `/work/out` at turn entry (the promote baseline).
+ *   promoteOutputs   : at turn exit, store files that are new/changed under
+ *                      `/work/out` back into the document store (text verbatim,
+ *                      binary as base64), so they survive container eviction and
+ *                      show up in the Data Stash.
+ *
+ * Best-effort per file: one bad file never aborts the turn. Keyed by sessionId,
+ * which for the Sandbox · Session agent equals the conversation id (the same
+ * key uploads are stored under).
+ */
+
+import { assertServerOnImport } from '../harness-patterns/assert.server'
+import {
+  listDocuments,
+  getDocument,
+  storeDocument,
+  type CallTool,
+} from '../document-store.server'
+import { guessMimeType, isTextMime } from '../stash/upload-service.server'
+import type { McpTransport } from './types'
+import {
+  WORK_IN_DIR,
+  WORK_OUT_DIR,
+  writeWorkFile,
+  readWorkFile,
+  listWorkFiles,
+  diffWorkFiles,
+} from './work-sync.server'
+
+assertServerOnImport()
+
+/** Reduce a stored filename to a safe basename for `/work/in` (no path
+ *  traversal, no shell-hostile characters). */
+function safeBasename(name: string): string {
+  const base = name.replace(/^.*[\\/]/, '').replace(/[^\w.\- ]+/g, '_').trim()
+  return base || 'file'
+}
+
+/**
+ * Write every (visible) stored document for the session into `/work/in`.
+ * Returns the number of files written. Hidden/archived docs are skipped
+ * (they're excluded from the agent's context elsewhere too).
+ */
+export async function hydrateWorkspace(
+  transport: McpTransport,
+  sessionId: string,
+  callTool?: CallTool,
+): Promise<number> {
+  const metas = await listDocuments(sessionId, callTool)
+  let written = 0
+  for (const meta of metas) {
+    if (meta.hidden || meta.archived) continue
+    const doc = await getDocument(sessionId, meta.id, callTool)
+    if (!doc) continue
+    const encoding = doc.encoding === 'base64' ? 'base64' : 'utf8'
+    const dest = `${WORK_IN_DIR}/${safeBasename(doc.filename)}`
+    try {
+      await writeWorkFile(transport, dest, doc.content, encoding)
+      written++
+    } catch {
+      // Best-effort: a single unwritable file shouldn't block the others.
+    }
+  }
+  return written
+}
+
+/** Hash `/work/out` so a later {@link promoteOutputs} only stores what this
+ *  turn actually produced (relative path → sha256). */
+export async function snapshotOutputs(
+  transport: McpTransport,
+): Promise<Map<string, string>> {
+  return listWorkFiles(transport, WORK_OUT_DIR)
+}
+
+/**
+ * Store files under `/work/out` that are new or changed since `baseline` into
+ * the document store. Returns the filenames promoted. Text files (by mimetype)
+ * are stored verbatim; everything else is read out as base64 and stored with
+ * `encoding: 'base64'` so the original bytes round-trip.
+ */
+export async function promoteOutputs(
+  transport: McpTransport,
+  sessionId: string,
+  baseline: Map<string, string>,
+  callTool?: CallTool,
+): Promise<string[]> {
+  const current = await listWorkFiles(transport, WORK_OUT_DIR)
+  const changed = diffWorkFiles(baseline, current)
+  const promoted: string[] = []
+  for (const rel of changed) {
+    const abs = `${WORK_OUT_DIR}/${rel}`
+    const filename = rel.replace(/^.*\//, '')
+    const mimeType = guessMimeType(filename)
+    const text = isTextMime(mimeType)
+    try {
+      const content = await readWorkFile(transport, abs, text ? 'utf8' : 'base64')
+      await storeDocument(
+        {
+          sessionId,
+          filename,
+          mimeType,
+          content,
+          ...(text ? {} : { encoding: 'base64' as const }),
+        },
+        callTool,
+      )
+      promoted.push(filename)
+    } catch {
+      // Best-effort: skip a file that can't be read/stored (e.g. over the size
+      // cap) without failing the turn.
+    }
+  }
+  return promoted
+}

--- a/ui/src/lib/sandbox/work-sync.server.ts
+++ b/ui/src/lib/sandbox/work-sync.server.ts
@@ -1,0 +1,171 @@
+/**
+ * work-sync — move files between the host and a sandbox VM's `/work` (#89).
+ *
+ * The durable workspace lives in the document store (Redis); `/work` is
+ * ephemeral scratch. On first boot we *hydrate* the session's documents into
+ * `/work/in`; on each turn's exit we *promote* new/changed files under
+ * `/work/out` back to the store. This module owns only the file movement +
+ * change detection over an `McpTransport`; the lifecycle wiring (when to call
+ * it) lives in `with-sandbox.server.ts`.
+ *
+ * Transport constraints (see `docker-backend.server.ts` / `rootfs/mcp-shell`):
+ *   - `sandbox_read` / `sandbox_write` are TEXT-only (rust-mcp-filesystem).
+ *   - `sandbox_bash` returns `{ stdout, stderr, exit_code, timed_out }` and
+ *     reports a non-zero exit as `success: false`.
+ *
+ * Binary (xlsx, pdf, …) therefore moves as base64 staged through a `.b64` text
+ * file, encoded/decoded in-VM with `base64` — never through a bash arg (ARG_MAX)
+ * or through bash stdout (parsing). Text moves directly.
+ */
+
+import { assertServerOnImport } from '../harness-patterns/assert.server'
+import type { McpTransport } from './types'
+
+assertServerOnImport()
+
+/** Conventional workspace layout. Inputs are read-only hydrated docs; the agent
+ *  writes deliverables it wants kept under OUT. STAGE holds transient `.b64`. */
+export const WORK_IN_DIR = '/work/in'
+export const WORK_OUT_DIR = '/work/out'
+
+export type WorkEncoding = 'utf8' | 'base64'
+
+/** Single-quote a string for safe interpolation into a `bash -lc` command. */
+function shq(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`
+}
+
+interface BashOutcome {
+  ok: boolean
+  stdout: string
+  stderr: string
+  code: number
+}
+
+/** Run a command in-VM and normalize the shell tool's result shape. */
+async function bash(transport: McpTransport, command: string): Promise<BashOutcome> {
+  const res = await transport.callTool('sandbox_bash', { command })
+  const d = (res.data ?? {}) as { stdout?: string; stderr?: string; exit_code?: number }
+  const code = typeof d.exit_code === 'number' ? d.exit_code : res.success ? 0 : 1
+  return {
+    ok: res.success && code === 0,
+    stdout: d.stdout ?? '',
+    stderr: d.stderr ?? (res.success ? '' : res.error ?? ''),
+    code,
+  }
+}
+
+function dirOf(absPath: string): string {
+  const i = absPath.lastIndexOf('/')
+  return i <= 0 ? '/' : absPath.slice(0, i)
+}
+
+function asString(data: unknown): string {
+  return typeof data === 'string' ? data : data == null ? '' : String(data)
+}
+
+/**
+ * Write a file into `/work`. `content` is literal UTF-8 (`utf8`) or base64 of
+ * the original bytes (`base64`). Parent dirs are created. Binary is staged as a
+ * `.b64` text file and decoded in-VM.
+ */
+export async function writeWorkFile(
+  transport: McpTransport,
+  absPath: string,
+  content: string,
+  encoding: WorkEncoding,
+): Promise<void> {
+  await bash(transport, `mkdir -p ${shq(dirOf(absPath))}`)
+
+  if (encoding === 'utf8') {
+    const res = await transport.callTool('sandbox_write', { path: absPath, content })
+    if (!res.success) {
+      throw new Error(`sandbox_write failed for ${absPath}: ${res.error ?? 'unknown error'}`)
+    }
+    return
+  }
+
+  // Binary: stage base64 as text, then decode to bytes in-VM.
+  const stage = `${absPath}.b64`
+  const staged = await transport.callTool('sandbox_write', { path: stage, content })
+  if (!staged.success) {
+    throw new Error(`staging base64 write failed for ${stage}: ${staged.error ?? 'unknown error'}`)
+  }
+  const decoded = await bash(
+    transport,
+    `base64 -d ${shq(stage)} > ${shq(absPath)} && rm -f ${shq(stage)}`,
+  )
+  if (!decoded.ok) {
+    throw new Error(`base64 decode failed for ${absPath}: ${decoded.stderr}`)
+  }
+}
+
+/**
+ * Read a file out of `/work`. Returns the content as UTF-8 text (`utf8`) or
+ * base64 of the original bytes (`base64`). Binary is encoded in-VM to a `.b64`
+ * text file and read back, so the bytes survive the text-only transport.
+ */
+export async function readWorkFile(
+  transport: McpTransport,
+  absPath: string,
+  encoding: WorkEncoding,
+): Promise<string> {
+  if (encoding === 'utf8') {
+    const res = await transport.callTool('sandbox_read', { path: absPath })
+    if (!res.success) {
+      throw new Error(`sandbox_read failed for ${absPath}: ${res.error ?? 'unknown error'}`)
+    }
+    return asString(res.data)
+  }
+
+  const stage = `${absPath}.b64`
+  // GNU coreutils (debian rootfs): -w 0 disables line wrapping → one clean line.
+  const enc = await bash(transport, `base64 -w 0 ${shq(absPath)} > ${shq(stage)}`)
+  if (!enc.ok) {
+    throw new Error(`base64 encode failed for ${absPath}: ${enc.stderr}`)
+  }
+  const res = await transport.callTool('sandbox_read', { path: stage })
+  await bash(transport, `rm -f ${shq(stage)}`)
+  if (!res.success) {
+    throw new Error(`reading staged base64 failed for ${absPath}: ${res.error ?? 'unknown error'}`)
+  }
+  return asString(res.data).trim()
+}
+
+/**
+ * List files under `dir` (default `/work/out`) as a map of POSIX-relative path
+ * → sha256, computed in-VM. Missing dir → empty map (the dir is created so the
+ * agent can always write there). Hashing in-VM avoids pulling unchanged bytes
+ * back across the transport just to diff them.
+ */
+export async function listWorkFiles(
+  transport: McpTransport,
+  dir: string = WORK_OUT_DIR,
+): Promise<Map<string, string>> {
+  const cmd =
+    `mkdir -p ${shq(dir)} && cd ${shq(dir)} && ` +
+    `find . -type f -exec sha256sum {} + 2>/dev/null || true`
+  const r = await bash(transport, cmd)
+  const map = new Map<string, string>()
+  for (const line of r.stdout.split('\n')) {
+    const m = /^([0-9a-f]{64})\s+\.\/(.+)$/.exec(line.trim())
+    if (m) map.set(m[2], m[1])
+  }
+  return map
+}
+
+/**
+ * Paths present in `current` whose hash differs from `baseline` (new or
+ * changed since the baseline snapshot). Deletions are intentionally ignored —
+ * promotion never removes already-stored documents.
+ */
+export function diffWorkFiles(
+  baseline: Map<string, string>,
+  current: Map<string, string>,
+): string[] {
+  const changed: string[] = []
+  for (const [rel, hash] of current) {
+    if (baseline.get(rel) !== hash) changed.push(rel)
+  }
+  return changed.sort()
+}

--- a/ui/src/lib/settings.ts
+++ b/ui/src/lib/settings.ts
@@ -52,7 +52,10 @@ export const DEFAULT_SETTINGS: HarnessSettings = {
     globalCap: 16,
     perSessionCap: 4,
     warmPool: { base: 1 },
-    idleEvictMs: 300_000,
+    // Hot-cache window only: a parked VM is reused instantly within this window.
+    // Durable workspace state lives in the document store (hydrated into /work on
+    // first boot, promoted from /work/out on exit), so this need not be long — 1h.
+    idleEvictMs: 3_600_000,
     defaultTimeoutSec: 60,
     defaultMemoryMB: 512,
     defaultEgress: 'mcp-only',

--- a/ui/src/lib/stash/upload-service.server.ts
+++ b/ui/src/lib/stash/upload-service.server.ts
@@ -10,10 +10,11 @@
  *   - `application/json` `{ sessionId, filename, mimeType, content, ttlSeconds? }`
  *     — the programmatic path (and what #89 / the sandbox lane can call).
  *
- * Both yield a {@link StoreDocumentInput} for `document-store.server.ts`. Binary
- * formats (PDF, xlsx, …) are decoded as UTF-8 text here — true text extraction
- * is left to the caller, matching the document-store contract ("`content` is
- * opaque UTF-8 text").
+ * Both yield a {@link StoreDocumentInput} for `document-store.server.ts`. Text
+ * formats are stored as UTF-8; recognized binary formats (xlsx, pdf, images, …)
+ * are base64-encoded with `encoding: 'base64'` so the original bytes round-trip
+ * through the sandbox `/work` flow (#89). Semantic text extraction from binaries
+ * (for RAG/search) is still left to the caller.
  */
 
 import { assertServerOnImport } from '../harness-patterns/assert.server'
@@ -35,6 +36,19 @@ const MIME_BY_EXT: Record<string, string> = {
   yaml: 'application/yaml',
   yml: 'application/yaml',
   log: 'text/plain',
+  // Common binary types — so a file arriving without a usable `blob.type`
+  // (e.g. the JSON intake path) is still classified binary and base64-encoded.
+  pdf: 'application/pdf',
+  xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  xls: 'application/vnd.ms-excel',
+  docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  gif: 'image/gif',
+  webp: 'image/webp',
+  zip: 'application/zip',
+  parquet: 'application/vnd.apache.parquet',
 }
 
 /** Best-effort MIME from a filename extension; defaults to `text/plain`. */
@@ -43,6 +57,17 @@ export function guessMimeType(filename: string): string {
   if (dot < 0 || dot === filename.length - 1) return 'text/plain'
   const ext = filename.slice(dot + 1).toLowerCase()
   return MIME_BY_EXT[ext] ?? 'text/plain'
+}
+
+/**
+ * Whether a MIME type holds UTF-8 text we can store verbatim. Everything else
+ * (xlsx, pdf, images, zip, …) is treated as binary → base64. Covers `text/*`
+ * plus the structured text application types and `+json`/`+xml` suffixes.
+ */
+export function isTextMime(mimeType: string): boolean {
+  const m = mimeType.toLowerCase()
+  if (m.startsWith('text/')) return true
+  return /^application\/(json|xml|yaml|x-yaml|x-ndjson|.*\+json|.*\+xml)$/.test(m)
 }
 
 /**
@@ -69,11 +94,17 @@ export async function parseUploadRequest(
     const ttlRaw = form.get('ttlSeconds')
     const ttlSeconds =
       ttlRaw != null && ttlRaw !== '' ? Number(ttlRaw) : undefined
+    const mimeType = blob.type || guessMimeType(filename)
+    const isText = isTextMime(mimeType)
+    const content = isText
+      ? await blob.text()
+      : Buffer.from(await blob.arrayBuffer()).toString('base64')
     return {
       sessionId,
       filename,
-      mimeType: blob.type || guessMimeType(filename),
-      content: await blob.text(),
+      mimeType,
+      content,
+      ...(isText ? {} : { encoding: 'base64' as const }),
       ...(Number.isFinite(ttlSeconds) ? { ttlSeconds } : {}),
     }
   }
@@ -94,6 +125,7 @@ export async function parseUploadRequest(
     filename,
     mimeType: body.mimeType?.trim() || guessMimeType(filename),
     content: body.content,
+    ...(body.encoding === 'base64' ? { encoding: 'base64' as const } : {}),
     ...(typeof body.ttlSeconds === 'number' ? { ttlSeconds: body.ttlSeconds } : {}),
   }
 }

--- a/ui/src/routes/api/stash/document/[id].ts
+++ b/ui/src/routes/api/stash/document/[id].ts
@@ -1,7 +1,9 @@
 /**
  * Data Stash single-document API (Issue #6)
  *
- *   GET    /api/stash/document/:id?sessionId  — full document (content + meta)
+ *   GET    /api/stash/document/:id?sessionId            — full document (content + meta)
+ *   GET    /api/stash/document/:id?sessionId&download   — raw file stream
+ *                                               (base64-decoded for binary)
  *   DELETE /api/stash/document/:id?sessionId  — remove from Redis + index
  *   PATCH  /api/stash/document/:id            — toggle hide/archive flags
  *                                               body: { sessionId, hidden?, archived? }
@@ -28,6 +30,27 @@ export async function GET(event: APIEvent) {
     if (!sessionId) return json({ error: 'sessionId is required' }, 400)
     const doc = await getDocument(sessionId, event.params.id)
     if (!doc) return json({ error: 'Document not found' }, 404)
+
+    // ?download → stream the raw file with its original content-type, so the
+    // DataStash UI can offer a real download. Binary docs are base64-decoded
+    // back to bytes; text docs stream verbatim.
+    if (new URL(event.request.url).searchParams.has('download')) {
+      const isBinary = doc.encoding === 'base64'
+      const body = isBinary ? Buffer.from(doc.content, 'base64') : doc.content
+      const filename = doc.filename.replace(/["\r\n]/g, '')
+      return new Response(body as BodyInit, {
+        headers: {
+          'Content-Type': doc.mimeType || 'application/octet-stream',
+          'Content-Disposition': `attachment; filename="${filename}"`,
+          'Content-Length': String(
+            isBinary
+              ? (body as Buffer).length
+              : Buffer.byteLength(doc.content, 'utf8'),
+          ),
+        },
+      })
+    }
+
     return json({ document: doc })
   })
 }

--- a/ui/src/routes/api/stash/ingest.ts
+++ b/ui/src/routes/api/stash/ingest.ts
@@ -34,6 +34,14 @@ export async function POST(event: APIEvent) {
 
     const doc = await getDocument(body.sessionId, body.docId)
     if (!doc) return json({ error: 'Document not found' }, 404)
+    // Binary (base64) documents hold raw bytes, not text — chunking/embedding
+    // them would index garbage. RAG ingestion is text-only (#89).
+    if (doc.encoding === 'base64') {
+      return json(
+        { error: 'Cannot ingest a binary document; text search applies to text content only' },
+        415,
+      )
+    }
 
     try {
       const result = await ingestDocument(doc, {


### PR DESCRIPTION
## Summary

Reconnecting to a persistent sandbox (`withSandbox({ id })`, the **Sandbox · Session** agent) returned an **empty `/work`** after a few minutes away: the workspace lifetime was glued to a disposable container (5-min idle eviction, warm-pool `reset`, and restarts all destroy `/work`, which has no durable backing).

This decouples them — **`/work` is ephemeral scratch; the DataStash (#6) is the durable store** — so an uploaded spreadsheet or a generated report survives idle eviction, restart, and next-day reconnects.

Closes the first slice of #89. Builds directly on the merged #6 document store (no parallel abstraction).

## How it works

`withSandbox({ id, sessionId, syncWorkspace: true })` (opt-in; Sandbox · Session sets it):

| Path | Role | Lifetime |
|------|------|----------|
| `/work/in`  | Uploads + prior deliverables, **restored on first boot** | Durable (DataStash) |
| `/work/out` | Files the agent wants kept, **promoted on each turn exit** | Durable (DataStash) |
| `/work/*`   | Scratch | Ephemeral |

- **Hydrate** (first boot only, via `Attachment.isFirstBoot`): `listDocuments(sessionId)` → `/work/in`. Reused live attachments skip it.
- **Promote** (turn exit, in `finally`): snapshot `/work/out` (in-VM `sha256sum`), diff, `storeDocument` each new/changed file. Deletions ignored.
- **Binary-faithful**: text stores verbatim; xlsx/pdf/images move as base64 staged through a `.b64` text file (the in-VM FS MCP is text-only) and store with `encoding: 'base64'`. Promoted files list in the DataStash panel like uploads; a `?download` route streams decoded bytes.

Only the `{ id }` path syncs — anonymous and `{ fresh: true }` sandboxes are untouched.

## Changes

**Storage (extends #6)** — `encoding: 'base64'` end-to-end (`document-store`, `upload-service`, `?download` on the document route), `size` = original bytes, ingest rejects binary (415).
**Sandbox** — `work-sync.server.ts` (host↔/work, text + base64), `work-artifacts.server.ts` (hydrate/promote), `attachment-table` `isFirstBoot`, `with-sandbox` `syncWorkspace` wiring, `idleEvictMs` 300_000 → 3_600_000 (now only the warm-cache horizon).
**Agent** — Sandbox · Session opts in + is taught the `/work/in` ÷ `/work/out` convention.
**UI** — DataStash Download action.
**Docs** — `docs/sandbox-plan.md` (new "Durable workspaces" section), `docs/sandbox/README.md`, `docs/DATA_STASH.md`, INDEX + READMEs (link, no mechanism duplication).

## Tests

`pnpm test:run` — **816 passing** (+13: work-sync 5, work-artifacts 2, document-store base64 +3, upload-service binary +3). `pnpm exec tsc --noEmit` — no new errors vs baseline.

## Deferred (tracked under #89)

Selective `withReferences`-driven hydration (vs. whole session set), an explicit `sandbox_publish` tool (needs an actorCritic synthetic-tool layer; `/work/out` convention used instead), and version/lineage UI (`parentArtifactId` not yet captured).

🤖 Generated with [Claude Code](https://claude.com/claude-code)