### PR TITLE
fix(harness): trim prompts against the real model's context window

### DIFF
--- a/ui/src/__tests__/lib/harness-patterns/patterns/synthesizer.test.ts
+++ b/ui/src/__tests__/lib/harness-patterns/patterns/synthesizer.test.ts
@@ -370,3 +370,92 @@ describe('synthesizer execution', () => {
     expect(result.data.synthesizedResponse).toContain('Iterations')
   })
 })
+
+// ---------------------------------------------------------------------------
+// Regression: large tool results must survive into the synthesizer's turns.
+//
+// .harness-logs/neo4j-no-results.json — two read_neo4j_cypher turns returned
+// ~58KB/~65KB of rows, then the loop's `Return`. The synth trimmed against
+// `getContextWindow('SynthesizerFallback')`, which wasn't in
+// MODEL_CONTEXT_WINDOWS → 16K default → budget ~12K tokens, so trimToFit
+// dropped BOTH data turns and kept only the `Return` (result: null). The synth
+// then truthfully reported "returned null". Fix: trim against the client the
+// call actually uses (resolveClientForRole('synth') → SynthesizerAnthropic =
+// 200K by default), so the data reaches the synth. b.Synthesize is mocked — no
+// real LLM call / tokens.
+// ---------------------------------------------------------------------------
+describe('synthesizer — context-window trimming regression', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('keeps large multi-turn tool results in the turns passed to Synthesize', async () => {
+    const { synthesizer } = await import('../../../../lib/harness-patterns/patterns/synthesizer.server')
+    const { createScope } = await import('../../../../lib/harness-patterns/context.server')
+    const { createEventView } = await import('../../../../lib/harness-patterns/patterns')
+    const { b } = await import('../../../../../baml_client')
+
+    // Two large cypher results (>49KB each → would each blow the old 12K-token
+    // budget) plus the loop's Return, all under the loop's patternId.
+    const big0 = { rows: [{ name: 'NODE_REDIS_DEG17', degree: 17, blob: 'R'.repeat(60_000) }] }
+    const big1 = { rows: [{ name: 'NODE_SCHEMA_DEG12', degree: 12, blob: 'S'.repeat(60_000) }] }
+    const ts = Date.now()
+    const mockContext = {
+      sessionId: 'test',
+      createdAt: ts,
+      events: [
+        { type: 'user_message' as const, ts, patternId: 'harness', data: { content: 'Sort nodes by centrality' } },
+        { type: 'pattern_enter' as const, ts: ts + 1, patternId: 'neo4j-query', data: { pattern: 'simpleLoop' } },
+        { type: 'controller_action' as const, ts: ts + 2, patternId: 'neo4j-query', data: { action: { tool_name: 'read_neo4j_cypher', tool_args: '{}', reasoning: '', status: 'success', is_final: false } } },
+        { type: 'tool_result' as const, ts: ts + 3, patternId: 'neo4j-query', data: { tool: 'read_neo4j_cypher', result: big0, success: true } },
+        { type: 'controller_action' as const, ts: ts + 4, patternId: 'neo4j-query', data: { action: { tool_name: 'read_neo4j_cypher', tool_args: '{}', reasoning: '', status: 'success', is_final: false } } },
+        { type: 'tool_result' as const, ts: ts + 5, patternId: 'neo4j-query', data: { tool: 'read_neo4j_cypher', result: big1, success: true } },
+        { type: 'controller_action' as const, ts: ts + 6, patternId: 'neo4j-query', data: { action: { tool_name: 'Return', tool_args: '## answer', reasoning: '', status: 'success', is_final: false } } },
+        { type: 'pattern_exit' as const, ts: ts + 7, patternId: 'neo4j-query', data: { status: 'completed' } },
+      ],
+      status: 'running' as const,
+      data: {},
+      input: 'Sort nodes by centrality',
+    }
+
+    // Default synthesis (no custom fn) → defaultSynthesize → b.Synthesize + trimToFit.
+    const pattern = synthesizer({ mode: 'thread', patternId: 'response-synth' })
+    const scope = createScope('test', {})
+    const view = createEventView(mockContext)
+
+    await pattern.fn(scope, view)
+
+    const synthMock = vi.mocked(b.Synthesize)
+    expect(synthMock).toHaveBeenCalledTimes(1)
+    // Synthesize(userMessage, intent, turns, hasError, errorMessage) → turns is arg[2].
+    const turns = synthMock.mock.calls[0][2] as unknown[]
+    const turnsJson = JSON.stringify(turns)
+    // Both large results survive into the synth's view (pre-fix: only the
+    // Return/null turn remained and neither marker was present).
+    expect(turnsJson).toContain('NODE_REDIS_DEG17')
+    expect(turnsJson).toContain('NODE_SCHEMA_DEG12')
+  })
+
+  it('resolves the trim window from the real client, not the missing Fallback key', async () => {
+    const { getContextWindow } = await import('../../../../lib/harness-patterns/token-budget.server')
+    const { resolveClientForRole } = await import('../../../../lib/harness-patterns/clients.server')
+
+    // The keys that were missing (→ 16K default → over-trim).
+    expect(getContextWindow('SynthesizerAnthropic')).toBe(200_000)
+    expect(getContextWindow('SynthesizerFallback')).toBe(32_768)
+
+    // Default (Anthropic-only) → declared client; not the Fallback label.
+    expect(resolveClientForRole('synth')).toBe('SynthesizerAnthropic')
+    expect(resolveClientForRole('controller')).toBe('ControllerAnthropic')
+
+    // Under mixed chains → the Fallback client.
+    const prev = process.env.USE_MIXED_CHAINS
+    process.env.USE_MIXED_CHAINS = '1'
+    try {
+      expect(resolveClientForRole('synth')).toBe('SynthesizerFallback')
+    } finally {
+      if (prev === undefined) delete process.env.USE_MIXED_CHAINS
+      else process.env.USE_MIXED_CHAINS = prev
+    }
+  })
+})

