### PR TITLE
feat(tools-panel): gate to code-mode-using harnesses (auto-detected)

### DIFF
--- a/ui/src/__tests__/agents/code-mode-catalog.test.ts
+++ b/ui/src/__tests__/agents/code-mode-catalog.test.ts
@@ -111,4 +111,15 @@ describe('code-mode agent — up-front ENABLED SERVERS catalog', () => {
     expect(context).toContain('neo4j-cypher')
     expect(context).toContain('read_neo4j_cypher')
   })
+
+  it('usesCodeMode detects the real (nested) code-mode pattern graph', async () => {
+    // Exercises the real combinators (router → routes → chain) populating
+    // `children` + the actorCritic loop's `dynamicToolPattern` marker. This is
+    // what `agentUsesCodeMode` (registry) runs to keep the Tools panel active.
+    const { codeModeAgent } = await import('../../lib/harness-client/examples/code-mode.server')
+    const { usesCodeMode } = await import('../../lib/harness-patterns/pattern-capabilities')
+
+    const patterns = await codeModeAgent.createPatterns('test-session')
+    expect(usesCodeMode(patterns)).toBe(true)
+  })
 })

--- a/ui/src/__tests__/lib/harness-patterns/pattern-capabilities.test.ts
+++ b/ui/src/__tests__/lib/harness-patterns/pattern-capabilities.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Pattern capabilities — static code-mode detection.
+ *
+ * `usesCodeMode` walks `ConfiguredPattern.children` (populated by the wrapping
+ * combinators) and flags a code-mode loop by its structural signature
+ * (`dynamicToolPattern` matching `code-mode-<name>`, or the
+ * `patternId === 'code-mode-loop'` convention). The Tools panel uses this to
+ * grey out for agents that don't compose a code-mode pattern.
+ *
+ * Pure functions (import the module directly, not the server barrel) — no mocks.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { usesCodeMode, isCodeModeLoopConfig } from '../../../lib/harness-patterns/pattern-capabilities'
+import type { ConfiguredPattern, PatternConfig } from '../../../lib/harness-patterns/types'
+
+type AnyPattern = ConfiguredPattern<Record<string, unknown>>
+
+const noop: AnyPattern['fn'] = async (scope) => scope
+
+/** Build a fake ConfiguredPattern; `config` may carry actorCritic-only fields
+ *  (e.g. dynamicToolPattern) that aren't on the base PatternConfig type. */
+function pat(name: string, config: Record<string, unknown>, children?: AnyPattern[]): AnyPattern {
+  return { name, fn: noop, config: config as PatternConfig, ...(children ? { children } : {}) }
+}
+
+describe('isCodeModeLoopConfig', () => {
+  it('flags the code-mode factory dynamicToolPattern', () => {
+    expect(isCodeModeLoopConfig({ dynamicToolPattern: /^code-mode-/ } as PatternConfig)).toBe(true)
+  })
+
+  it('flags the patternId convention', () => {
+    expect(isCodeModeLoopConfig({ patternId: 'code-mode-loop' } as PatternConfig)).toBe(true)
+  })
+
+  it('is robust to a global-flagged regex (no lastIndex carryover)', () => {
+    const cfg = { dynamicToolPattern: /^code-mode-/g } as unknown as PatternConfig
+    expect(isCodeModeLoopConfig(cfg)).toBe(true)
+    expect(isCodeModeLoopConfig(cfg)).toBe(true) // second call must not flip
+  })
+
+  it('does NOT flag a different dynamic pattern or unrelated patternId', () => {
+    expect(isCodeModeLoopConfig({ dynamicToolPattern: /^sandbox-/ } as unknown as PatternConfig)).toBe(false)
+    expect(isCodeModeLoopConfig({ patternId: 'neo4j-query' } as PatternConfig)).toBe(false)
+    expect(isCodeModeLoopConfig({} as PatternConfig)).toBe(false)
+  })
+})
+
+describe('usesCodeMode', () => {
+  it('returns false for empty / undefined', () => {
+    expect(usesCodeMode(undefined)).toBe(false)
+    expect(usesCodeMode([])).toBe(false)
+  })
+
+  it('returns false for a graph with no code-mode loop', () => {
+    const tree = [
+      pat('router', {}),
+      pat('routes(neo4j)', {}, [
+        pat('chain', {}, [
+          pat('simpleLoop', { patternId: 'neo4j-query' }),
+          pat('synthesizer', {}),
+        ]),
+      ]),
+    ]
+    expect(usesCodeMode(tree)).toBe(false)
+  })
+
+  it('detects a code-mode loop nested router → routes → chain → actorCritic', () => {
+    const tree = [
+      pat('router', {}),
+      pat('routes(code_mode)', {}, [
+        pat('chain', {}, [
+          pat('actorCritic', { patternId: 'code-mode-loop', dynamicToolPattern: /^code-mode-/ }),
+          pat('synthesizer', {}),
+        ]),
+      ]),
+    ]
+    expect(usesCodeMode(tree)).toBe(true)
+  })
+
+  it('detects through single-child wrappers (guardrail → withApproval → chain → loop)', () => {
+    const tree = [
+      pat('guardrail', {}, [
+        pat('withApproval', {}, [
+          pat('chain', {}, [pat('actorCritic', { dynamicToolPattern: /^code-mode-/ })]),
+        ]),
+      ]),
+    ]
+    expect(usesCodeMode(tree)).toBe(true)
+  })
+})

