### PR TITLE
feat(semantic-cache): real embedding-based caching + shared vector-store helper

### DIFF
--- a/docs/DATA_STASH.md
+++ b/docs/DATA_STASH.md
@@ -18,7 +18,8 @@ query ─────────────────────── embe
 | `document-store.server.ts` (#6) | RedisJSON storage: CRUD, TTL, per-session index, hide/archive flags, `toPriorResult` adapter |
 | `chunking.server.ts` (#9) | Pure text chunking — `fixed` / `sentence` / `paragraph` + MIME-aware `chunkDocument` |
 | `embeddings.server.ts` (#8) | Provider-pluggable embedding with a one-model-per-corpus guard |
-| `document-ingest.server.ts` | Orchestrator: chunk → embed → Redis HNSW index, and `searchDocuments` (KNN) |
+| `vector-store.server.ts` | Shared RediSearch wrapper: `createVectorStore` → `ensureIndex` / `upsert` / `search`; owns the index/key/payload plumbing + naming (`spaceTag`) |
+| `document-ingest.server.ts` | Orchestrator: chunk → embed → vector store, and `searchDocuments` (KNN) |
 | `stash/upload-service.server.ts`, `stash/http.server.ts` | Upload request parsing (multipart + JSON), auth/response helpers |
 
 ## API routes (`ui/src/routes/api/stash/`)
@@ -63,6 +64,14 @@ Start the local embedder (separate from `pnpm dev:llama`, which serves a *chat* 
 ```bash
 llama-server --embedding -m models/Qwen3-Embedding-0.6B-Q8_0.gguf --port 8090 --ctx-size 8192
 ```
+
+## Shared vector store
+
+`vector-store.server.ts` is the single home for the embed-target Redis plumbing —
+`createVectorStore({ indexName, prefix, dim })` → `ensureIndex()` / `upsert(id, vector, payload, ttl)` / `search(queryVector, k)`. It owns index creation (tolerating "already exists"), the 2-writes-per-record format (vector + base64 `meta` payload), KNN result parsing, and the `spaceTag(space)` naming that keeps one index to one model. Both consumers use it:
+
+- **`document-ingest.server.ts`** — document chunks (index/prefix per `(session, space)`).
+- **Semantic Cache agent** (`harness-client/examples/semantic-cache.server.ts`) — caches query→result vectors in a global per-model index (`qcache_idx_{spaceTag}`). It embeds the query on read and write: L1 is an exact-hash `json_get`; L2 is a distance-thresholded KNN over the query embeddings (`SEMANTIC_HIT_MAX_DISTANCE`), best-effort so it degrades to exact-match + retrieval when the embedder/RediSearch is unavailable.
 
 ## Requirements & gotchas
 

--- a/ui/src/__tests__/lib/harness-client/examples/agents.test.ts
+++ b/ui/src/__tests__/lib/harness-client/examples/agents.test.ts
@@ -68,6 +68,18 @@ vi.mock('../../../../lib/harness-patterns/mcp-client.server', () => ({
   listTools: mockListTools(mockToolSets.all)
 }))
 
+// Mock embeddings — the Semantic Cache embeds queries on read + write; keep it
+// deterministic and offline. The vector-store the cache uses still routes its
+// Redis calls through callToolMock above.
+vi.mock('../../../../lib/embeddings.server', () => ({
+  embedOne: vi.fn(async () => ({
+    provider: 'local',
+    model: 'test-embed',
+    dimensions: 4,
+    vector: [0.1, 0.2, 0.3, 0.4],
+  })),
+}))
+
 // Mock BAML client
 vi.mock('../../../../../baml_client', () => ({
   b: {
@@ -626,17 +638,22 @@ describe('Semantic Cache Patterns', () => {
       const patterns = await semanticCacheAgent.createPatterns('test-session') as Pattern[]
       const cachePattern = patterns.find(p => p.config.patternId === 'semantic-cache')
 
-      // Mock cache miss from json_get but hit from vector search
+      // L1 (json_get) misses; L2 KNN returns a near neighbour within the distance
+      // threshold whose payload carries the cached result (no second lookup).
       callToolMock
-        .mockResolvedValueOnce({ success: false, data: null }) // json_get fails
-        .mockResolvedValueOnce({ success: true, data: [{ key: 'similar:key', score: 0.95 }] }) // vector_search_hash
-        .mockResolvedValueOnce({ success: true, data: { result: 'similar result' } }) // json_get for similar
+        .mockResolvedValueOnce({ success: false, data: null }) // json_get (L1) miss
+        .mockResolvedValueOnce({
+          success: true,
+          data: [{ meta: JSON.stringify({ result: 'similar result' }), score: 0.05 }],
+        }) // vector_search_hash (L2) — distance 0.05 < threshold
 
       const scope = createMockScope({ input: 'test query' })
       const view = createMockView()
 
       const result = await cachePattern!.fn(scope, view)
-      expect((result as typeof scope).data.cacheHit).toBe(true)
+      const out = (result as typeof scope).data as Record<string, unknown>
+      expect(out.cacheHit).toBe(true)
+      expect(out.cacheKind).toBe('semantic')
     })
   })
 

--- a/ui/src/__tests__/lib/vector-store.test.ts
+++ b/ui/src/__tests__/lib/vector-store.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Vector Store Tests
+ *
+ * Exercises the shared RediSearch wrapper (ensureIndex / upsert / search) and
+ * the payload encode/decode + naming helpers against a fake `callTool`.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+vi.mock('../../lib/harness-patterns/assert.server', () => ({
+  assertServerOnImport: vi.fn(),
+  assertServer: vi.fn(),
+}))
+vi.mock('../../lib/harness-patterns/mcp-client.server', () => ({
+  callTool: vi.fn(async () => ({ success: false, data: null, error: 'no gateway' })),
+}))
+
+import {
+  createVectorStore,
+  encodeMeta,
+  decodeMeta,
+  spaceTag,
+  sanitize,
+} from '../../lib/vector-store.server'
+import type { CallTool } from '../../lib/document-store.server'
+import type { ToolCallResult } from '../../lib/harness-patterns/types'
+
+function makeFakeRedis() {
+  const hashes = new Map<string, Record<string, unknown>>()
+  const indexes = new Map<string, { prefix: string; dim: number; metric: string }>()
+  const calls: Array<[string, Record<string, unknown>]> = []
+
+  const callTool = (async (name: string, args: Record<string, unknown>): Promise<ToolCallResult> => {
+    calls.push([name, args])
+    switch (name) {
+      case 'create_vector_index_hash':
+        indexes.set(args.index_name as string, {
+          prefix: args.prefix as string,
+          dim: args.dim as number,
+          metric: args.distance_metric as string,
+        })
+        return { success: true, data: 'Index created' }
+      case 'set_vector_in_hash': {
+        const key = args.name as string
+        const h = hashes.get(key) ?? {}
+        h.vector = args.vector
+        hashes.set(key, h)
+        return { success: true, data: true }
+      }
+      case 'hset': {
+        const key = args.name as string
+        const h = hashes.get(key) ?? {}
+        h[args.key as string] = args.value
+        hashes.set(key, h)
+        return { success: true, data: 1 }
+      }
+      case 'vector_search_hash': {
+        // Return every stored hash as a "match" (field dicts minus the vector).
+        const rows = Array.from(hashes.values()).map((h) => {
+          const { vector: _v, ...fields } = h
+          return { ...fields, score: 0.1 }
+        })
+        return { success: true, data: rows }
+      }
+      default:
+        return { success: false, data: null, error: `unhandled ${name}` }
+    }
+  }) as CallTool
+  return { hashes, indexes, calls, callTool }
+}
+
+describe('vector-store', () => {
+  let fake: ReturnType<typeof makeFakeRedis>
+  beforeEach(() => {
+    fake = makeFakeRedis()
+  })
+
+  describe('ensureIndex', () => {
+    it('creates an HNSW index with the given name/prefix/dim/metric', async () => {
+      const store = createVectorStore({ indexName: 'idx1', prefix: 'p:', dim: 8, callTool: fake.callTool })
+      await store.ensureIndex()
+      expect(fake.indexes.get('idx1')).toEqual({ prefix: 'p:', dim: 8, metric: 'COSINE' })
+    })
+
+    it('tolerates an "already exists" error', async () => {
+      const callTool: CallTool = async (name) =>
+        name === 'create_vector_index_hash'
+          ? { success: false, data: null, error: 'Index already exists' }
+          : { success: true, data: 1 }
+      const store = createVectorStore({ indexName: 'idx1', prefix: 'p:', dim: 8, callTool })
+      await expect(store.ensureIndex()).resolves.toBeUndefined()
+    })
+
+    it('throws on a non-exists index error', async () => {
+      const callTool: CallTool = async () => ({ success: false, data: null, error: 'WRONGTYPE boom' })
+      const store = createVectorStore({ indexName: 'idx1', prefix: 'p:', dim: 8, callTool })
+      await expect(store.ensureIndex()).rejects.toThrow(/WRONGTYPE/)
+    })
+  })
+
+  describe('upsert', () => {
+    it('stores a vector + base64 payload at prefix+id, with TTL', async () => {
+      const store = createVectorStore({ indexName: 'idx1', prefix: 'p:', dim: 3, callTool: fake.callTool })
+      await store.upsert('a', [1, 2, 3], { content: 'hi', n: 5 }, 60)
+
+      const h = fake.hashes.get('p:a')!
+      expect(h.vector).toEqual([1, 2, 3])
+      expect((h.meta as string).startsWith('b64:')).toBe(true)
+      const payload = decodeMeta(h.meta)
+      expect(payload).toMatchObject({ content: 'hi', n: 5, _vid: 'a' })
+
+      const hset = fake.calls.find((c) => c[0] === 'hset')!
+      expect(hset[1].expire_seconds).toBe(60)
+    })
+
+    it('throws when the vector write fails', async () => {
+      const callTool: CallTool = async (name) =>
+        name === 'set_vector_in_hash'
+          ? { success: false, data: null, error: 'boom' }
+          : { success: true, data: 1 }
+      const store = createVectorStore({ indexName: 'idx1', prefix: 'p:', dim: 3, callTool })
+      await expect(store.upsert('a', [1, 2, 3])).rejects.toThrow(/boom/)
+    })
+  })
+
+  describe('search', () => {
+    it('returns hits with decoded payloads, id (from _vid) and score', async () => {
+      const store = createVectorStore({ indexName: 'idx1', prefix: 'p:', dim: 3, callTool: fake.callTool })
+      await store.upsert('doc-1', [1, 2, 3], { content: 'alpha', kind: 'x' })
+      await store.upsert('doc-2', [4, 5, 6], { content: 'beta' })
+
+      const hits = await store.search([1, 2, 3], 5)
+      expect(hits.length).toBe(2)
+      const ids = hits.map((h) => h.id).sort()
+      expect(ids).toEqual(['doc-1', 'doc-2'])
+      const first = hits.find((h) => h.id === 'doc-1')!
+      expect(first.payload.content).toBe('alpha')
+      expect(first.score).toBe(0.1)
+      // The search targets the configured index with the right k.
+      const call = fake.calls.find((c) => c[0] === 'vector_search_hash')!
+      expect(call[1].index_name).toBe('idx1')
+      expect(call[1].k).toBe(5)
+    })
+
+    it('returns [] on an unsuccessful search', async () => {
+      const callTool: CallTool = async () => ({ success: false, data: null, error: 'no index' })
+      const store = createVectorStore({ indexName: 'idx1', prefix: 'p:', dim: 3, callTool })
+      expect(await store.search([1, 2, 3])).toEqual([])
+    })
+
+    it('parses a JSON-string meta and a {result} wrapper shape', async () => {
+      // Mimic a backend that returns rows under a key, with meta as raw JSON.
+      const callTool: CallTool = async (name) =>
+        name === 'vector_search_hash'
+          ? {
+              success: true,
+              data: { results: [{ meta: JSON.stringify({ result: 'r', _vid: 'q1' }), score: 0.04 }] },
+            }
+          : { success: true, data: 1 }
+      const store = createVectorStore({ indexName: 'idx1', prefix: 'p:', dim: 3, callTool })
+      const hits = await store.search([0, 0, 0], 1)
+      expect(hits).toHaveLength(1)
+      expect(hits[0].id).toBe('q1')
+      expect(hits[0].payload.result).toBe('r')
+      expect(hits[0].score).toBe(0.04)
+    })
+  })
+
+  describe('helpers', () => {
+    it('encodeMeta/decodeMeta round-trip', () => {
+      const enc = encodeMeta({ a: 1, b: 'x' })
+      expect(enc.startsWith('b64:')).toBe(true)
+      expect(decodeMeta(enc)).toEqual({ a: 1, b: 'x' })
+    })
+    it('decodeMeta tolerates plain JSON string and object', () => {
+      expect(decodeMeta('{"a":1}')).toEqual({ a: 1 })
+      expect(decodeMeta({ a: 1 })).toEqual({ a: 1 })
+      expect(decodeMeta('not json')).toEqual({})
+    })
+    it('spaceTag encodes provider_model_dim (sanitized)', () => {
+      expect(spaceTag({ provider: 'local', model: 'Qwen3-Embedding-0.6B', dimensions: 1024 })).toBe(
+        'local_Qwen3_Embedding_0_6B_1024',
+      )
+      expect(sanitize('a/b.c:d')).toBe('a_b_c_d')
+    })
+  })
+})

--- a/ui/src/lib/document-ingest.server.ts
+++ b/ui/src/lib/document-ingest.server.ts
@@ -4,37 +4,31 @@
  * The capstone of the store → chunk → embed pipeline. Takes a stored
  * {@link StashDocument} and makes it *searchable*:
  *
- *   chunkDocument(content)  →  embed(chunks)  →  Redis vector hashes + HNSW index
+ *   chunkDocument(content)  →  embed(chunks)  →  vector store (RediSearch HNSW)
  *
  * and answers queries:
  *
- *   embedOne(query)  →  vector_search_hash  →  top-k chunks (with provenance)
+ *   embedOne(query)  →  vector store KNN  →  top-k chunks (with provenance)
+ *
+ * The Redis vector plumbing (index, upsert, KNN, payload encoding) lives in the
+ * shared `vector-store.server.ts` — this module owns the document-specific
+ * policy: chunking, embedding, and the one-model-per-corpus guard.
  *
  * ── One embedding space per session corpus ────────────────────────────────
- * Vectors are only comparable within one model (see `embeddings.server.ts`).
- * This module makes that structural, not advisory:
- *   - The Redis key prefix AND index name both encode the embedding space
- *     (`provider_model_dim`), so a hash embedded with model A can never land in
- *     model B's index — different prefix, different index, different `dim`.
- *   - The session's space is recorded at `stash:space:{sessionId}`. Re-ingesting
- *     with a *different* model throws (unless `allowSpaceChange`), and queries
- *     are always embedded with the recorded model — so a search can never
- *     compare across spaces.
+ * Vectors are only comparable within one model. The vector store's index name
+ * AND key prefix both encode the embedding space (`provider_model_dim`), so a
+ * chunk embedded with model A can never land in model B's index. The session's
+ * space is recorded at `stash:space:{sessionId}`; re-ingesting with a different
+ * model throws (unless `allowSpaceChange`), and queries are always embedded with
+ * the recorded model — so a search can never compare across spaces.
  *
- * Redis is reached via the injectable MCP `callTool` (defaults to the real
- * client) and embedding via an injectable embed fn, so the whole orchestrator
- * is unit-testable without a live gateway or model server — mirroring
- * `document-store.server.ts`.
+ * Redis + embedding are injectable so the orchestrator is unit-testable without
+ * a live gateway or model server.
  */
 
 import { assertServerOnImport } from './harness-patterns/assert.server'
 import { callTool as defaultCallTool } from './harness-patterns/mcp-client.server'
-import {
-  DEFAULT_TTL_SECONDS,
-  redisWriteError,
-  type CallTool,
-  type StashDocument,
-} from './document-store.server'
+import { DEFAULT_TTL_SECONDS, type CallTool, type StashDocument } from './document-store.server'
 import { chunkDocument, type Chunk, type ChunkConfig } from './chunking.server'
 import {
   embed as defaultEmbed,
@@ -45,6 +39,7 @@ import {
   type EmbeddingSpace,
   type SingleEmbeddingResult,
 } from './embeddings.server'
+import { createVectorStore, sanitize, spaceTag } from './vector-store.server'
 
 assertServerOnImport()
 
@@ -53,27 +48,20 @@ assertServerOnImport()
 // ============================================================================
 
 export interface IngestOptions {
-  /** Chunking config override (strategy / maxChars / overlap). */
   chunk?: Partial<ChunkConfig>
-  /** Embedding provider/model override. */
   embedding?: EmbeddingConfig
-  /** TTL for the chunk hashes; defaults to the document TTL window. */
   ttlSeconds?: number
-  /** Allow re-ingesting a session under a different embedding space (splits
-   *  the corpus — off by default to preserve comparability). */
+  /** Allow re-ingesting a session under a different embedding space (splits the
+   *  corpus — off by default to preserve comparability). */
   allowSpaceChange?: boolean
-  /** Injected Redis MCP caller (tests). */
   callTool?: CallTool
-  /** Injected embed fn (tests). */
   embedFn?: (texts: string[], config?: EmbeddingConfig) => Promise<EmbeddingResult>
 }
 
 export interface IngestResult {
   docId: string
   sessionId: string
-  /** Number of chunks embedded + indexed. */
   chunks: number
-  /** The embedding space this corpus is bound to. */
   space: EmbeddingSpace
   indexName: string
   prefix: string
@@ -99,19 +87,10 @@ export interface SearchOptions {
 }
 
 // ============================================================================
-// Key / index naming — the space is baked into both
+// Naming (the space is baked into both the index name and the key prefix)
 // ============================================================================
 
 const SPACE_KEY_PREFIX = 'stash:space'
-
-function sanitize(s: string): string {
-  return s.replace(/[^a-zA-Z0-9]+/g, '_').replace(/^_+|_+$/g, '')
-}
-
-/** `provider_model_dim` — equal tags ⇒ comparable vectors. */
-function spaceTag(space: EmbeddingSpace): string {
-  return `${space.provider}_${sanitize(space.model)}_${space.dimensions}`
-}
 
 export function indexNameFor(sessionId: string, space: EmbeddingSpace): string {
   return `stash_idx_${sanitize(sessionId)}_${spaceTag(space)}`
@@ -121,41 +100,8 @@ export function prefixFor(sessionId: string, space: EmbeddingSpace): string {
   return `stashvec:${sessionId}:${spaceTag(space)}:`
 }
 
-function chunkKey(prefix: string, docId: string, chunkIndex: number): string {
-  return `${prefix}${docId}:${chunkIndex}`
-}
-
 function spaceKey(sessionId: string): string {
   return `${SPACE_KEY_PREFIX}:${sessionId}`
-}
-
-/**
- * Encode a chunk's content+provenance as an opaque, non-JSON string. The MCP
- * gateway auto-parses JSON-looking string arguments into objects (so a JSON
- * `hset` value is rejected as a dict, and a chunk that is itself valid JSON
- * would be mangled). `b64:`-prefixed base64 sidesteps both.
- */
-function encodeMeta(obj: Record<string, unknown>): string {
-  return 'b64:' + Buffer.from(JSON.stringify(obj), 'utf8').toString('base64')
-}
-
-/** Inverse of {@link encodeMeta}; tolerant of an already-object or plain-JSON value. */
-export function decodeMeta(raw: unknown): Record<string, unknown> {
-  if (raw && typeof raw === 'object') return raw as Record<string, unknown>
-  if (typeof raw !== 'string') return {}
-  let s = raw
-  if (s.startsWith('b64:')) {
-    try {
-      s = Buffer.from(s.slice(4), 'base64').toString('utf8')
-    } catch {
-      return {}
-    }
-  }
-  try {
-    return JSON.parse(s) as Record<string, unknown>
-  } catch {
-    return {}
-  }
 }
 
 // ============================================================================
@@ -203,7 +149,7 @@ async function recordSpace(
 // ============================================================================
 
 /**
- * Chunk → embed → index a stored document into Redis for similarity search.
+ * Chunk → embed → index a stored document into the vector store for search.
  *
  * @throws if the session already has a different embedding space (and
  *         `allowSpaceChange` is not set), or if Redis writes fail.
@@ -230,41 +176,30 @@ export async function ingestDocument(
 
   const indexName = indexNameFor(doc.sessionId, space)
   const prefix = prefixFor(doc.sessionId, space)
-  await ensureVectorIndex(callTool, indexName, prefix, space.dimensions)
+  const store = createVectorStore({ indexName, prefix, dim: space.dimensions, callTool })
+  await store.ensureIndex()
 
-  // Write each chunk in just TWO round-trips: the vector (must be a packed
-  // float blob, so set_vector_in_hash) plus a single JSON `meta` field holding
-  // the content AND provenance. The gateway runs the redis MCP over one serial
-  // stdio pipe, so call count is the ingest cost and concurrent writes only
-  // queue up and time out — keep it minimal and sequential. TTL is set on the
-  // meta write (per-key; it covers the whole hash).
-  for (let idx = 0; idx < chunks.length; idx++) {
-    const c = chunks[idx]
-    const key = chunkKey(prefix, doc.id, c.index)
-
-    const setVec = await callTool('set_vector_in_hash', { name: key, vector: vectors[idx] })
-    const vecErr = redisWriteError(setVec)
-    if (vecErr) throw new Error(`Failed to store vector for chunk ${c.index}: ${vecErr}`)
-
-    // base64 the JSON blob: the gateway auto-parses JSON-looking string args
-    // into objects (hset then rejects the dict), and a raw chunk could itself
-    // be valid JSON — so encode to an opaque string. The `b64:` prefix makes it
-    // unambiguously non-JSON. Decoded in parseSearchHits.
-    const meta = encodeMeta({
-      content: c.content,
-      doc_id: doc.id,
-      session_id: doc.sessionId,
-      source: doc.filename,
-      chunk_index: c.index,
-      start_offset: c.startOffset,
-      end_offset: c.endOffset,
-      model: space.model,
-      provider: space.provider,
-      dim: space.dimensions,
-    })
-    const metaRes = await callTool('hset', { name: key, key: 'meta', value: meta, expire_seconds: ttl })
-    const metaErr = redisWriteError(metaRes)
-    if (metaErr) throw new Error(`Failed to store chunk ${c.index} meta: ${metaErr}`)
+  // Sequential: the gateway runs the redis MCP over one serial stdio pipe, so
+  // concurrent writes only queue and time out. Each chunk is 2 Redis calls.
+  for (let i = 0; i < chunks.length; i++) {
+    const c = chunks[i]
+    await store.upsert(
+      `${doc.id}:${c.index}`,
+      vectors[i],
+      {
+        content: c.content,
+        doc_id: doc.id,
+        session_id: doc.sessionId,
+        source: doc.filename,
+        chunk_index: c.index,
+        start_offset: c.startOffset,
+        end_offset: c.endOffset,
+        model: space.model,
+        provider: space.provider,
+        dim: space.dimensions,
+      },
+      ttl,
+    )
   }
 
   await recordSpace(callTool, doc.sessionId, space, ttl)
@@ -279,39 +214,15 @@ export async function ingestDocument(
   }
 }
 
-/** Create the HNSW index for a (session, space), tolerating "already exists". */
-async function ensureVectorIndex(
-  callTool: CallTool,
-  indexName: string,
-  prefix: string,
-  dim: number,
-): Promise<void> {
-  const res = await callTool('create_vector_index_hash', {
-    index_name: indexName,
-    prefix,
-    dim,
-    distance_metric: 'COSINE',
-  })
-  // The Redis MCP returns a string; an existing index surfaces as an error-ish
-  // message rather than a thrown exception. Only a hard failure that is NOT an
-  // "already exists" should propagate.
-  const err = redisWriteError(res)
-  if (err && !/exist/i.test(err)) {
-    throw new Error(`Failed to create vector index ${indexName}: ${err}`)
-  }
-}
-
 // ============================================================================
 // Search
 // ============================================================================
 
 /**
  * Embed `query` with the session's recorded model and KNN-search its index.
- * Returns [] when the session has no ingested corpus yet.
- *
- * The query is always embedded with the *recorded* provider/model, and
- * {@link assertSameSpace} re-checks dimensionality — a search can never compare
- * vectors across embedding spaces.
+ * Returns [] when the session has no ingested corpus yet. The query is always
+ * embedded with the *recorded* provider/model, and {@link assertSameSpace}
+ * re-checks dimensionality — a search can never compare across embedding spaces.
  */
 export async function searchDocuments(
   sessionId: string,
@@ -332,58 +243,29 @@ export async function searchDocuments(
   })
   assertSameSpace(recorded, { provider: q.provider, model: q.model, dimensions: q.dimensions })
 
-  const res = await callTool('vector_search_hash', {
-    index_name: indexNameFor(sessionId, recorded),
-    query_vector: q.vector,
-    k: opts.k ?? 5,
-    // Content + provenance travel in a single JSON `meta` field (see ingest);
-    // ask for flat names too in case a backend version flattens them.
-    return_fields: ['meta', 'content', 'doc_id', 'source', 'chunk_index'],
+  const store = createVectorStore({
+    indexName: indexNameFor(sessionId, recorded),
+    prefix: prefixFor(sessionId, recorded),
+    dim: recorded.dimensions,
+    callTool,
   })
-  if (!res.success || res.data == null) return []
-  return parseSearchHits(res.data)
-}
+  const hits = await store.search(q.vector, opts.k ?? 5)
 
-/**
- * Tolerant parser for `vector_search_hash` output. The Redis MCP returns "a
- * list of matched documents"; field names vary slightly by version, so this
- * accepts a few shapes and skips anything it can't read rather than throwing.
- */
-function parseSearchHits(data: unknown): SearchHit[] {
-  let rows: unknown = data
-  if (typeof rows === 'string') {
-    try {
-      rows = JSON.parse(rows)
-    } catch {
-      return []
-    }
-  }
-  // Some versions wrap results under a key; unwrap common shapes.
-  if (rows && typeof rows === 'object' && !Array.isArray(rows)) {
-    const obj = rows as Record<string, unknown>
-    rows = obj.results ?? obj.documents ?? obj.matches ?? []
-  }
-  if (!Array.isArray(rows)) return []
-
-  const hits: SearchHit[] = []
-  for (const row of rows) {
-    if (!row || typeof row !== 'object') continue
-    const r = row as Record<string, unknown>
-    // Content + provenance live in the base64 `meta` field; fall back to flat.
-    const meta = decodeMeta(r.meta)
-    const content = str(meta.content) ?? str(r.content)
+  const out: SearchHit[] = []
+  for (const h of hits) {
+    const content = str(h.payload.content)
     if (content == null) continue
-    hits.push({
-      docId: str(meta.doc_id) ?? str(r.doc_id) ?? '',
-      source: str(meta.source) ?? str(r.source) ?? '',
-      chunkIndex: num(meta.chunk_index) ?? num(r.chunk_index) ?? 0,
+    out.push({
+      docId: str(h.payload.doc_id) ?? '',
+      source: str(h.payload.source) ?? '',
+      chunkIndex: num(h.payload.chunk_index) ?? 0,
       content,
-      startOffset: num(meta.start_offset) ?? num(r.start_offset),
-      endOffset: num(meta.end_offset) ?? num(r.end_offset),
-      score: num(r.score ?? r.distance ?? r.__vector_score),
+      startOffset: num(h.payload.start_offset),
+      endOffset: num(h.payload.end_offset),
+      score: h.score,
     })
   }
-  return hits
+  return out
 }
 
 function str(v: unknown): string | undefined {

--- a/ui/src/lib/harness-client/examples/semantic-cache.server.ts
+++ b/ui/src/lib/harness-client/examples/semantic-cache.server.ts
@@ -1,9 +1,21 @@
 /**
  * Semantic Cache Agent
  *
- * Pattern: semanticCache → (parallel) → cacheWriter → synthesizer
- * Use case: Build a semantic cache that checks redis vector similarity
- * before hitting web/neo4j sources.
+ * Pattern: semanticCache → conditionalRetrieval (parallel web+kg) → cacheWriter → synthesizer
+ * Use case: serve answers to *semantically equivalent* queries from cache before
+ * hitting web/neo4j sources.
+ *
+ * Two cache layers:
+ *   L1 — exact match: `json_get query:${hashInput(input)}` (fast, byte-identical).
+ *   L2 — semantic: embed the query (embeddings.server) and KNN-search a Redis
+ *        vector index (vector-store.server). A hit requires the nearest neighbour
+ *        within `SEMANTIC_HIT_MAX_DISTANCE` (cosine distance, lower = closer).
+ *
+ * Both the read (check) and write paths embed the query; the cached result rides
+ * in the vector record's payload, so a semantic hit needs no second lookup. The
+ * L2 layer is best-effort: if the embedder (local llama :8090) or RediSearch is
+ * unavailable it is skipped, and the agent falls back to exact-match + retrieval.
+ * (RediSearch on arm64 colima needs the amd64 redis override — see docs/DATA_STASH.md.)
  */
 "use server";
 
@@ -18,10 +30,19 @@ import {
   createNeo4jController,
   type ConfiguredPattern,
 } from "../../harness-patterns";
+import { embedOne } from "../../embeddings.server";
+import { createVectorStore, spaceTag } from "../../vector-store.server";
+import type { EmbeddingSpace } from "../../embeddings.server";
 import type { SessionData } from "../session.server";
 import type { AgentConfig } from "../registry.server";
 
-// Simple hash function for cache keys
+/** Max cosine distance for a semantic cache hit (lower = more similar). Tunable;
+ *  a future iteration could surface this via HarnessSettings. */
+const SEMANTIC_HIT_MAX_DISTANCE = 0.15;
+/** Cache entries live 24h. */
+const CACHE_TTL_SECONDS = 86400;
+
+// Simple hash function for exact-match cache keys
 function hashInput(input: string): string {
   let hash = 0;
   for (let i = 0; i < input.length; i++) {
@@ -30,6 +51,14 @@ function hashInput(input: string): string {
     hash = hash & hash; // Convert to 32bit integer
   }
   return Math.abs(hash).toString(36);
+}
+
+// The semantic cache is global (cross-session); one index per embedding model.
+function cacheIndexName(space: EmbeddingSpace): string {
+  return `qcache_idx_${spaceTag(space)}`;
+}
+function cacheKeyPrefix(space: EmbeddingSpace): string {
+  return `qcache:${spaceTag(space)}:`;
 }
 
 async function getSchema(): Promise<string> {
@@ -41,60 +70,57 @@ async function createPatterns(_sessionId: string): Promise<ConfiguredPattern<Ses
   const tools = await Tools();
   const schema = await getSchema();
 
-  // Semantic cache check pattern
+  // Cache check: L1 exact-match, then L2 semantic (KNN over query embeddings).
   const semanticCache = configurePattern<SessionData>(
     "semantic-cache",
     async (scope) => {
       const input = (scope.data as Record<string, unknown>).input as string ?? "";
       const cacheKey = `query:${hashInput(input)}`;
 
+      // L1 — exact match.
       try {
-        // Try to get from cache
         const cached = await callTool("json_get", { name: cacheKey, path: "$" });
-
         if (cached.success && cached.data) {
-          // Cache hit
-          console.log("[SemanticCache] Cache hit for:", input.slice(0, 50));
+          console.log("[SemanticCache] exact hit:", input.slice(0, 50));
           scope.data = {
             ...scope.data,
             response: JSON.stringify(cached.data),
             cacheHit: true,
+            cacheKind: "exact",
           };
           return scope;
         }
-
-        // For vector similarity search (if redis has vector support)
-        // This is a placeholder - in production, compute embedding first
-        try {
-          const similar = await callTool("vector_search_hash", {
-            index_name: "idx:query_cache",
-            query_vector: [], // Would be embedding vector in production
-            k: 1,
-          });
-
-          if (
-            similar.success &&
-            Array.isArray(similar.data) &&
-            similar.data.length > 0 &&
-            similar.data[0].score > 0.92
-          ) {
-            const resultKey = similar.data[0].key;
-            const result = await callTool("json_get", { name: resultKey, path: "$.result" });
-            if (result.success && result.data) {
-              scope.data = {
-                ...scope.data,
-                response: JSON.stringify(result.data),
-                cacheHit: true,
-              };
-              return scope;
-            }
-          }
-        } catch {
-          // Vector search may not be configured
-        }
-
       } catch {
-        // Redis may not be available
+        // Redis unavailable — fall through to a miss.
+      }
+
+      // L2 — semantic (best-effort: needs the embedder + RediSearch).
+      try {
+        const q = await embedOne(input);
+        const space: EmbeddingSpace = { provider: q.provider, model: q.model, dimensions: q.dimensions };
+        const store = createVectorStore({
+          indexName: cacheIndexName(space),
+          prefix: cacheKeyPrefix(space),
+          dim: q.dimensions,
+        });
+        const [top] = await store.search(q.vector, 1);
+        if (
+          top &&
+          typeof top.score === "number" &&
+          top.score <= SEMANTIC_HIT_MAX_DISTANCE &&
+          top.payload.result != null
+        ) {
+          console.log(`[SemanticCache] semantic hit (d=${top.score.toFixed(3)}):`, input.slice(0, 50));
+          scope.data = {
+            ...scope.data,
+            response: JSON.stringify(top.payload.result),
+            cacheHit: true,
+            cacheKind: "semantic",
+          };
+          return scope;
+        }
+      } catch {
+        // Embedder/RediSearch unavailable — skip the semantic layer.
       }
 
       // Cache miss
@@ -138,7 +164,7 @@ async function createPatterns(_sessionId: string): Promise<ConfiguredPattern<Ses
     { patternId: "conditional-retrieval" },
   );
 
-  // Cache writer: store results on cache miss
+  // Cache writer: store results on cache miss (both layers)
   const cacheWriter = configurePattern<SessionData>(
     "cache-writer",
     async (scope, view) => {
@@ -147,30 +173,37 @@ async function createPatterns(_sessionId: string): Promise<ConfiguredPattern<Ses
 
       const input = data.input as string ?? "";
       const cacheKey = `query:${hashInput(input)}`;
+      const results = view.fromLastPattern().ofType("tool_result").get().map((r) => r.data);
+      const payload = { query: input, result: results, ts: Date.now() };
 
+      // L1 — exact-match entry.
       try {
-        // Get results from events
-        const results = view.fromLastPattern().ofType("tool_result").get();
-
-        // Store result as JSON
         await callTool("json_set", {
           name: cacheKey,
           path: "$",
-          value: JSON.stringify({
-            query: input,
-            result: results.map((r) => r.data),
-            ts: Date.now(),
-          }),
+          value: JSON.stringify(payload),
         });
-
-        // Set TTL: 24 hours
-        await callTool("expire", { name: cacheKey, expire_seconds: 86400 });
-
-        console.log("[SemanticCache] Cached result for:", input.slice(0, 50));
+        await callTool("expire", { name: cacheKey, expire_seconds: CACHE_TTL_SECONDS });
       } catch {
-        // Redis may not be available
+        // Redis unavailable.
       }
 
+      // L2 — semantic entry (best-effort): embed the query, store query→result.
+      try {
+        const q = await embedOne(input);
+        const space: EmbeddingSpace = { provider: q.provider, model: q.model, dimensions: q.dimensions };
+        const store = createVectorStore({
+          indexName: cacheIndexName(space),
+          prefix: cacheKeyPrefix(space),
+          dim: q.dimensions,
+        });
+        await store.ensureIndex();
+        await store.upsert(hashInput(input), q.vector, payload, CACHE_TTL_SECONDS);
+      } catch {
+        // Embedder/RediSearch unavailable — skip the semantic layer.
+      }
+
+      console.log("[SemanticCache] cached result for:", input.slice(0, 50));
       return scope;
     },
     { patternId: "cache-writer" },
@@ -182,9 +215,9 @@ async function createPatterns(_sessionId: string): Promise<ConfiguredPattern<Ses
   });
 
   return [
-    semanticCache,       // Check cache first
+    semanticCache,       // Check cache first (L1 exact, L2 semantic)
     conditionalRetrieval, // On miss: fetch from sources
-    cacheWriter,         // Store result in cache
+    cacheWriter,         // Store result in both cache layers
     responseSynth,
   ];
 }
@@ -192,7 +225,7 @@ async function createPatterns(_sessionId: string): Promise<ConfiguredPattern<Ses
 export const semanticCacheAgent: AgentConfig = {
   id: "semantic-cache",
   name: "Semantic Cache",
-  description: "Redis-backed semantic cache with vector similarity search",
+  description: "Redis-backed semantic cache with real embedding-based vector similarity search",
   icon: "⚡",
   servers: ["redis", "web_search", "neo4j-cypher"],
   createPatterns,

--- a/ui/src/lib/vector-store.server.ts
+++ b/ui/src/lib/vector-store.server.ts
@@ -1,0 +1,218 @@
+/**
+ * Vector Store — Server Only
+ *
+ * A thin, reusable wrapper over the Redis (RediSearch HNSW) vector primitives:
+ * ensure an index, upsert (vector + opaque JSON payload), KNN search. Shared by
+ * the Data Stash ingest/search (`document-ingest.server.ts`) and the Semantic
+ * Cache agent so the embed→index→KNN plumbing lives in one tested place.
+ *
+ * The caller supplies the index name, key prefix and dimensionality — typically
+ * with an embedding-space tag baked into the names (see {@link spaceTag}) so one
+ * index never mixes models (vectors from different models aren't comparable; see
+ * `embeddings.server.ts`).
+ *
+ * Two gateway quirks are encapsulated here (see CLAUDE.md → Redis MCP quirks):
+ *   - payloads are base64-encoded before `hset` because the gateway auto-parses
+ *     JSON-looking string args into objects (which `hset` then rejects);
+ *   - `vector_search_hash` results may arrive as one text block per match —
+ *     handled by `callTool`'s aggregation + the tolerant {@link decodeMeta}.
+ *
+ * Requires redis-stack (RediSearch). On arm64 colima run the redis service as
+ * `platform: linux/amd64` (see docs/DATA_STASH.md) — the native arm64
+ * `redisearch.so` SIGILL-crashes on vector ops.
+ */
+
+import { assertServerOnImport } from './harness-patterns/assert.server'
+import { callTool as defaultCallTool } from './harness-patterns/mcp-client.server'
+import { redisWriteError, type CallTool } from './document-store.server'
+import type { EmbeddingSpace } from './embeddings.server'
+
+assertServerOnImport()
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface VectorHit {
+  /** The upsert id (recovered from the stored payload). */
+  id: string
+  /** Vector distance (lower = closer) when the backend reports one. */
+  score?: number
+  /** The decoded JSON payload stored alongside the vector. */
+  payload: Record<string, unknown>
+}
+
+export interface VectorStoreOptions {
+  /** RediSearch index name (should encode the embedding space — see {@link spaceTag}). */
+  indexName: string
+  /** Key prefix; each record lives at `${prefix}${id}` and is indexed by the prefix. */
+  prefix: string
+  /** Vector dimensionality; must match the embedding model's output. */
+  dim: number
+  /** Distance metric for the index. Default COSINE. */
+  distanceMetric?: 'COSINE' | 'L2' | 'IP'
+  /** Injectable MCP caller (tests); defaults to the real client. */
+  callTool?: CallTool
+}
+
+export interface VectorStore {
+  readonly indexName: string
+  readonly prefix: string
+  /** Create the HNSW index, tolerating "already exists". */
+  ensureIndex(): Promise<void>
+  /** Store a vector + JSON payload at `${prefix}${id}` (2 Redis writes). */
+  upsert(id: string, vector: number[], payload?: Record<string, unknown>, ttlSeconds?: number): Promise<void>
+  /** KNN search; returns hits with decoded payloads, closest first. */
+  search(queryVector: number[], k?: number): Promise<VectorHit[]>
+}
+
+const META_FIELD = 'meta'
+/** Internal payload key carrying the upsert id, so search can recover it. */
+const VID_KEY = '_vid'
+
+// ============================================================================
+// Factory
+// ============================================================================
+
+export function createVectorStore(opts: VectorStoreOptions): VectorStore {
+  const callTool = opts.callTool ?? defaultCallTool
+  const metric = opts.distanceMetric ?? 'COSINE'
+
+  async function ensureIndex(): Promise<void> {
+    const res = await callTool('create_vector_index_hash', {
+      index_name: opts.indexName,
+      prefix: opts.prefix,
+      dim: opts.dim,
+      distance_metric: metric,
+    })
+    const err = redisWriteError(res)
+    if (err && !/exist/i.test(err)) {
+      throw new Error(`Failed to create vector index ${opts.indexName}: ${err}`)
+    }
+  }
+
+  async function upsert(
+    id: string,
+    vector: number[],
+    payload: Record<string, unknown> = {},
+    ttlSeconds?: number,
+  ): Promise<void> {
+    const key = `${opts.prefix}${id}`
+
+    const vec = await callTool('set_vector_in_hash', { name: key, vector })
+    const vecErr = redisWriteError(vec)
+    if (vecErr) throw new Error(`Failed to store vector for "${id}": ${vecErr}`)
+
+    const meta = encodeMeta({ ...payload, [VID_KEY]: id })
+    const m = await callTool('hset', {
+      name: key,
+      key: META_FIELD,
+      value: meta,
+      ...(ttlSeconds ? { expire_seconds: ttlSeconds } : {}),
+    })
+    const mErr = redisWriteError(m)
+    if (mErr) throw new Error(`Failed to store payload for "${id}": ${mErr}`)
+  }
+
+  async function search(queryVector: number[], k = 5): Promise<VectorHit[]> {
+    const res = await callTool('vector_search_hash', {
+      index_name: opts.indexName,
+      query_vector: queryVector,
+      k,
+      return_fields: [META_FIELD],
+    })
+    if (!res.success || res.data == null) return []
+    return parseHits(res.data)
+  }
+
+  return { indexName: opts.indexName, prefix: opts.prefix, ensureIndex, upsert, search }
+}
+
+// ============================================================================
+// Naming helpers (shared so one index never mixes embedding models)
+// ============================================================================
+
+export function sanitize(s: string): string {
+  return s.replace(/[^a-zA-Z0-9]+/g, '_').replace(/^_+|_+$/g, '')
+}
+
+/** `provider_model_dim` — equal tags ⇒ comparable vectors / same index. */
+export function spaceTag(space: EmbeddingSpace): string {
+  return `${space.provider}_${sanitize(space.model)}_${space.dimensions}`
+}
+
+// ============================================================================
+// Payload encode / decode
+// ============================================================================
+
+/**
+ * Encode a payload as an opaque, non-JSON string. The MCP gateway auto-parses
+ * JSON-looking string args into objects (so a raw JSON `hset` value is rejected
+ * as a dict, and a payload that is itself valid JSON would be mangled); the
+ * `b64:` prefix keeps it unambiguously a string.
+ */
+export function encodeMeta(obj: Record<string, unknown>): string {
+  return 'b64:' + Buffer.from(JSON.stringify(obj), 'utf8').toString('base64')
+}
+
+/** Inverse of {@link encodeMeta}; tolerant of an already-object or plain-JSON value. */
+export function decodeMeta(raw: unknown): Record<string, unknown> {
+  if (raw && typeof raw === 'object') return raw as Record<string, unknown>
+  if (typeof raw !== 'string') return {}
+  let s = raw
+  if (s.startsWith('b64:')) {
+    try {
+      s = Buffer.from(s.slice(4), 'base64').toString('utf8')
+    } catch {
+      return {}
+    }
+  }
+  try {
+    return JSON.parse(s) as Record<string, unknown>
+  } catch {
+    return {}
+  }
+}
+
+// ============================================================================
+// Search result parsing — tolerant of the gateway's shapes
+// ============================================================================
+
+function parseHits(data: unknown): VectorHit[] {
+  let rows: unknown = data
+  if (typeof rows === 'string') {
+    try {
+      rows = JSON.parse(rows)
+    } catch {
+      return []
+    }
+  }
+  if (rows && typeof rows === 'object' && !Array.isArray(rows)) {
+    const obj = rows as Record<string, unknown>
+    rows = obj.results ?? obj.documents ?? obj.matches ?? []
+  }
+  if (!Array.isArray(rows)) return []
+
+  const hits: VectorHit[] = []
+  for (const row of rows) {
+    if (!row || typeof row !== 'object') continue
+    const r = row as Record<string, unknown>
+    const payload = decodeMeta(r.meta)
+    const id = str(payload[VID_KEY]) ?? str(r.id) ?? str(r.key) ?? ''
+    hits.push({
+      id,
+      score: num(r.score ?? r.distance ?? r.__vector_score),
+      payload,
+    })
+  }
+  return hits
+}
+
+function str(v: unknown): string | undefined {
+  return typeof v === 'string' ? v : typeof v === 'number' ? String(v) : undefined
+}
+function num(v: unknown): number | undefined {
+  if (typeof v === 'number') return v
+  if (typeof v === 'string' && v.trim() !== '' && Number.isFinite(Number(v))) return Number(v)
+  return undefined
+}


### PR DESCRIPTION
Makes the Semantic Cache agent genuinely semantic, and extracts the embed→index→KNN Redis plumbing into a shared helper so the DataStash search and the cache no longer duplicate it.

## Why
The Semantic Cache was **exact-match only** — it keyed on a 32-bit hash of the query string. Its "vector similarity" branch was a non-functional placeholder: empty `query_vector: []`, no embedding ever computed, no index populated, and an inverted threshold (`score > 0.92` against a COSINE *distance* where lower = closer). So it only hit on byte-identical queries.

## What
**New `ui/src/lib/vector-store.server.ts`** — `createVectorStore({ indexName, prefix, dim })` → `ensureIndex` / `upsert(id, vector, payload, ttl)` / `search(queryVector, k)`. Owns index creation (tolerating "already exists"), the 2-writes/record format (vector + base64 `meta`), KNN result parsing, and `spaceTag` naming (one index ↔ one model). Encapsulates the gateway quirks (base64 args, multi-block results).

**`document-ingest.server.ts`** refactored to delegate to it — **public API + index/key/meta naming unchanged**, so `document-ingest.test.ts` passes untouched.

**`semantic-cache.server.ts`** rewritten (same 4 patterns / patternIds):
- *check*: L1 exact `json_get`; on miss, L2 `embedOne(query)` → KNN, hit when nearest-neighbour distance ≤ `SEMANTIC_HIT_MAX_DISTANCE` (0.15). The cached result rides in the vector payload — no second lookup.
- *write*: keep L1 `json_set`/`expire`; add L2 `embedOne` → `ensureIndex` → `upsert(query→result)`.
- L2 is **best-effort** (try/catch): degrades to exact-match + retrieval when the embedder/RediSearch is unavailable. Cache index is global, per embedding model.

## Verification
- `pnpm exec tsc --noEmit`: **25** (≤ 26 baseline, no new errors).
- `pnpm test:run`: **818 pass** (+ `vector-store.test.ts`; `document-ingest.test` unchanged; `agents.test` mocks the embedder offline + a rewritten distance-threshold case).
- **Live** (amd64 redis + Qwen3 embedder on :8090): the refactored shared store does real semantic KNN — paraphrase *"how to register a tool server"* matched the *"add a new MCP server"* chunk (distance 0.526) with redis `restarts=0`. The cache's L2 uses this same primitive; its 0.15 threshold is deliberately strict (near-duplicate queries).
- Note: RediSearch indexes asynchronously — a search issued in the same instant as ingest can briefly return empty until the index catches up (slower under QEMU emulation). Not a code issue.

Follow-up to #92/#94. Reuses the redis-stack amd64 override (docs/DATA_STASH.md) for the vector path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)