--- a/ui/src/lib/harness-patterns/clients.server.ts
+++ b/ui/src/lib/harness-patterns/clients.server.ts
@@ -37,6 +37,18 @@ const MIXED_CLIENT_BY_ROLE: Record<BamlRole, string> = {
   describe: 'DescribeFallback',
 }
 
+/** The BAML-declared (default) client per role — the Anthropic-only chain each
+ *  function declares in `baml_src/`. Used to resolve the *actual* model behind
+ *  a call when no mixed-chain override is active. Keep in sync with the
+ *  `client X` lines in baml_src/*.baml. */
+const DECLARED_CLIENT_BY_ROLE: Record<BamlRole, string> = {
+  controller: 'ControllerAnthropic',
+  critic: 'CriticAnthropic',
+  synth: 'SynthesizerAnthropic',
+  router: 'RouterAnthropic',
+  describe: 'DescribeAnthropic',
+}
+
 /**
  * Returns `{ client: 'XFallback' }` when `USE_MIXED_CHAINS=1` is set,
  * otherwise `undefined` — letting the BAML function fall through to its
@@ -52,4 +64,16 @@ const MIXED_CLIENT_BY_ROLE: Record<BamlRole, string> = {
 export function clientOverrideFor(role: BamlRole): { client: string } | undefined {
   if (process.env.USE_MIXED_CHAINS !== '1') return undefined
   return { client: MIXED_CLIENT_BY_ROLE[role] }
+}
+
+/**
+ * The client BAML will actually use for `role` right now: the mixed-chain
+ * override when `USE_MIXED_CHAINS=1`, else the function's declared Anthropic
+ * client. Patterns use this to look up the real model's context window for
+ * prompt trimming (`getContextWindow(resolveClientForRole(role))`) instead of
+ * hardcoding the `*Fallback` label — which, when missing from
+ * `MODEL_CONTEXT_WINDOWS`, silently defaulted to 16K and over-trimmed prompts.
+ */
+export function resolveClientForRole(role: BamlRole): string {
+  return clientOverrideFor(role)?.client ?? DECLARED_CLIENT_BY_ROLE[role]
 }

--- a/ui/src/lib/harness-patterns/patterns/compactIntent.server.ts
+++ b/ui/src/lib/harness-patterns/patterns/compactIntent.server.ts
@@ -43,7 +43,7 @@ import { getErrorHint } from '../error-hints'
 import { stripThinkBlocks } from '../content-transforms'
 import { trimToFit, getContextWindow } from '../token-budget.server'
 import { extractLLMCallData, extractFailureLLMCallData } from '../baml-adapters.server'
-import { clientOverrideFor } from '../clients.server'
+import { clientOverrideFor, resolveClientForRole } from '../clients.server'
 
 assertServerOnImport()
 