--- a/ui/src/components/ark-ui/ToolsPanel.tsx
+++ b/ui/src/components/ark-ui/ToolsPanel.tsx
@@ -231,6 +231,24 @@ export const ToolsPanel = (props: ToolsPanelProps) => {
             load shows a panel skeleton instead of blanking the whole app via
             the empty-fallback root <Suspense> in app.tsx. */}
         <Suspense fallback={<div p="4" text="sm dark-text-tertiary">Loading tools…</div>}>
+        {/* Gate the whole code-mode-specific body on whether the conversation's
+            agent actually composes a code-mode pattern (the sole consumer of
+            this allowlist). Reading state() here stays inside the local
+            <Suspense> so a pending load can't bubble to the app-root boundary
+            and flash the app. `usesCodeMode !== false` keeps the body for the
+            true case AND the error case (state() === null → undefined). */}
+        <Show
+          when={state()?.usesCodeMode !== false}
+          fallback={
+            <div p="6" text="center" flex="~ col 1" justify="center" items="center">
+              <div text="sm dark-text-secondary">Tool selection applies to code-mode agents.</div>
+              <div text="xs dark-text-tertiary" m="t-1">
+                This conversation's agent doesn't run a code-mode pattern, so the
+                allowlist has no effect here.
+              </div>
+            </div>
+          }
+        >
         {/* Controls header — always in sight */}
         <div p="4" border="b dark-border-primary" flex="~ col" gap="3">
           {/* "Default code mode" preset switch */}
@@ -400,7 +418,6 @@ export const ToolsPanel = (props: ToolsPanelProps) => {
             </div>
           </Show>
         </div>
-        </Suspense>
 
         {/* Coded Tools Repository Section */}
         <div p="4">
@@ -441,6 +458,8 @@ export const ToolsPanel = (props: ToolsPanelProps) => {
             </div>
           </Show>
         </div>
+        </Show>
+        </Suspense>
       </Show>
     </div>
   );

--- a/ui/src/lib/harness-client/registry.server.ts
+++ b/ui/src/lib/harness-client/registry.server.ts
@@ -10,6 +10,7 @@
 "use server";
 
 import type { ConfiguredPattern } from "../harness-patterns";
+import { usesCodeMode } from "../harness-patterns";
 import type { SessionData } from "./session.server";
 
 // ============================================================================
@@ -75,6 +76,48 @@ export function getAgentMetadata(): Array<{
     icon,
     servers,
   }));
