### PR TITLE
fix(tools-panel): live-agent code-mode gate + tab-mount white flash

### DIFF
--- a/ui/src/__tests__/lib/tool-config/config.server.test.ts
+++ b/ui/src/__tests__/lib/tool-config/config.server.test.ts
@@ -1,0 +1,76 @@
+/**
+ * config.server — getCodeModeAllowedTools usesCodeMode gate source.
+ *
+ * The Tools panel greys out for agents that don't run a code-mode pattern. To
+ * make that track the LIVE agent selection (not lag a turn behind the persisted
+ * session), getCodeModeAllowedTools takes an optional selectedAgentId and gates
+ * on it, preferring it over the persisted agent. Mocks the registry's
+ * agentUsesCodeMode (no real pattern build / gateway call).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const agentUsesCodeMode = vi.fn(async () => false)
+vi.mock('../../../lib/harness-client/registry.server', () => ({ agentUsesCodeMode }))
+
+const loadSession = vi.fn()
+vi.mock('../../../lib/harness-client/session.server', () => ({
+  loadSession,
+  saveSession: vi.fn(),
+}))
+
+vi.mock('../../../lib/harness-patterns/mcp-client.server', () => ({
+  listTools: vi.fn(async () => [{ name: 'read_neo4j_cypher' }]),
+}))
+
+vi.mock('../../../lib/harness-patterns', () => ({
+  deserializeContext: vi.fn(() => ({ data: {} })),
+  serializeContext: vi.fn(() => '{}'),
+}))
+
+vi.mock('../../../lib/auth/server', () => ({
+  getAuthenticatedUser: vi.fn(async () => ({ id: 'u1' })),
+}))
+
+vi.mock('../../../lib/tool-config/server-catalog.server', () => ({
+  getPresetTools: vi.fn(async () => ['read_neo4j_cypher']),
+}))
+
+describe('getCodeModeAllowedTools — usesCodeMode gate source', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    agentUsesCodeMode.mockResolvedValue(false)
+  })
+
+  it('prefers the client-selected agent over the persisted one', async () => {
+    // Persisted as code-mode, but the user has switched the live selection to default.
+    loadSession.mockResolvedValue({ serializedContext: '{}', agentId: 'code-mode' })
+    const { getCodeModeAllowedTools } = await import('../../../lib/tool-config/config.server')
+
+    const res = await getCodeModeAllowedTools('s1', 'default')
+
+    expect(agentUsesCodeMode).toHaveBeenCalledWith('default', 's1')
+    expect(res.usesCodeMode).toBe(false)
+  })
+
+  it('falls back to the persisted agent when no selection is passed', async () => {
+    loadSession.mockResolvedValue({ serializedContext: '{}', agentId: 'code-mode' })
+    agentUsesCodeMode.mockResolvedValue(true)
+    const { getCodeModeAllowedTools } = await import('../../../lib/tool-config/config.server')
+
+    const res = await getCodeModeAllowedTools('s1')
+
+    expect(agentUsesCodeMode).toHaveBeenCalledWith('code-mode', 's1')
+    expect(res.usesCodeMode).toBe(true)
+  })
+
+  it('stays optimistic (true) when neither selection nor session is known', async () => {
+    loadSession.mockResolvedValue(null)
+    const { getCodeModeAllowedTools } = await import('../../../lib/tool-config/config.server')
+
+    const res = await getCodeModeAllowedTools('s1')
+
+    expect(agentUsesCodeMode).not.toHaveBeenCalled()
+    expect(res.usesCodeMode).toBe(true)
+  })
+})

--- a/ui/src/components/ark-ui/ChatInterface.tsx
+++ b/ui/src/components/ark-ui/ChatInterface.tsx
@@ -63,6 +63,9 @@ export interface ChatInterfaceProps {
   /** Called when the user changes agent — parent should mint a fresh sessionId so
    *  the new agent gets its own conversation row rather than overwriting an existing one. */
   onAgentChangeRequestsNewSession?: () => void
+  /** Reports the conversation's selected agent (initial, on load, and on change)
+   *  so the parent can drive agent-aware UI (e.g. the Tools panel's code-mode gate). */
+  onSelectedAgentChange?: (agentId: string) => void
   /** Map of entity/relation names → graph element IDs for interactive highlighting */
   graphEntityNames?: Map<string, string[]>
   /** Callback to highlight specific graph element IDs */