@@ -118,8 +118,9 @@ export function compactIntent<T extends CompactIntentData>(
         return scope
       }
 
-      // Trim oldest history if it would overflow the describe-tier model.
-      const contextWindow = getContextWindow('DescribeFallback')
+      // Trim oldest history if it would overflow the describe-tier model
+      // (the client this call will actually use, not the hardcoded Fallback).
+      const contextWindow = getContextWindow(resolveClientForRole('describe'))
       const history = trimToFit(rawHistory, h => JSON.stringify(h), 300, contextWindow)
 
       const { b } = await import('../../../../baml_client')

--- a/ui/src/lib/harness-patterns/patterns/router.server.ts
+++ b/ui/src/lib/harness-patterns/patterns/router.server.ts
@@ -29,6 +29,7 @@ import { emitLive } from '../live-event-context.server'
 import { getRequestSettings } from '../../settings-context.server'
 import { stripThinkBlocks } from '../content-transforms'
 import { trimToFit, getContextWindow } from '../token-budget.server'
+import { resolveClientForRole } from '../clients.server'
 
 assertServerOnImport()
 
@@ -110,7 +111,7 @@ export function router<T extends RouterData>(
           role: e.type === 'user_message' ? 'user' : 'assistant',
           content: (e.data as UserMessageEventData | AssistantMessageEventData).content
         }))
-      const contextWindow = getContextWindow('RouterFallback')
+      const contextWindow = getContextWindow(resolveClientForRole('router'))
       const history = trimToFit(rawHistory, h => JSON.stringify(h), 300, contextWindow)
 
       // Convert routes Record<string,string> to Array<{name,description}>

--- a/ui/src/lib/harness-patterns/patterns/simpleLoop.server.ts
+++ b/ui/src/lib/harness-patterns/patterns/simpleLoop.server.ts
@@ -27,6 +27,7 @@ import { trackEvent, resolveConfig, generateId } from '../context.server'
 import { getRequestSettings } from '../../settings-context.server'
 import { getActiveSandbox } from '../../sandbox/scope.server'
 import { trimToFit, getContextWindow } from '../token-budget.server'
+import { resolveClientForRole } from '../clients.server'
 import type { ControllerFnWithLLMData } from '../baml-adapters.server'
 import { dedupByRefId, annotateExpansions, LLMCallError } from '../baml-adapters.server'
 import type { LLMCallData } from '../types'