+}
+
+// ============================================================================
+// Capability introspection
+// ============================================================================
+
+/** Memoized by agentId — a harness's pattern *structure* is
+ *  session-independent (sessionId only parameterizes the closures), so the
+ *  answer is stable for the process lifetime. Cleared implicitly on restart. */
+const codeModeCapabilityCache = new Map<string, boolean>();
+
+/**
+ * Whether an agent composes a **code-mode pattern** anywhere in its (possibly
+ * nested) pattern graph — i.e. whether the per-conversation
+ * `codeModeAllowedTools` allowlist has any runtime consumer for this agent.
+ * The Tools panel uses this to stay active vs. grey out (config.server.ts).
+ *
+ * Detection is structural (see `usesCodeMode` / `isCodeModeLoopConfig`), so a
+ * future multi-route agent with a single code-mode route is covered without a
+ * per-agent flag. Builds the patterns once via `createPatterns` and memoizes
+ * the result. On a `createPatterns` failure (e.g. transient gateway outage
+ * during pattern construction) we fall back to `id === 'code-mode'` and do NOT
+ * cache, so the next call re-attempts a real detection.
+ */
+export async function agentUsesCodeMode(
+  agentId: string,
+  sessionId: string,
+): Promise<boolean> {
+  const cached = codeModeCapabilityCache.get(agentId);
+  if (cached !== undefined) return cached;
+
+  const agent = getAgent(agentId);
+  if (!agent) return false;
+
+  try {
+    const patterns = await agent.createPatterns(sessionId);
+    const result = usesCodeMode(patterns);
+    codeModeCapabilityCache.set(agentId, result);
+    return result;
+  } catch {
+    return agentId === "code-mode";
+  }
 }
 
 // ============================================================================

--- a/ui/src/lib/harness-patterns/index.ts
+++ b/ui/src/lib/harness-patterns/index.ts
@@ -105,6 +105,12 @@ export { router, routes, type Routes, type RoutePatterns, type RouterData } from
 export { DIRECT_RESPONSE_ROUTE } from './types'
 
 // ============================================================================
+// Pattern capabilities (static introspection)
+// ============================================================================
+
+export { usesCodeMode, isCodeModeLoopConfig } from './pattern-capabilities'
+
+// ============================================================================
 // Harness
 // ============================================================================
 

--- a/ui/src/lib/harness-patterns/pattern-capabilities.ts
+++ b/ui/src/lib/harness-patterns/pattern-capabilities.ts
@@ -1,0 +1,62 @@
+/**
+ * Pattern Capabilities — static introspection of a pattern graph
+ *
+ * Pure helpers (no server-only deps) that walk the `children` of a
+ * `ConfiguredPattern[]` to answer capability questions about a harness without
+ * running it. Wrapping combinators (`chain`, `routes`, `parallel`, `guardrail`,
+ * `hook`, `withApproval`, `withReferences`) expose their sub-patterns via
+ * `ConfiguredPattern.children`; leaves omit it. Execution never reads `children`
+ * — it's introspection-only.
+ *
+ * First consumer: the Tools panel greys itself out for conversations whose agent
+ * does NOT compose a code-mode pattern (the only runtime consumer of the
+ * per-conversation `codeModeAllowedTools` allowlist). See
+ * `tool-config/config.server.ts` → `harness-client/registry.server.ts`
+ * (`agentUsesCodeMode`).
+ */
+
+import type { ConfiguredPattern, ActorCriticConfig, PatternConfig } from './types'
+
+/** A string the code-mode factory's `dynamicToolPattern` (`/^code-mode-/`)
+ *  matches — used to probe a loop's config without depending on the regex's
+ *  exact source. */
+const CODE_MODE_TOOL_PROBE = 'code-mode-probe'
+
+/**
+ * True when a pattern's resolved config is a **code-mode loop** — i.e. an
+ * `actorCritic` wired to the kg-agent `code-mode` factory. We detect it by the
+ * structural signature the factory requires, not by a name an agent author
+ * could choose differently:
+ *
+ *  - `dynamicToolPattern` (a RegExp) matches the `code-mode-<name>` factory
+ *    tool naming — this is what lets the loop dispatch the generated tool, so
+ *    any code-mode-composing agent has it; OR
+ *  - `patternId === 'code-mode-loop'` (the convention the bundled agent uses),
+ *    as a secondary signal.
+ *
+ * `dynamicToolPattern` lives on `ActorCriticConfig`, not the base
+ * `PatternConfig`, so we widen the type to read it; `resolveConfig` preserves
+ * it (it spreads the input config).
+ */
+export function isCodeModeLoopConfig(config: PatternConfig): boolean {
+  const cfg = config as ActorCriticConfig
+  if (cfg.patternId === 'code-mode-loop') return true
+  const pattern = cfg.dynamicToolPattern
+  // Build a fresh RegExp so a stray global flag's `lastIndex` can't make
+  // `.test()` non-deterministic across calls.
+  return pattern instanceof RegExp && new RegExp(pattern.source).test(CODE_MODE_TOOL_PROBE)
+}
+
+/**
+ * True when any pattern in the (possibly nested) graph is a code-mode loop.
+ * Walks `ConfiguredPattern.children` depth-first.
+ */
+export function usesCodeMode<T>(patterns: ConfiguredPattern<T>[] | undefined): boolean {
+  if (!patterns || patterns.length === 0) return false
+  return patterns.some(patternUsesCodeMode)
+}
+
+function patternUsesCodeMode<T>(pattern: ConfiguredPattern<T>): boolean {
+  if (isCodeModeLoopConfig(pattern.config)) return true
+  return usesCodeMode(pattern.children)
+}