@@ -96,6 +99,9 @@ const WELCOME_MESSAGE: Message = {
 export const ChatInterface = (props: ChatInterfaceProps) => {
   const [messages, setMessages] = createSignal<Message[]>([])
   const [selectedAgent, setSelectedAgent] = createSignal('default')
+  // Report the selected agent up to the parent (initial 'default', then on load
+  // and on every change) so agent-aware UI like the Tools panel can react.
+  createEffect(() => props.onSelectedAgentChange?.(selectedAgent()))
   // Cursor into ctx.events — tracks how many events were sent last turn so we
   // emit only the delta (new events) rather than the full accumulated history
   let prevEventCount = 0

--- a/ui/src/components/ark-ui/SupportPanel.tsx
+++ b/ui/src/components/ark-ui/SupportPanel.tsx
@@ -6,7 +6,7 @@
  */
 
 import { Tabs } from '@ark-ui/solid/tabs';
-import { Show, createSignal, createMemo } from 'solid-js';
+import { Show, createSignal, createMemo, Suspense } from 'solid-js';
 import { GraphVisualization } from './GraphVisualization';
 import { ObservabilityPanel } from './ObservabilityPanel';
 import { DataStashPanel, type StashAction } from './DataStashPanel';
@@ -61,6 +61,9 @@ export interface SupportPanelProps {
   onCypherWrite?: (cypher: string, params?: Record<string, unknown>) => Promise<void>;
   /** Session ID for stash API calls */
   sessionId?: string;
+  /** The conversation's currently-selected agent — forwarded to the Tools
+   *  panel so its code-mode gate tracks the live selection. */
+  agentId?: string;
   /** Callback for data stash actions (hide/unhide/archive/unarchive) */
   onStashAction?: (eventId: string, action: StashAction) => Promise<void>;
 }
@@ -290,18 +293,25 @@ export const SupportPanel = (props: SupportPanelProps) => {
             />
           </Tabs.Content>
 
-          {/* Data Stash Tab */}
+          {/* Data Stash Tab. Local Suspense so the panel's resource load on
+              (lazy) mount can't bubble to the empty-fallback root <Suspense>
+              in app.tsx and flash the whole app white. */}
           <Tabs.Content value="data" h="full">
-            <DataStashPanel
-              events={props.contextEvents ?? []}
-              sessionId={props.sessionId ?? ''}
-              onStashAction={props.onStashAction ?? (async () => {})}
-            />
+            <Suspense fallback={<div p="4" text="sm dark-text-tertiary">Loading data…</div>}>
+              <DataStashPanel
+                events={props.contextEvents ?? []}
+                sessionId={props.sessionId ?? ''}
+                onStashAction={props.onStashAction ?? (async () => {})}
+              />
+            </Suspense>
           </Tabs.Content>
 
-          {/* Tools Tab */}
+          {/* Tools Tab. Same local-Suspense guard (belt-and-braces with the
+              panel's own internal boundary) against the tab-mount white flash. */}
           <Tabs.Content value="tools" h="full">
-            <ToolsPanel sessionId={props.sessionId} />
+            <Suspense fallback={<div p="4" text="sm dark-text-tertiary">Loading tools…</div>}>
+              <ToolsPanel sessionId={props.sessionId} agentId={props.agentId} />
+            </Suspense>
           </Tabs.Content>
 
           {/* Terminal Tab — read-only feed + interactive shell (#79) */}

--- a/ui/src/components/ark-ui/ToolsPanel.tsx
+++ b/ui/src/components/ark-ui/ToolsPanel.tsx
@@ -39,20 +39,27 @@ interface ToolsPanelProps {
   /** Active conversation id. Required for the per-conversation allowlist;
    *  when undefined the panel renders an empty state. */
   sessionId?: string;
+  /** The conversation's currently-selected agent. Drives the code-mode gate
+   *  (grey-out for agents that don't run a code-mode pattern) off the live
+   *  selection, so a fresh chat re-evaluates the moment the agent changes
+   *  rather than waiting for the session to persist. */
+  agentId?: string;
 }
 
 export const ToolsPanel = (props: ToolsPanelProps) => {
   const [isSaving, setIsSaving] = createSignal(false);
   const [saveError, setSaveError] = createSignal<string | null>(null);
 
-  // Single round-trip: returns allowed + available + meta-tool defaults.
-  // Re-fetches when sessionId changes (selecting a different chat).
+  // Single round-trip: returns allowed + available + meta-tool defaults + the
+  // code-mode gate. Re-fetches when EITHER the session (different chat) or the
+  // selected agent changes — the latter is what makes the grey-out track agent
+  // switches on a not-yet-persisted conversation.
   const [state, { mutate }] = createResource(
-    () => props.sessionId,
-    async (sid) => {
+    () => [props.sessionId, props.agentId] as const,
+    async ([sid, agentId]) => {
       if (!sid) return null;
       try {
-        return await getCodeModeAllowedTools(sid);
+        return await getCodeModeAllowedTools(sid, agentId);
       } catch (err) {
         console.error('[ToolsPanel] load failed:', err);
         return null;

--- a/ui/src/lib/tool-config/config.server.ts
+++ b/ui/src/lib/tool-config/config.server.ts
@@ -53,6 +53,11 @@ async function requireUser(): Promise<{ id: string }> {
  */
 export async function getCodeModeAllowedTools(
   sessionId: string,
+  /** The conversation's currently-selected agent (from the client). Drives the
+   *  `usesCodeMode` gate so it reflects the live selection immediately — before
+   *  the first message persists the session — rather than lagging a turn behind.
+   *  Falls back to the persisted agent, then optimistic. */
+  selectedAgentId?: string,
 ): Promise<CodeModeToolsState> {
   const user = await requireUser();
 
@@ -90,12 +95,12 @@ export async function getCodeModeAllowedTools(
       : Array.from(new Set([...defaults, ...presetTools]));
 
   // Does this conversation's agent actually consume the allowlist? Auto-detected
-  // from its pattern graph. When the session isn't persisted yet (pre-first-
-  // message, no agentId), stay optimistic (true) — the panel can't save before
-  // the first turn anyway, and greying the bundled code-mode agent would be the
-  // more harmful error.
-  const usesCodeMode = loaded
-    ? await agentUsesCodeMode(loaded.agentId, sessionId)
+  // from its pattern graph. Prefer the client's live selection so a fresh chat
+  // greys immediately on agent switch; fall back to the persisted agent, then
+  // optimistic (true) when neither is known.
+  const agentId = selectedAgentId ?? loaded?.agentId;
+  const usesCodeMode = agentId
+    ? await agentUsesCodeMode(agentId, sessionId)
     : true;
 
   return { allowed, available, defaults, usesCodeMode };

--- a/ui/src/routes/index.tsx
+++ b/ui/src/routes/index.tsx
@@ -33,6 +33,9 @@ export default function Home() {
   const [highlightedIds, setHighlightedIds] = createSignal<string[]>([])
   const [contextEvents, setContextEvents] = createSignal<ContextEvent[]>([])
   const [unifiedContext, setUnifiedContext] = createSignal<UnifiedContext | undefined>(undefined)
+  // The conversation's selected agent, reported up from ChatInterface, so the
+  // Tools panel's code-mode gate tracks the live selection (default until set).
+  const [currentAgentId, setCurrentAgentId] = createSignal<string>('default')
 
   // Sidebar threads — refetched after each turn completes (see onContextUpdate).
   // `mutate` is exposed so the `title_updated` SSE event can patch a single
@@ -264,6 +267,7 @@ export default function Home() {
                 onContextUpdate={handleContextUpdate}
                 onResetForNewSession={resetForNewSession}
                 onAgentChangeRequestsNewSession={handleNewChat}
+                onSelectedAgentChange={setCurrentAgentId}
                 graphEntityNames={graphEntityNames()}
                 onHighlightEntities={setHighlightedIds}
                 getProgress={getProgress}
@@ -299,6 +303,7 @@ export default function Home() {
             onClearEvents={clearEvents}
             onCypherWrite={handleCypherWrite}
             sessionId={selectedSessionId()}
+            agentId={currentAgentId()}
             onStashAction={handleStashAction}
           />
         </Splitter.Panel>


### PR DESCRIPTION
## Summary

Two glitches reported while testing after #98 (gating) and #99 (trim fix) landed.

### 1. Panel didn't grey for non-code-mode agents

#98 inferred `usesCodeMode` from the **persisted** session `agentId` and keyed the panel resource only on `sessionId`. So a brand-new chat fetched the optimistic `true` (session not persisted yet) and **never re-fetched** when the first message persisted the session — or when the user switched agents. Net: the panel stayed active for non-code-mode agents.

Fix — drive the gate off the conversation's **live selected agent**:
- `ChatInterface` reports `selectedAgent` up via a new `onSelectedAgentChange` callback (initial, on load, and on change).
- `index.tsx` holds `currentAgentId` and passes it down to `SupportPanel` → `ToolsPanel`.
- `ToolsPanel`'s resource now keys on `[sessionId, agentId]` and forwards the agent to `getCodeModeAllowedTools(sessionId, selectedAgentId?)`, which gates on `selectedAgentId ?? loaded.agentId` (optimistic `true` only when neither is known). So the grey-out re-evaluates the instant the agent changes, no persistence wait.

### 2. Tools/Data tab clicks flashed the whole app white

With `Tabs` `lazyMount`, a panel's `createResource` suspends on mount; with no local boundary it bubbled to the **empty-fallback root `<Suspense>`** in `app.tsx` (`DataStashPanel` had none; `ToolsPanel`'s internal one didn't fully cover the mount). Wrapped both tabs' content in a local `<Suspense fallback>` in `SupportPanel`.

## Tests

- `config.server.test.ts` (new): `selectedAgentId` precedence over the persisted agent + the optimistic fallback (mocks `agentUsesCodeMode` — no real pattern build / gateway call).
- **845 pass** (+3). `tsc` clean on touched files.
- The white-flash fix is structural JSX (Suspense boundary) — verified via tsc + manual; not unit-tested.

Follow-up to #98. Independent; branched off current `main` (has #98 + #99).

🤖 Generated with [Claude Code](https://claude.com/claude-code)