@@ -195,7 +196,8 @@ export function simpleLoop<T extends SimpleLoopData>(
     try {
       for (let turn = 0; turn < maxTurns; turn++) {
         // Trim oldest turns if they would overflow the controller's context window
-        const contextWindow = getContextWindow('ControllerFallback')
+        // (the client this call will actually use, not the hardcoded Fallback).
+        const contextWindow = getContextWindow(resolveClientForRole('controller'))
         // ~500 chars base prompt overhead (template, schema, intent, etc.)
         const trimmedTurns = trimToFit(turns, t => JSON.stringify(t), 500, contextWindow)
         const previousResults = JSON.stringify(trimmedTurns)

--- a/ui/src/lib/harness-patterns/patterns/synthesizer.server.ts
+++ b/ui/src/lib/harness-patterns/patterns/synthesizer.server.ts
@@ -24,7 +24,7 @@ import { trackEvent, resolveConfig } from '../context.server'
 import { Collector } from '@boundaryml/baml'
 import { trimToFit, getContextWindow } from '../token-budget.server'
 import { extractFailureLLMCallData } from '../baml-adapters.server'
-import { clientOverrideFor } from '../clients.server'
+import { clientOverrideFor, resolveClientForRole } from '../clients.server'
 
 assertServerOnImport()
 
@@ -77,7 +77,11 @@ async function defaultSynthesize(input: SynthesizerInput, collector?: Collector)
   }
 
   // Trim oldest turns if they would overflow the synthesizer's context window
-  const contextWindow = getContextWindow('SynthesizerFallback')
+  // Trim against the window of the client this call will ACTUALLY use
+  // (Anthropic 200K by default, the mixed-chain floor under USE_MIXED_CHAINS).
+  // Hardcoding 'SynthesizerFallback' here trimmed against a 16K default and
+  // dropped real tool results (see .harness-logs/neo4j-no-results.json).
+  const contextWindow = getContextWindow(resolveClientForRole('synth'))
   const trimmedTurns = trimToFit(turns, t => JSON.stringify(t), 500, contextWindow)
 
   const variables = {

--- a/ui/src/lib/settings.ts
+++ b/ui/src/lib/settings.ts
@@ -88,6 +88,25 @@ export const MODEL_CONTEXT_WINDOWS: Record<string, number> = {
   CerebrasQwen3_235B: 131_072,     // qwen-3-235b-a22b-instruct-2507
   // Local (local-client.baml, not used in chains)
   LocalGLM: 16_384,
+  // Strategy-level chain clients — the names patterns actually pass to
+  // getContextWindow() (via resolveClientForRole). Without these the lookup
+  // fell through to the 16_384 default and over-trimmed prompts, dropping real
+  // tool results before the LLM saw them (see .harness-logs/neo4j-no-results.json).
+  // Anthropic-only chains (dev default) → Sonnet 4.6 / Haiku 4.5, 200K each.
+  RouterAnthropic: 200_000,
+  ControllerAnthropic: 200_000,
+  CriticAnthropic: 200_000,
+  SynthesizerAnthropic: 200_000,
+  DescribeAnthropic: 200_000,
+  // Mixed-provider fallback chains (USE_MIXED_CHAINS=1). Conservative floor =
+  // the smallest window any client in the chain can fall back to (32_768), so
+  // trimming never overflows a downstream model regardless of which one BAML
+  // lands on.
+  RouterFallback: 32_768,
+  ControllerFallback: 32_768,
+  CriticFallback: 32_768,
+  SynthesizerFallback: 32_768,
+  DescribeFallback: 32_768,
 }
 
 export const SETTINGS_STORAGE_KEY = 'kg_agent_settings'


### PR DESCRIPTION
## Summary

Diagnosed from **`.harness-logs/neo4j-no-results.json`**: a neo4j query returned real rows (Redis/Schema/… — ~58KB + ~65KB across two turns), the actor composed a full answer, yet the synthesizer reported *"returned null — no data."*

Root cause: all four prompt-trimming sites call `getContextWindow('<role>Fallback')`, but those strategy-level client names **were absent from `MODEL_CONTEXT_WINDOWS`**, so the lookup fell through to the **16,384** default. On the Anthropic-only dev default (Sonnet/Haiku, **200K**), `trimToFit` then trimmed against a window ~12× too small (budget 16384−4096 = **12,288 tokens**), dropping both data-bearing turns and keeping only the loop's `Return` (result: `null`). The synth honestly synthesized over `null`.

The FIDELITY block from the now-merged #93 was working as intended — it reported the null it received. The bug is upstream: **the data never reached the synth.**

## Scope

The reported failure was the synthesizer, but the **identical bug** existed in `simpleLoop`, `router`, and `compactIntent` (all four hardcode a `*Fallback` label that's missing from the table). Fixed the shared root cause uniformly rather than patching one site.

## Changes

- **`settings.ts`** — add the strategy-level client windows to `MODEL_CONTEXT_WINDOWS`: `*Anthropic` chains = `200_000` (Sonnet/Haiku); `*Fallback` chains = `32_768` (conservative floor — the smallest model any mixed chain can fall back to, so trimming never overflows a downstream model).
- **`clients.server.ts`** — add `DECLARED_CLIENT_BY_ROLE` + `resolveClientForRole(role)`: returns the client BAML will *actually* use right now (mixed override under `USE_MIXED_CHAINS=1`, else the declared Anthropic client).
- **`synthesizer` / `simpleLoop` / `router` / `compactIntent`** — trim against `getContextWindow(resolveClientForRole(role))` instead of the hardcoded `*Fallback` label.

## Tests (no real LLM calls)

- `synthesizer.test.ts`: a large two-turn result now survives into the `turns` passed to a **mocked** `b.Synthesize` (zero tokens). The test genuinely requires the fix — with the `*Fallback` floor (32K) turn 0 would still be trimmed; only resolving to `SynthesizerAnthropic` (200K) keeps both.
- Window/role-resolution units: `getContextWindow` keys present; `resolveClientForRole` returns the declared client by default and the Fallback under `USE_MIXED_CHAINS=1`.
- **833 pass** (+2). `tsc` clean on touched files.

Follow-up to the merged **#93** (synth fidelity) — the FIDELITY prompt is only as good as the data that reaches it. Independent of the open **#98** (tools-panel gating).

🤖 Generated with [Claude Code](https://claude.com/claude-code)