--- a/ui/src/lib/harness-patterns/patterns/chain.server.ts
+++ b/ui/src/lib/harness-patterns/patterns/chain.server.ts
@@ -201,7 +201,8 @@ export function chain<T extends Record<string, unknown>>(
     },
     config: resolved,
     estimateTurns: (s) =>
-      patterns.reduce((sum, p) => sum + (p.estimateTurns?.(s) ?? 1), 0)
+      patterns.reduce((sum, p) => sum + (p.estimateTurns?.(s) ?? 1), 0),
+    children: patterns
   }
 }
 

--- a/ui/src/lib/harness-patterns/patterns/guardrail.server.ts
+++ b/ui/src/lib/harness-patterns/patterns/guardrail.server.ts
@@ -193,7 +193,8 @@ export function guardrail<T extends Record<string, unknown>>(
       }
     },
     config: resolved,
-    estimateTurns: (s) => pattern.estimateTurns?.(s) ?? 1
+    estimateTurns: (s) => pattern.estimateTurns?.(s) ?? 1,
+    children: [pattern]
   }
 }
 

--- a/ui/src/lib/harness-patterns/patterns/hook.server.ts
+++ b/ui/src/lib/harness-patterns/patterns/hook.server.ts
@@ -101,6 +101,7 @@ export function hook<T extends Record<string, unknown>>(
     config: resolved,
     // Background hooks don't add perceived turns; sync hooks delegate to child.
     estimateTurns: (s) =>
-      config.background ? 0 : pattern.estimateTurns?.(s) ?? 1
+      config.background ? 0 : pattern.estimateTurns?.(s) ?? 1,
+    children: [pattern]
   }
 }

--- a/ui/src/lib/harness-patterns/patterns/parallel.server.ts
+++ b/ui/src/lib/harness-patterns/patterns/parallel.server.ts
@@ -85,6 +85,7 @@ export function parallel<T extends Record<string, unknown>>(
     config: resolved,
     // Branches run concurrently; user-perceived duration tracks the longest one.
     estimateTurns: (s) =>
-      Math.max(...patterns.map((p) => p.estimateTurns?.(s) ?? 1))
+      Math.max(...patterns.map((p) => p.estimateTurns?.(s) ?? 1)),
+    children: patterns
   }
 }

--- a/ui/src/lib/harness-patterns/patterns/router.server.ts
+++ b/ui/src/lib/harness-patterns/patterns/router.server.ts
@@ -272,6 +272,7 @@ export function routes<T extends RouterData & Record<string, unknown>>(
     // drives perceived progress duration. UI can refine downward once the
     // dispatched branch's `pattern_enter` arrives.
     estimateTurns: (s) =>
-      Math.max(...Object.values(patternMap).map((p) => p.estimateTurns?.(s) ?? 1))
+      Math.max(...Object.values(patternMap).map((p) => p.estimateTurns?.(s) ?? 1)),
+    children: Object.values(patternMap)
   }
 }

--- a/ui/src/lib/harness-patterns/patterns/with-references.server.ts
+++ b/ui/src/lib/harness-patterns/patterns/with-references.server.ts
@@ -306,6 +306,7 @@ export function withReferences<T>(
     name: `withReferences(${wrappedPattern.name})`,
     fn,
     config: resolved,
-    estimateTurns: (s) => wrappedPattern.estimateTurns?.(s) ?? 1
+    estimateTurns: (s) => wrappedPattern.estimateTurns?.(s) ?? 1,
+    children: [wrappedPattern]
   }
 }

--- a/ui/src/lib/harness-patterns/patterns/withApproval.server.ts
+++ b/ui/src/lib/harness-patterns/patterns/withApproval.server.ts
@@ -138,7 +138,8 @@ export function withApproval<T extends WithApprovalData>(
     fn,
     config: resolved,
     // Approval gate doesn't add work — delegate to the wrapped pattern.
-    estimateTurns: (s) => wrappedPattern.estimateTurns?.(s) ?? 1
+    estimateTurns: (s) => wrappedPattern.estimateTurns?.(s) ?? 1,
+    children: [wrappedPattern]
   }
 }
 

--- a/ui/src/lib/harness-patterns/types.ts
+++ b/ui/src/lib/harness-patterns/types.ts
@@ -361,6 +361,13 @@ export interface ConfiguredPattern<T> {
    *  Wrapper patterns delegate to their child(ren). Returning `undefined` is
    *  equivalent to a contribution of 1. */
   estimateTurns?: (settings: TurnEstimateSettings) => number
+  /** Wrapped sub-patterns, for combinators that compose others
+   *  (`chain`, `routes`, `parallel`, `guardrail`, `hook`, `withApproval`,
+   *  `withReferences`). Leaf patterns omit it. Purely for static
+   *  introspection of the pattern graph — execution runs through `fn`, never
+   *  this — so it's safe and additive. See `pattern-capabilities.ts`
+   *  (`usesCodeMode`) for the canonical walk. */
+  children?: ConfiguredPattern<T>[]
 }
 
 // ============================================================================

--- a/ui/src/lib/tool-config/config.server.ts
+++ b/ui/src/lib/tool-config/config.server.ts
@@ -18,6 +18,7 @@ import { deserializeContext, serializeContext } from "../harness-patterns";
 import type { UnifiedContext } from "../harness-patterns";
 import { listTools } from "../harness-patterns/mcp-client.server";
 import { loadSession, saveSession, type SessionData } from "../harness-client/session.server";
+import { agentUsesCodeMode } from "../harness-client/registry.server";
 import { getAuthenticatedUser } from "../auth/server";
 import { CODE_MODE_DEFAULTS, type CodeModeToolsState } from "./constants";
 import { getPresetTools } from "./server-catalog.server";
@@ -87,7 +88,17 @@ export async function getCodeModeAllowedTools(
     persisted && persisted.length > 0
       ? persisted
       : Array.from(new Set([...defaults, ...presetTools]));
-  return { allowed, available, defaults };
+
+  // Does this conversation's agent actually consume the allowlist? Auto-detected
+  // from its pattern graph. When the session isn't persisted yet (pre-first-
+  // message, no agentId), stay optimistic (true) — the panel can't save before
+  // the first turn anyway, and greying the bundled code-mode agent would be the
+  // more harmful error.
+  const usesCodeMode = loaded
+    ? await agentUsesCodeMode(loaded.agentId, sessionId)
+    : true;
+
+  return { allowed, available, defaults, usesCodeMode };
 }
 
 /**

--- a/ui/src/lib/tool-config/constants.ts
+++ b/ui/src/lib/tool-config/constants.ts
@@ -28,6 +28,11 @@ export interface CodeModeToolsState {
   /** Meta-tools the actor always needs (`mcp-find`, `mcp-add`, `code-mode`,
    *  `mcp-exec`). UI should render them pre-checked and locked-on. */
   defaults: string[];
+  /** Whether this conversation's agent actually composes a code-mode pattern
+   *  (the only runtime consumer of the allowlist). When false, the Tools panel
+   *  greys out — the selection would have no effect. Auto-detected from the
+   *  agent's pattern graph; see `registry.server.ts` `agentUsesCodeMode`. */
+  usesCodeMode: boolean;
 }
 
 /** Default "starter set" highlighted with a `Core` badge in the UI. */


### PR DESCRIPTION
## Summary

The Tools panel curates a per-conversation tool allowlist (`ctx.data.codeModeAllowedTools`), but the **only runtime consumer** is the code-mode agent's `toolNamesProvider`. For every other agent the panel was a **silent no-op** — toggles persisted, nothing read them.

This greys out the panel for agents that don't compose a code-mode pattern, **auto-detected from the pattern graph** (not a hardcoded `agentId === 'code-mode'`, not a manual per-agent flag), so a future multi-route agent with a single code-mode route is covered.

## Why auto-detect needed pattern-tree traversal

`ConfiguredPattern` had no child refs — all 8 combinators closed over their children — and the code-mode loop is nested `router → routes → chain → actorCritic`, so a top-level scan misses it. Fix: make the tree traversable (additive), then walk it for the code-mode marker.

## Changes

- **`ConfiguredPattern.children`** (optional): wrapping combinators (`chain`, `routes`, `parallel`, `guardrail`, `hook`, `withApproval`, `withReferences`) now expose their sub-patterns for static introspection. **Additive — execution still runs via `fn`; nothing reads `children` at runtime**, so zero behavior change.
- **`pattern-capabilities.ts`** (new, pure): `usesCodeMode(patterns)` walks `children` and flags a code-mode loop by its **structural signature** — `dynamicToolPattern` matching `code-mode-<name>` (the factory's required marker) or `patternId === 'code-mode-loop'`. `isCodeModeLoopConfig` is robust to a global-flagged regex (`lastIndex`).
- **`registry.agentUsesCodeMode(agentId, sessionId)`**: builds the agent's patterns once, runs `usesCodeMode`, **memoizes by agentId** (structure is session-independent). On `createPatterns` failure → falls back to `id === 'code-mode'` **without caching**, so a transient gateway hiccup can't permanently grey the real agent.
- **`config.server.getCodeModeAllowedTools`**: returns `usesCodeMode` (from the session's `agentId`); optimistic `true` when the session isn't persisted yet (pre-first-message — the panel can't save then anyway, and greying the real code-mode agent would be the worse error).
- **`ToolsPanel`**: greys the code-mode-specific body (controls + servers + Coded Tools repo) behind a notice when `usesCodeMode === false`. All `state()` reads stay inside the local `<Suspense>` so a pending load can't bubble to the app-root boundary and flash the app.

## Tests / verification

- `pattern-capabilities.test.ts` (new): predicate cases + nested-graph walk (router→routes→chain→loop, single-child-wrapper chains, global-regex robustness, negative graphs).
- `code-mode-catalog.test.ts`: asserts the **real** (nested) code-mode agent graph is detected via the real combinators.
- **816 pass** (+9). `tsc` clean on touched files (26 pre-existing errors in untouched files).
- Manual: code-mode conversation → panel interactive; default/neo4j/web conversation → greyed "no effect" notice. (Switching agents starts a new session, so the gate re-evaluates per conversation.)

Separate concern from #93 (synth/critic refinement); branched off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)