### PR TITLE
feat(retriever): harness-aware Data Stash + retriever pattern

### DIFF
--- a/docs/DATA_STASH.md
+++ b/docs/DATA_STASH.md
@@ -19,7 +19,8 @@ query ─────────────────────── embe
 | `chunking.server.ts` (#9) | Pure text chunking — `fixed` / `sentence` / `paragraph` + MIME-aware `chunkDocument` |
 | `embeddings.server.ts` (#8) | Provider-pluggable embedding with a one-model-per-corpus guard |
 | `vector-store.server.ts` | Shared RediSearch wrapper: `createVectorStore` → `ensureIndex` / `upsert` / `search`; owns the index/key/payload plumbing + naming (`spaceTag`) |
-| `document-ingest.server.ts` | Orchestrator: chunk → embed → vector store, and `searchDocuments` (KNN) |
+| `document-ingest.server.ts` | Orchestrator: chunk → embed → vector store, `searchDocuments` (KNN), and the status-tracked `ingestStashDocument` / `ensureSessionIngested` (harness-aware ingest) |
+| `retriever/redis-backend.server.ts`, `retriever/supabase-backend.server.ts` | `RetrieverBackend` impls for the harness `retriever` pattern — local Data Stash (`redis`, live) + company pgvector via the Supabase MCP (`supabase`, deferred stub) |
 | `stash/upload-service.server.ts`, `stash/http.server.ts` | Upload request parsing (multipart + JSON), auth/response helpers |
 
 ## API routes (`ui/src/routes/api/stash/`)
@@ -35,11 +36,42 @@ query ─────────────────────── embe
 | `POST /api/stash/ingest` | Chunk → embed → index a stored doc (`{sessionId, docId, chunk?, embedding?}`) |
 | `GET /api/stash/search?sessionId=&q=&k=` | KNN similarity search over a session's chunks |
 
-Auth follows the existing posture (dev-bypass aware; see `lib/auth/dev-bypass.ts`). Ingest is **explicit**, not auto-run on upload — it needs an embedding backend and binds the corpus to one model.
+Auth follows the existing posture (dev-bypass aware; see `lib/auth/dev-bypass.ts`). Ingest runs two ways: **explicitly** via `POST /api/stash/ingest`, or **automatically on upload** when the session's agent composes a `retriever` wired to the redis backend (see [Harness-aware ingest](#harness-aware-ingest-the-retriever-pattern) below). Either way it needs an embedding backend and binds the corpus to one model.
+
+## Harness-aware ingest (the `retriever` pattern)
+
+The Data Stash adapts to the agent's harness composition:
+
+- **Sandbox present** (`withSandbox` + `syncWorkspace`) → uploads are hydrated into the VM's `/work/in` on first boot (`hydrateWorkspace`, #89). No vector ingest implied.
+- **A `retriever` wired to the `redis` backend present** → uploads are **auto-ingested** into the local vector store so they're semantically searchable. An agent without such a retriever never ingests — the upload is just stored.
+- Both can hold at once (independent, composable).
+
+**The gate.** `POST /api/stash/upload`, after storing, resolves the session's agent (`loadSession` → `getOrBuildPatterns`) and checks `harnessHasRedisRetriever(patterns)` — static introspection in `harness-patterns/pattern-capabilities.ts` that walks `ConfiguredPattern.children` (the combinators — `routes`, `chain`, `withReferences`, `withSandbox` — all expose them). On a match it marks the doc `ingestStatus: 'pending'` and ingests **in the background** (the response returns immediately — embedding a large doc takes seconds). Base64 binaries are skipped (`failed`). Best-effort: any failure leaves the `201` untouched.
+
+**Safety net.** Docs uploaded *before* the agent was known (session not yet persisted) miss the gate. The redis backend runs `ensureSessionIngested` on its first search per session (idempotent via `ingestStatus`), so they still become searchable on first retrieval.
+
+**The pattern** (`harness-patterns/patterns/retriever.server.ts`) is framework-pure: it forms ONE query (compacted `scope.data.intent` → last user message → optional last-N turns), fans it out to injected `RetrieverBackend`s concurrently (per-backend error isolation), merges hits closest-first capped at `k`, sets `scope.data.matches`, and emits a `tool_result` the synthesizer consumes. It's a low-latency alternative to a tool-calling `simpleLoop` — one embed + KNN instead of a >30s LLM loop. Typical wiring (see `harness-client/examples/retriever-agent.server.ts`):
+
+```ts
+router({ retriever, neo4j, web_search }),
+routes({
+  retriever: chain(compactIntent(), retriever({ backends: [createRedisBackend(sessionId)], k: 5 })),
+  neo4j: simpleLoop(neo4jController, tools.neo4j),
+  web_search: simpleLoop(webController, tools.web),
+}),
+synthesizer({ mode: 'thread' }),
+```
+
+**Backends** (`ui/src/lib/retriever/`) implement `RetrieverBackend { name, type, search() }`:
+
+- **`redis`** (`createRedisBackend`, `type: 'vector'`) — wraps `searchDocuments` (local Data Stash KNN), embedding the query locally with the corpus's recorded model. **Live.**
+- **`supabase`** (`createSupabaseBackend`, `type: 'vector'`) — the company pgvector corpus via the **Supabase MCP** server; **text-in** (Supabase embeds server-side via Automatic Embeddings / Edge Functions, so no client-side embedding and no OpenAI provider here). **Deferred stub** pending IT access: when `SUPABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY` land, add the Supabase MCP to `configs/custom-catalog.yaml` and implement `search()` against its match RPC. Until then `search()` throws and the retriever's per-backend guard turns it into an empty result + error event — a misconfigured backend never sinks a run.
+
+The `type` field distinguishes vector backends from future non-vector ones (web keyword, neo4j graph, raw SQL) — only `vector` backends embed.
 
 ## Storage model (Redis)
 
-- **Document**: RedisJSON blob at `stash:doc:{sessionId}:{docId}`, TTL default 7 days. `content` is UTF-8 text by default; binary files (xlsx, pdf, images) are stored with `encoding: 'base64'` and `size` = the original (decoded) byte count (#89). Binary content is byte-faithful but **not** semantically searchable — `POST /api/stash/ingest` rejects base64 docs (chunking/embedding is text-only).
+- **Document**: RedisJSON blob at `stash:doc:{sessionId}:{docId}`, TTL default 7 days. `content` is UTF-8 text by default; binary files (xlsx, pdf, images) are stored with `encoding: 'base64'` and `size` = the original (decoded) byte count (#89). Binary content is byte-faithful but **not** semantically searchable — `POST /api/stash/ingest` rejects base64 docs (chunking/embedding is text-only). An `ingestStatus` (`pending` | `indexed` | `failed`) is stamped when the harness-aware path ingests the doc; absent means it was never ingested (no redis-retriever in the harness).
 - **Session index**: a Redis SET `stash:docs:{sessionId}` of doc ids (self-healing — stale entries pruned on list).
 - **Chunk**: a Redis HASH `stashvec:{sessionId}:{spaceTag}:{docId}:{chunkIndex}` with `vector` (float blob) + `meta` (base64 of a JSON `{content, doc_id, source, chunk_index, offsets, model, provider, dim}`). 2 writes/chunk.
 - **Vector index**: a RediSearch HNSW index per `(session, embedding-space)`; `dim` matches the embedding model.

--- a/ui/src/__tests__/lib/document-ingest-status.test.ts
+++ b/ui/src/__tests__/lib/document-ingest-status.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Status-tracked ingest tests — `ingestStashDocument` + `ensureSessionIngested`
+ * (the harness-aware Data Stash auto-ingest gate + retriever safety net).
+ *
+ * Drives the REAL document-store (storeDocument / setDocumentFlags / getDocument)
+ * over a fake Redis so status transitions are exercised end-to-end: indexed on
+ * success, failed on error/binary, and idempotent skip-when-terminal.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+vi.mock('../../lib/harness-patterns/assert.server', () => ({
+  assertServerOnImport: vi.fn(),
+  assertServer: vi.fn(),
+}))
+vi.mock('../../lib/harness-patterns/mcp-client.server', () => ({
+  callTool: vi.fn(async () => ({ success: false, data: null, error: 'no gateway' })),
+}))
+
+import { ingestStashDocument, ensureSessionIngested } from '../../lib/document-ingest.server'
+import { storeDocument, setDocumentFlags, getDocument } from '../../lib/document-store.server'
+import type { CallTool } from '../../lib/document-store.server'
+import type { ToolCallResult } from '../../lib/harness-patterns/types'
+import type { EmbeddingConfig, EmbeddingResult } from '../../lib/embeddings.server'
+
+// ----------------------------------------------------------------------------
+// Fake Redis: JSON docs + a per-session index set + vector hashes.
+// ----------------------------------------------------------------------------
+function makeFakeRedis() {
+  const json = new Map<string, unknown>()
+  const hashes = new Map<string, Record<string, unknown>>()
+  const sets = new Map<string, Set<string>>()
+  const callTool = (async (name: string, args: Record<string, unknown>): Promise<ToolCallResult> => {
+    switch (name) {
+      case 'json_set':
+        json.set(args.name as string, JSON.parse(args.value as string))
+        return { success: true, data: 'OK' }
+      case 'json_get': {
+        const v = json.get(args.name as string)
+        return { success: true, data: v == null ? null : [v] }
+      }
+      case 'sadd': {
+        const s = sets.get(args.name as string) ?? new Set<string>()
+        s.add(String(args.value))
+        sets.set(args.name as string, s)
+        return { success: true, data: 1 }
+      }
+      case 'smembers': {
+        const s = sets.get(args.name as string)
+        return { success: true, data: s ? [...s] : [] }
+      }
+      case 'srem':
+        sets.get(args.name as string)?.delete(String(args.value))
+        return { success: true, data: 1 }
+      case 'create_vector_index_hash':
+        return { success: true, data: 'Index created' }
+      case 'set_vector_in_hash': {
+        const h = hashes.get(args.name as string) ?? {}
+        h.vector = args.vector
+        hashes.set(args.name as string, h)
+        return { success: true, data: true }
+      }
+      case 'hset': {
+        const h = hashes.get(args.name as string) ?? {}
+        h[args.key as string] = args.value
+        hashes.set(args.name as string, h)
+        return { success: true, data: 1 }
+      }
+      default:
+        return { success: false, data: null, error: `unhandled ${name}` }
+    }
+  }) as CallTool
+  return { json, hashes, sets, callTool }
+}
+
+function makeEmbedder(model: string, dim: number) {
+  const embedFn = async (texts: string[], config?: EmbeddingConfig): Promise<EmbeddingResult> => ({
+    provider: config?.provider ?? 'local',
+    model: config?.model ?? model,
+    dimensions: dim,
+    vectors: texts.map((t, i) => Array.from({ length: dim }, (_, d) => t.length + i + d)),
+  })
+  return { embedFn }
+}
+
+async function seed(
+  fake: ReturnType<typeof makeFakeRedis>,
+  id: string,
+  content: string,
+  opts: { encoding?: 'base64' } = {},
+) {
+  return storeDocument(
+    {
+      sessionId: 's1',
+      id,
+      filename: `${id}.txt`,
+      mimeType: 'text/plain',
+      content,
+      ...(opts.encoding ? { encoding: opts.encoding } : {}),
+    },
+    fake.callTool,
+  )
+}
+
+describe('ingestStashDocument', () => {
+  let fake: ReturnType<typeof makeFakeRedis>
+  beforeEach(() => {
+    fake = makeFakeRedis()
+  })
+
+  it('indexes a text doc and stamps status "indexed"', async () => {
+    const { embedFn } = makeEmbedder('m', 3)
+    await seed(fake, 'd1', 'Alpha sentence.\n\nBeta paragraph.')
+    const res = await ingestStashDocument('s1', 'd1', { callTool: fake.callTool, embedFn })
+    expect(res?.docId).toBe('d1')
+    expect((await getDocument('s1', 'd1', fake.callTool))?.ingestStatus).toBe('indexed')
+    expect(fake.hashes.size).toBeGreaterThan(0)
+  })
+
+  it('marks a base64 binary doc "failed" without attempting ingest', async () => {
+    const { embedFn } = makeEmbedder('m', 3)
+    await seed(fake, 'bin', Buffer.from('binary').toString('base64'), { encoding: 'base64' })
+    const res = await ingestStashDocument('s1', 'bin', { callTool: fake.callTool, embedFn })
+    expect(res).toBeNull()
+    expect((await getDocument('s1', 'bin', fake.callTool))?.ingestStatus).toBe('failed')
+    expect(fake.hashes.size).toBe(0)
+  })
+
+  it('returns null for a missing doc', async () => {
+    const { embedFn } = makeEmbedder('m', 3)
+    expect(await ingestStashDocument('s1', 'ghost', { callTool: fake.callTool, embedFn })).toBeNull()
+  })
+
+  it('marks status "failed" (and never throws) when ingest errors', async () => {
+    const boom: ReturnType<typeof makeEmbedder>['embedFn'] = async () => {
+      throw new Error('embedder offline')
+    }
+    await seed(fake, 'd2', 'some text')
+    const res = await ingestStashDocument('s1', 'd2', { callTool: fake.callTool, embedFn: boom })
+    expect(res).toBeNull()
+    expect((await getDocument('s1', 'd2', fake.callTool))?.ingestStatus).toBe('failed')
+  })
+})
+
+describe('ensureSessionIngested', () => {
+  let fake: ReturnType<typeof makeFakeRedis>
+  beforeEach(() => {
+    fake = makeFakeRedis()
+  })
+
+  it('ingests every not-yet-indexed doc, and is idempotent on a second run', async () => {
+    const { embedFn } = makeEmbedder('m', 3)
+    const embedSpy = vi.fn(embedFn)
+    await seed(fake, 'a', 'Aaa text.')
+    await seed(fake, 'b', 'Bbb text.')
+
+    await ensureSessionIngested('s1', { callTool: fake.callTool, embedFn: embedSpy })
+    expect((await getDocument('s1', 'a', fake.callTool))?.ingestStatus).toBe('indexed')
+    expect((await getDocument('s1', 'b', fake.callTool))?.ingestStatus).toBe('indexed')
+
+    const callsAfterFirst = embedSpy.mock.calls.length
+    await ensureSessionIngested('s1', { callTool: fake.callTool, embedFn: embedSpy })
+    expect(embedSpy.mock.calls.length).toBe(callsAfterFirst) // nothing re-embedded
+  })
+
+  it('skips terminal (failed) and binary (base64) docs, ingesting only the fresh one', async () => {
+    const { embedFn } = makeEmbedder('m', 3)
+    const embedSpy = vi.fn(embedFn)
+    await seed(fake, 'old-failed', 'x')
+    await setDocumentFlags('s1', 'old-failed', { ingestStatus: 'failed' }, fake.callTool)
+    await seed(fake, 'bin', Buffer.from('b').toString('base64'), { encoding: 'base64' })
+    await seed(fake, 'fresh', 'Fresh content here.')
+
+    await ensureSessionIngested('s1', { callTool: fake.callTool, embedFn: embedSpy })
+
+    expect((await getDocument('s1', 'fresh', fake.callTool))?.ingestStatus).toBe('indexed')
+    expect((await getDocument('s1', 'old-failed', fake.callTool))?.ingestStatus).toBe('failed') // untouched
+    expect((await getDocument('s1', 'bin', fake.callTool))?.ingestStatus).toBeUndefined() // skipped
+    expect(embedSpy).toHaveBeenCalledTimes(1) // only 'fresh'
+  })
+})

--- a/ui/src/__tests__/lib/harness-patterns/pattern-capabilities.test.ts
+++ b/ui/src/__tests__/lib/harness-patterns/pattern-capabilities.test.ts
@@ -11,7 +11,13 @@
  */
 
 import { describe, it, expect } from 'vitest'
-import { usesCodeMode, isCodeModeLoopConfig } from '../../../lib/harness-patterns/pattern-capabilities'
+import {
+  usesCodeMode,
+  isCodeModeLoopConfig,
+  isRetrieverConfig,
+  harnessHasRetriever,
+  harnessHasRedisRetriever,
+} from '../../../lib/harness-patterns/pattern-capabilities'
 import type { ConfiguredPattern, PatternConfig } from '../../../lib/harness-patterns/types'
 
 type AnyPattern = ConfiguredPattern<Record<string, unknown>>
@@ -87,5 +93,69 @@ describe('usesCodeMode', () => {
       ]),
     ]
     expect(usesCodeMode(tree)).toBe(true)
+  })
+})
+
+describe('isRetrieverConfig', () => {
+  it('flags the retriever patternId', () => {
+    expect(isRetrieverConfig({ patternId: 'retriever' } as PatternConfig)).toBe(true)
+  })
+  it('does NOT flag other patterns', () => {
+    expect(isRetrieverConfig({ patternId: 'neo4j-query' } as PatternConfig)).toBe(false)
+    expect(isRetrieverConfig({} as PatternConfig)).toBe(false)
+  })
+})
+
+describe('harnessHasRetriever', () => {
+  it('returns false for empty / undefined / retriever-free graphs', () => {
+    expect(harnessHasRetriever(undefined)).toBe(false)
+    expect(harnessHasRetriever([])).toBe(false)
+    expect(
+      harnessHasRetriever([pat('router', {}), pat('routes', {}, [pat('simpleLoop', { patternId: 'neo4j-query' })])]),
+    ).toBe(false)
+  })
+
+  it('detects a retriever nested router → routes → chain', () => {
+    const tree = [
+      pat('router', {}),
+      pat('routes(retriever|neo4j)', {}, [
+        pat('chain', {}, [
+          pat('compactIntent', { patternId: 'retriever-intent' }),
+          pat('retriever', { patternId: 'retriever', backendKinds: ['redis'] }),
+        ]),
+        pat('simpleLoop', { patternId: 'neo4j-query' }),
+      ]),
+    ]
+    expect(harnessHasRetriever(tree)).toBe(true)
+  })
+
+  it('detects a top-level retriever leaf', () => {
+    expect(harnessHasRetriever([pat('retriever', { patternId: 'retriever' })])).toBe(true)
+  })
+})
+
+describe('harnessHasRedisRetriever', () => {
+  const nest = (retrieverConfig: Record<string, unknown>) => [
+    pat('router', {}),
+    pat('routes', {}, [pat('chain', {}, [pat('retriever', retrieverConfig)])]),
+  ]
+
+  it('is true only when a retriever lists the redis backend', () => {
+    expect(harnessHasRedisRetriever(nest({ patternId: 'retriever', backendKinds: ['redis'] }))).toBe(true)
+    expect(
+      harnessHasRedisRetriever(nest({ patternId: 'retriever', backendKinds: ['supabase', 'redis'] })),
+    ).toBe(true)
+  })
+
+  it('is false for a non-redis (e.g. supabase-only) retriever', () => {
+    expect(harnessHasRedisRetriever(nest({ patternId: 'retriever', backendKinds: ['supabase'] }))).toBe(false)
+  })
+
+  it('is false when backendKinds is absent', () => {
+    expect(harnessHasRedisRetriever(nest({ patternId: 'retriever' }))).toBe(false)
+  })
+
+  it('is false for a graph with no retriever at all', () => {
+    expect(harnessHasRedisRetriever([pat('router', {}), pat('simpleLoop', { patternId: 'neo4j-query' })])).toBe(false)
   })
 })

--- a/ui/src/__tests__/lib/harness-patterns/patterns/retriever.test.ts
+++ b/ui/src/__tests__/lib/harness-patterns/patterns/retriever.test.ts
@@ -1,0 +1,236 @@
+/**
+ * retriever Pattern Tests
+ *
+ * The retriever forms ONE query (compacted intent → last message → last-N
+ * turns), fans it out to injected backends, merges hits closest-first capped at
+ * k, sets `scope.data.matches`, and emits a `tool_result` for the synthesizer.
+ * Backends are mocked — this is the framework-pure pattern, no app deps.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type {
+  ContextEvent,
+  EventType,
+  UnifiedContext,
+  ToolResultEventData,
+} from '../../../../lib/harness-patterns'
+import type {
+  RetrieverBackend,
+  RetrievalHit,
+} from '../../../../lib/harness-patterns/patterns/retriever.server'
+
+vi.mock('../../../../lib/harness-patterns/assert.server', () => ({
+  assertServerOnImport: vi.fn(),
+  assertServer: vi.fn(),
+}))
+
+type Ev = { type: EventType; ts: number; patternId: string; data: unknown }
+
+function ctxOf(events: Ev[]): UnifiedContext<Record<string, unknown>> {
+  const lastUser = events.filter((e) => e.type === 'user_message').slice(-1)[0]
+  return {
+    sessionId: 'test',
+    createdAt: 1,
+    events: events as ContextEvent[],
+    status: 'running',
+    data: {},
+    input: lastUser ? (lastUser.data as { content: string }).content : '',
+  }
+}
+
+const PATTERN_ID = 'retriever'
+
+async function load() {
+  const { retriever } = await import(
+    '../../../../lib/harness-patterns/patterns/retriever.server'
+  )
+  const { createScope } = await import('../../../../lib/harness-patterns/context.server')
+  const { createEventView } = await import('../../../../lib/harness-patterns/patterns')
+  return { retriever, createScope, createEventView }
+}
+
+/** A mock backend that records the query it received and returns canned hits. */
+function mockBackend(
+  name: string,
+  hits: RetrievalHit[],
+  opts: { type?: RetrieverBackend['type']; throws?: Error } = {},
+): RetrieverBackend & { calls: Array<{ text: string; intent?: string; k: number }> } {
+  const calls: Array<{ text: string; intent?: string; k: number }> = []
+  return {
+    name,
+    type: opts.type ?? 'vector',
+    calls,
+    async search({ text, intent }, { k }) {
+      calls.push({ text, intent, k })
+      if (opts.throws) throw opts.throws
+      return hits
+    },
+  }
+}
+
+function hit(backend: string, id: string, score: number): RetrievalHit {
+  return { backend, id, content: `content-${id}`, source: `${id}.txt`, score }
+}
+
+const userMsg = (content: string, ts = 1): Ev => ({
+  type: 'user_message',
+  ts,
+  patternId: 'harness',
+  data: { content },
+})
+
+async function run(
+  scopeData: Record<string, unknown>,
+  events: Ev[],
+  config: Parameters<Awaited<ReturnType<typeof load>>['retriever']>[0],
+) {
+  const { retriever, createScope, createEventView } = await load()
+  const pattern = retriever(config)
+  const scope = createScope(PATTERN_ID, scopeData)
+  const view = createEventView(ctxOf(events), pattern.config.viewConfig, PATTERN_ID)
+  const result = await pattern.fn(scope, view)
+  return { pattern, result }
+}
+
+function toolResults(events: ContextEvent[]): ToolResultEventData[] {
+  return events
+    .filter((e) => e.type === 'tool_result')
+    .map((e) => e.data as ToolResultEventData)
+}
+
+describe('retriever', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('exports a factory that returns a zero-turn ConfiguredPattern', async () => {
+    const { retriever } = await load()
+    const pattern = retriever({ backends: [], patternId: PATTERN_ID })
+    expect(pattern.name).toBe('retriever')
+    expect(pattern.config.patternId).toBe('retriever')
+    expect(pattern.estimateTurns?.({} as never)).toBe(0)
+  })
+
+  it('stamps backendKinds on its resolved config (the seam pattern-capabilities reads)', async () => {
+    const { retriever } = await load()
+    const pattern = retriever({
+      backends: [mockBackend('redis', []), mockBackend('supabase', [])],
+      patternId: PATTERN_ID,
+    })
+    expect((pattern.config as { backendKinds?: string[] }).backendKinds).toEqual([
+      'redis',
+      'supabase',
+    ])
+  })
+
+  it('queries with the compacted intent when present (preferred source)', async () => {
+    const b = mockBackend('redis', [hit('redis', 'a', 0.1)])
+    const { result } = await run(
+      { intent: 'find the quarterly revenue figure' },
+      [userMsg('what was it again?')],
+      { backends: [b], k: 5 },
+    )
+    expect(b.calls).toHaveLength(1)
+    expect(b.calls[0].text).toBe('find the quarterly revenue figure')
+    expect(b.calls[0].intent).toBe('find the quarterly revenue figure')
+    expect((result.data as { matches?: RetrievalHit[] }).matches).toHaveLength(1)
+  })
+
+  it('falls back to the last user message when there is no intent', async () => {
+    const b = mockBackend('redis', [])
+    const { result } = await run({}, [userMsg('first'), userMsg('latest question')], {
+      backends: [b],
+    })
+    expect(b.calls[0].text).toBe('latest question')
+    expect(b.calls[0].intent).toBeUndefined()
+    expect((result.data as { matches?: RetrievalHit[] }).matches).toEqual([])
+  })
+
+  it('widens the query to the last N user turns when turnWindow is set', async () => {
+    const b = mockBackend('redis', [])
+    await run(
+      {},
+      [userMsg('alpha', 1), userMsg('beta', 2), userMsg('gamma', 3)],
+      { backends: [b], turnWindow: 3 },
+    )
+    // Joined recent user turns (no intent present).
+    expect(b.calls[0].text).toContain('alpha')
+    expect(b.calls[0].text).toContain('gamma')
+  })
+
+  it('fans out to all backends and merges closest-first, capped at k', async () => {
+    const redis = mockBackend('redis', [hit('redis', 'r1', 0.5), hit('redis', 'r2', 0.2)])
+    const supa = mockBackend('supabase', [hit('supabase', 's1', 0.1), hit('supabase', 's2', 0.9)])
+    const { result } = await run({ intent: 'q' }, [userMsg('q')], {
+      backends: [redis, supa],
+      k: 3,
+    })
+    const matches = (result.data as { matches: RetrievalHit[] }).matches
+    expect(matches).toHaveLength(3) // capped at k=3 (4 hits available)
+    expect(matches.map((m) => m.id)).toEqual(['s1', 'r2', 'r1']) // 0.1 < 0.2 < 0.5
+    expect(redis.calls[0].k).toBe(3)
+    expect(supa.calls[0].k).toBe(3)
+  })
+
+  it('sorts hits without a score last', async () => {
+    const b = mockBackend('redis', [
+      { backend: 'redis', id: 'noscore', content: 'x' },
+      hit('redis', 'scored', 0.4),
+    ])
+    const { result } = await run({ intent: 'q' }, [userMsg('q')], { backends: [b], k: 5 })
+    const matches = (result.data as { matches: RetrievalHit[] }).matches
+    expect(matches.map((m) => m.id)).toEqual(['scored', 'noscore'])
+  })
+
+  it('emits a tool_result the synthesizer can read, with matches + backends + query', async () => {
+    const b = mockBackend('redis', [hit('redis', 'a', 0.1)])
+    const { result } = await run({ intent: 'the query' }, [userMsg('x')], {
+      backends: [b],
+    })
+    const trs = toolResults(result.events)
+    expect(trs).toHaveLength(1)
+    expect(trs[0].tool).toBe('retriever')
+    expect(trs[0].success).toBe(true)
+    const payload = trs[0].result as { matches: RetrievalHit[]; backends: string[]; query: string }
+    expect(payload.matches).toHaveLength(1)
+    expect(payload.backends).toEqual(['redis'])
+    expect(payload.query).toBe('the query')
+    expect(trs[0].summary).toContain('1 match')
+  })
+
+  it('reports "no matches" (empty) without erroring when backends find nothing', async () => {
+    const b = mockBackend('redis', [])
+    const { result } = await run({ intent: 'q' }, [userMsg('q')], { backends: [b] })
+    expect((result.data as { matches: RetrievalHit[] }).matches).toEqual([])
+    expect(toolResults(result.events)[0].summary).toBe('no matches')
+    expect(result.events.some((e) => e.type === 'error')).toBe(false)
+  })
+
+  it('isolates a failing backend: error event + the other backend still contributes', async () => {
+    const ok = mockBackend('redis', [hit('redis', 'a', 0.3)])
+    const bad = mockBackend('supabase', [], { throws: new Error('pgvector down') })
+    const { result } = await run({ intent: 'q' }, [userMsg('q')], {
+      backends: [ok, bad],
+      k: 5,
+    })
+    const matches = (result.data as { matches: RetrievalHit[] }).matches
+    expect(matches.map((m) => m.id)).toEqual(['a'])
+    const errors = result.events.filter((e) => e.type === 'error')
+    expect(errors).toHaveLength(1)
+    expect(JSON.stringify(errors[0].data)).toContain('pgvector down')
+    expect(JSON.stringify(errors[0].data)).toContain('supabase')
+    // Still emits a tool_result with the surviving hit.
+    expect(toolResults(result.events)[0].success).toBe(true)
+  })
+
+  it('short-circuits to empty matches when there are no backends', async () => {
+    const { result } = await run({ intent: 'q' }, [userMsg('q')], { backends: [] })
+    expect((result.data as { matches: RetrievalHit[] }).matches).toEqual([])
+    expect(toolResults(result.events)).toHaveLength(1)
+  })
+
+  it('short-circuits when there is no query text at all', async () => {
+    const b = mockBackend('redis', [hit('redis', 'a', 0.1)])
+    const { result } = await run({}, [], { backends: [b] })
+    expect(b.calls).toHaveLength(0)
+    expect((result.data as { matches: RetrievalHit[] }).matches).toEqual([])
+  })
+})

--- a/ui/src/__tests__/lib/retriever/redis-backend.test.ts
+++ b/ui/src/__tests__/lib/retriever/redis-backend.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Redis RetrieverBackend Tests
+ *
+ * Wraps `searchDocuments` (Data Stash KNN) → normalized RetrievalHit, and runs
+ * `ensureSessionIngested` once per session as a lazy ingest safety net. Both
+ * dependencies are injected, so no gateway/embedder is touched.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+vi.mock('../../../lib/harness-patterns/assert.server', () => ({
+  assertServerOnImport: vi.fn(),
+  assertServer: vi.fn(),
+}))
+vi.mock('../../../lib/harness-patterns/mcp-client.server', () => ({
+  callTool: vi.fn(async () => ({ success: false, data: null, error: 'no gateway' })),
+}))
+
+import { createRedisBackend } from '../../../lib/retriever/redis-backend.server'
+import type { SearchHit } from '../../../lib/document-ingest.server'
+
+const SAMPLE: SearchHit[] = [
+  {
+    docId: 'doc1',
+    source: 'notes.txt',
+    chunkIndex: 2,
+    content: 'the matched chunk',
+    startOffset: 10,
+    endOffset: 27,
+    score: 0.13,
+  },
+]
+
+describe('createRedisBackend', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('self-describes as a vector backend named "redis"', () => {
+    const b = createRedisBackend('s1', { searchFn: vi.fn(async () => []), ensureIngested: false })
+    expect(b.name).toBe('redis')
+    expect(b.type).toBe('vector')
+  })
+
+  it('passes sessionId + query text + k through to searchDocuments', async () => {
+    const searchFn = vi.fn(async () => [])
+    const b = createRedisBackend('sess-42', { searchFn, ensureIngested: false })
+    await b.search({ text: 'how do refunds work?' }, { k: 7 })
+    expect(searchFn).toHaveBeenCalledWith('sess-42', 'how do refunds work?', { k: 7 })
+  })
+
+  it('normalizes SearchHit → RetrievalHit (id, provenance metadata)', async () => {
+    const b = createRedisBackend('s1', {
+      searchFn: vi.fn(async () => SAMPLE),
+      ensureIngested: false,
+    })
+    const hits = await b.search({ text: 'q' }, { k: 5 })
+    expect(hits).toEqual([
+      {
+        backend: 'redis',
+        id: 'doc1:2',
+        content: 'the matched chunk',
+        source: 'notes.txt',
+        score: 0.13,
+        metadata: { docId: 'doc1', chunkIndex: 2, startOffset: 10, endOffset: 27 },
+      },
+    ])
+  })
+
+  it('runs the ingest safety net once per session, not per query', async () => {
+    const ensureFn = vi.fn(async () => {})
+    const searchFn = vi.fn(async () => [])
+    const b = createRedisBackend('s1', { searchFn, ensureFn })
+    await b.search({ text: 'a' }, { k: 5 })
+    await b.search({ text: 'b' }, { k: 5 })
+    await b.search({ text: 'c' }, { k: 5 })
+    expect(ensureFn).toHaveBeenCalledTimes(1)
+    expect(ensureFn).toHaveBeenCalledWith('s1')
+    expect(searchFn).toHaveBeenCalledTimes(3)
+  })
+
+  it('skips the safety net entirely when ensureIngested is false', async () => {
+    const ensureFn = vi.fn(async () => {})
+    const b = createRedisBackend('s1', { searchFn: vi.fn(async () => []), ensureFn, ensureIngested: false })
+    await b.search({ text: 'a' }, { k: 5 })
+    expect(ensureFn).not.toHaveBeenCalled()
+  })
+
+  it('still searches when the safety net throws (best-effort)', async () => {
+    const ensureFn = vi.fn(async () => {
+      throw new Error('embedder offline')
+    })
+    const searchFn = vi.fn(async () => SAMPLE)
+    const b = createRedisBackend('s1', { searchFn, ensureFn })
+    const hits = await b.search({ text: 'q' }, { k: 5 })
+    expect(hits).toHaveLength(1)
+    expect(searchFn).toHaveBeenCalledTimes(1)
+    // A failed ensure isn't retried on the next query (marked done up-front).
+    await b.search({ text: 'q2' }, { k: 5 })
+    expect(ensureFn).toHaveBeenCalledTimes(1)
+  })
+})

--- a/ui/src/lib/document-ingest.server.ts
+++ b/ui/src/lib/document-ingest.server.ts
@@ -28,7 +28,14 @@
 
 import { assertServerOnImport } from './harness-patterns/assert.server'
 import { callTool as defaultCallTool } from './harness-patterns/mcp-client.server'
-import { DEFAULT_TTL_SECONDS, type CallTool, type StashDocument } from './document-store.server'
+import {
+  DEFAULT_TTL_SECONDS,
+  getDocument,
+  listDocuments,
+  setDocumentFlags,
+  type CallTool,
+  type StashDocument,
+} from './document-store.server'
 import { chunkDocument, type Chunk, type ChunkConfig } from './chunking.server'
 import {
   embed as defaultEmbed,
@@ -211,6 +218,67 @@ export async function ingestDocument(
     space,
     indexName,
     prefix,
+  }
+}
+
+// ============================================================================
+// Status-tracked ingest (harness-aware Data Stash)
+// ============================================================================
+
+/**
+ * Fetch a stored document and ingest it, recording the outcome as the doc's
+ * {@link StashDocument.ingestStatus}. The status-aware wrapper around
+ * {@link ingestDocument} used by the auto-ingest-on-upload gate and the
+ * retriever's lazy safety net:
+ *
+ *  - missing doc            → `null` (nothing to do)
+ *  - `base64` binary        → status `'failed'` (the text pipeline can't chunk
+ *                             binary; mark it so we don't retry forever)
+ *  - ingest throws          → status `'failed'`, returns `null`
+ *  - ingest ok              → status `'indexed'`, returns the {@link IngestResult}
+ *
+ * Best-effort by contract: it never throws (failures live in the status field),
+ * so callers on the upload hot path don't need their own try/catch.
+ */
+export async function ingestStashDocument(
+  sessionId: string,
+  docId: string,
+  opts: IngestOptions = {},
+): Promise<IngestResult | null> {
+  const callTool = opts.callTool ?? defaultCallTool
+  const doc = await getDocument(sessionId, docId, callTool)
+  if (!doc) return null
+  if (doc.encoding === 'base64') {
+    await setDocumentFlags(sessionId, docId, { ingestStatus: 'failed' }, callTool)
+    return null
+  }
+  try {
+    const result = await ingestDocument(doc, opts)
+    await setDocumentFlags(sessionId, docId, { ingestStatus: 'indexed' }, callTool)
+    return result
+  } catch {
+    await setDocumentFlags(sessionId, docId, { ingestStatus: 'failed' }, callTool)
+    return null
+  }
+}
+
+/**
+ * Idempotently ingest every not-yet-indexed document in a session. The
+ * retriever's safety net: an upload that happened before the agent was known
+ * (so the upload-time gate couldn't fire) still becomes searchable on first
+ * retrieval. Skips docs already `'indexed'` or `'failed'` (terminal) and binary
+ * uploads, so a fully-indexed corpus costs just one `listDocuments`.
+ */
+export async function ensureSessionIngested(
+  sessionId: string,
+  opts: IngestOptions = {},
+): Promise<void> {
+  const callTool = opts.callTool ?? defaultCallTool
+  const metas = await listDocuments(sessionId, callTool)
+  for (const m of metas) {
+    if (m.ingestStatus === 'indexed' || m.ingestStatus === 'failed') continue
+    if (m.encoding === 'base64') continue
+    await ingestStashDocument(sessionId, m.id, opts)
   }
 }
 

--- a/ui/src/lib/document-store.server.ts
+++ b/ui/src/lib/document-store.server.ts
@@ -64,7 +64,16 @@ export interface StashDocumentMeta {
    * byte-faithful storage, which the text-only upload path could not provide.
    */
   encoding?: 'utf8' | 'base64'
+  /**
+   * Vector-ingestion status (chunk→embed→index into the local Data Stash vector
+   * store). Set by the harness-aware auto-ingest path: `'pending'` queued/in
+   * progress, `'indexed'` searchable, `'failed'` ingest errored (e.g. embedder
+   * offline). Absent → never ingested (no redis-retriever in the harness).
+   */
+  ingestStatus?: IngestStatus
 }
+
+export type IngestStatus = 'pending' | 'indexed' | 'failed'
 
 /** A stored document: metadata + its (already text-extracted) content. */
 export interface StashDocument extends StashDocumentMeta {
@@ -386,7 +395,7 @@ export async function listDocuments(
 export async function setDocumentFlags(
   sessionId: string,
   docId: string,
-  patch: { hidden?: boolean; archived?: boolean },
+  patch: { hidden?: boolean; archived?: boolean; ingestStatus?: IngestStatus },
   callTool: CallTool = defaultCallTool,
 ): Promise<StashDocument | null> {
   const doc = await getDocument(sessionId, docId, callTool)
@@ -394,6 +403,7 @@ export async function setDocumentFlags(
 
   if (patch.hidden !== undefined) doc.hidden = patch.hidden
   if (patch.archived !== undefined) doc.archived = patch.archived
+  if (patch.ingestStatus !== undefined) doc.ingestStatus = patch.ingestStatus
 
   // Rewriting via json_set at `$` would clear any existing expiry, so we
   // re-apply a TTL. There is no `ttl` tool on the Redis MCP surface to read the

--- a/ui/src/lib/harness-client/examples/retriever-agent.server.ts
+++ b/ui/src/lib/harness-client/examples/retriever-agent.server.ts
@@ -1,0 +1,135 @@
+/**
+ * Retriever Agent
+ *
+ * Router-based agent that adds a fast, low-latency **retriever** route alongside
+ * the Neo4j and Web Search loops of the default agent. The retriever does ONE
+ * embedding + KNN over the session's ingested Data Stash uploads — seconds, not
+ * the 30s+ a Neo4j `simpleLoop` can take — and hands matches-with-references to
+ * the synthesizer.
+ *
+ * Harness-aware Data Stash: because this agent composes a `retriever` wired to
+ * the **redis** (local-vector) backend, uploads to its sessions auto-ingest into
+ * the local vector store (see `routes/api/stash/upload.ts` →
+ * `harnessHasRedisRetriever`). An agent WITHOUT a redis retriever never triggers
+ * ingest — the upload is just stored.
+ *
+ * Composition:
+ *   router({ retriever | neo4j | web_search })
+ *     → routes({
+ *         retriever:  chain(compactIntent(), retriever({ backends:[redis] })),
+ *         neo4j:      simpleLoop(neo4j),
+ *         web_search: simpleLoop(web),
+ *       })
+ *     → synthesizer('thread')
+ *
+ * `chain(compactIntent(), retriever())` rephrases the conversation into a clean
+ * search query (one cheap Haiku/Sonnet call) before the vector search — reusing
+ * the existing `compactIntent` pattern rather than a bespoke query step.
+ *
+ * The Supabase backend (company pgvector via the Supabase MCP) is a deferred
+ * stub; add `createSupabaseBackend()` to `backends` once IT provides access.
+ */
+"use server";
+
+import {
+  router,
+  routes,
+  chain,
+  simpleLoop,
+  compactIntent,
+  retriever,
+  synthesizer,
+  withReferences,
+  Tools,
+  callTool,
+  createNeo4jController,
+  createWebSearchController,
+  type ConfiguredPattern,
+} from "../../harness-patterns";
+import type { SessionData } from "../session.server";
+import type { AgentConfig } from "../registry.server";
+import { NEO4J_FEW_SHOTS_DEFAULT } from "./neo4j-fewshots.server";
+import { enrichNeo4jResult } from "../neo4j-enricher.server";
+import { createRedisBackend } from "../../retriever";
+
+async function getSchema(): Promise<string> {
+  const result = await callTool("get_neo4j_schema", {});
+  return result.success ? JSON.stringify(result.data) : "";
+}
+
+async function createPatterns(sessionId: string): Promise<ConfiguredPattern<SessionData>[]> {
+  const tools = await Tools();
+  const schema = await getSchema();
+
+  // ── retriever route: rephrase → vector search over this session's uploads ──
+  const redisBackend = createRedisBackend(sessionId);
+  const retrieverPattern = chain<SessionData>(
+    compactIntent<SessionData>({ patternId: "retriever-intent", liveEvents: true }),
+    retriever<SessionData>({
+      patternId: "retriever",
+      backends: [redisBackend],
+      k: 5,
+      liveEvents: true,
+    }),
+  );
+
+  // ── neo4j + web routes: identical to the default agent ──
+  const neo4jController = createNeo4jController(tools.neo4j ?? []);
+  const webTools = tools.web ?? [];
+  const webController = createWebSearchController(webTools);
+
+  const neo4jPattern = simpleLoop<SessionData>(neo4jController, tools.neo4j ?? [], {
+    patternId: "neo4j-query",
+    schema,
+    liveEvents: true,
+    rememberPriorTurns: false,
+    fewShots: NEO4J_FEW_SHOTS_DEFAULT,
+    onToolResult: enrichNeo4jResult,
+  });
+
+  const webPattern = simpleLoop<SessionData>(webController, webTools, {
+    patternId: "web-search",
+    liveEvents: true,
+    rememberPriorTurns: false,
+  });
+
+  const routerPattern = router<SessionData>(
+    {
+      retriever:
+        "Answer from the user's uploaded documents (the Data Stash) — fast semantic search over ingested files",
+      neo4j: "Database queries and graph operations",
+      web_search: "Web lookups and information retrieval",
+    },
+    { liveEvents: true },
+  );
+
+  const routesPattern = routes<SessionData>(
+    {
+      // The retriever does its own context-scoped search, so it isn't wrapped
+      // in `withReferences` (which injects prior tool_results) — unlike the
+      // neo4j / web loops, which benefit from cross-turn reference curation.
+      retriever: retrieverPattern,
+      neo4j: withReferences<SessionData>(neo4jPattern, { scope: "global", liveEvents: true }),
+      web_search: withReferences<SessionData>(webPattern, { scope: "global", liveEvents: true }),
+    },
+    { liveEvents: true },
+  );
+
+  const responseSynth = synthesizer<SessionData>({
+    mode: "thread",
+    patternId: "response-synth",
+    liveEvents: true,
+  });
+
+  return [routerPattern, routesPattern, responseSynth];
+}
+
+export const retrieverAgent: AgentConfig = {
+  id: "retriever",
+  name: "Retriever Agent",
+  description:
+    "Fast semantic retrieval over uploaded documents (Data Stash), with Neo4j and Web Search routes",
+  icon: "🔎",
+  servers: ["neo4j-cypher", "web_search", "fetch"],
+  createPatterns,
+};

--- a/ui/src/lib/harness-client/registry.server.ts
+++ b/ui/src/lib/harness-client/registry.server.ts
@@ -131,6 +131,7 @@ import { multiSourceResearchAgent } from "./examples/multi-source-research.serve
 import { kgBuilderAgent } from "./examples/kg-builder.server";
 import { conversationalMemoryAgent } from "./examples/conversational-memory.server";
 import { sandboxSessionAgent } from "./examples/sandbox-session.server";
+import { retrieverAgent } from "./examples/retriever-agent.server";
 
 // Register all agents
 registerAgent(defaultAgent);
@@ -139,3 +140,4 @@ registerAgent(multiSourceResearchAgent);
 registerAgent(kgBuilderAgent);
 registerAgent(conversationalMemoryAgent);
 registerAgent(sandboxSessionAgent);
+registerAgent(retrieverAgent);

--- a/ui/src/lib/harness-client/session.server.ts
+++ b/ui/src/lib/harness-client/session.server.ts
@@ -12,7 +12,7 @@
  */
 
 import { assertServerOnImport } from '../harness-patterns/assert.server'
-import type { ConfiguredPattern, WithApproval } from '../harness-patterns'
+import type { ConfiguredPattern, WithApproval, RetrieverData } from '../harness-patterns'
 import type { HarnessData } from '../harness-patterns/harness.server'
 import type { RouterData } from '../harness-patterns/patterns/router.server'
 import type { SimpleLoopData } from '../harness-patterns/patterns'
@@ -32,7 +32,12 @@ assertServerOnImport()
 // Types
 // ============================================================================
 
-export interface SessionData extends HarnessData, RouterData, SimpleLoopData, WithApproval {
+export interface SessionData
+  extends HarnessData,
+    RouterData,
+    SimpleLoopData,
+    RetrieverData,
+    WithApproval {
   response?: string
   /** User-curated allowlist for the code-mode actor's tool selection.
    *  Undefined → fall back to the agent's hardcoded CODE_MODE_TOOLS. Set

--- a/ui/src/lib/harness-patterns/README.md
+++ b/ui/src/lib/harness-patterns/README.md
@@ -37,6 +37,7 @@ Functional, composable framework for agentic tool execution.
   - [withReferences()](#withreferencespattern-config)
   - [synthesizer()](#synthesizerconfig)
   - [compactIntent()](#compactintentconfig)
+  - [retriever()](#retrieverconfig)
   - [router()](#routerroutedescriptions-config)
   - [routes()](#routespatternmap-config)
   - [chain()](#chainctx-patterns)
@@ -537,6 +538,52 @@ type CompactIntentConfig = PatternConfig
 > Agents that already route don't need it — `router` fills `data.intent` itself.
 > Part E of [#83](https://github.com/mknw/harness-playground/issues/83) (the
 > `compact*` naming unification) is a deferred follow-up.
+
+### `retriever(config)`
+
+A low-latency alternative to a tool-calling `simpleLoop`: instead of an LLM loop
+deciding which DB tool to call (often >30s for a Neo4j loop), the retriever forms
+ONE query from context and fans it out to one or more injected **backends**,
+returning normalized matches-with-references for a downstream `synthesizer`.
+
+```typescript
+chain(
+  compactIntent(),                                   // rephrase → scope.data.intent
+  retriever({ backends: [redisBackend], k: 5 }),     // embed + KNN, no LLM loop
+)
+
+interface RetrieverConfig extends PatternConfig {
+  backends: RetrieverBackend[]   // injected DB sources (app-side)
+  k?: number                     // max hits, default 5
+  turnWindow?: number            // widen the query to the last N user turns
+}
+interface RetrieverBackend {
+  name: string
+  type: 'vector' | 'keyword' | 'graph' | 'web'   // only 'vector' backends embed
+  search(q: { text: string; intent?: string }, opts: { k: number }): Promise<RetrievalHit[]>
+}
+```
+
+**How it works:**
+1. **Query**: prefers the upstream compacted `scope.data.intent`; falls back to
+   the last `user_message`, or the last `turnWindow` user turns joined.
+2. **Fan-out**: `Promise.all` over the backends. A failing backend yields `[]`
+   plus an `error` event (per-backend isolation) — one bad source never sinks
+   the retrieval.
+3. **Merge**: flatten, sort closest-first (`score` ascending; un-scored last),
+   cap at `k`. Writes `scope.data.matches` and emits a `tool_result`
+   (`tool: 'retriever'`) — the same channel `synthesizer` reads via
+   `view.fromLastPattern()`.
+
+Framework-pure: concrete backends live app-side (`ui/src/lib/retriever/` —
+`createRedisBackend` is live; `createSupabaseBackend` is a deferred stub). The
+resolved config carries a `backendKinds: string[]` marker so
+`harnessHasRedisRetriever` (pattern-capabilities) can gate the Data Stash's
+auto-ingest-on-upload. **Best-effort / `recoverable`**: on total failure it
+leaves `matches` empty and the synthesizer answers from the rest of context.
+
+> See [`docs/DATA_STASH.md → Harness-aware ingest`](../../../../docs/DATA_STASH.md)
+> for the upload-side gate and the `redis` / `supabase` backends.
 
 ### `router(routeDescriptions, config?)`
 

--- a/ui/src/lib/harness-patterns/index.ts
+++ b/ui/src/lib/harness-patterns/index.ts
@@ -108,7 +108,13 @@ export { DIRECT_RESPONSE_ROUTE } from './types'
 // Pattern capabilities (static introspection)
 // ============================================================================
 
-export { usesCodeMode, isCodeModeLoopConfig } from './pattern-capabilities'
+export {
+  usesCodeMode,
+  isCodeModeLoopConfig,
+  isRetrieverConfig,
+  harnessHasRetriever,
+  harnessHasRedisRetriever,
+} from './pattern-capabilities'
 
 // ============================================================================
 // Harness
@@ -136,6 +142,7 @@ export {
   runChain,
   synthesizer,
   compactIntent,
+  retriever,
   configurePattern,
   parallel,
   judge,
@@ -148,6 +155,10 @@ export {
   type ActorCriticData,
   type CompactIntentConfig,
   type CompactIntentData,
+  type RetrieverBackend,
+  type RetrieverConfig,
+  type RetrieverData,
+  type RetrievalHit,
   type ApprovalPredicate,
   type WithApprovalData,
   type JudgeConfig,

--- a/ui/src/lib/harness-patterns/pattern-capabilities.ts
+++ b/ui/src/lib/harness-patterns/pattern-capabilities.ts
@@ -60,3 +60,35 @@ function patternUsesCodeMode<T>(pattern: ConfiguredPattern<T>): boolean {
   if (isCodeModeLoopConfig(pattern.config)) return true
   return usesCodeMode(pattern.children)
 }
+
+/** True when a pattern's resolved config is a `retriever` (it stamps
+ *  `patternId: 'retriever'`). */
+export function isRetrieverConfig(config: PatternConfig): boolean {
+  return config.patternId === 'retriever'
+}
+
+/** True when a retriever config is wired to the redis/local-vector backend —
+ *  the `retriever` stamps `backendKinds: string[]` (backend names) onto its
+ *  resolved config; `'redis'` means the local Data Stash vector path. */
+function isRedisRetrieverConfig(config: PatternConfig): boolean {
+  if (!isRetrieverConfig(config)) return false
+  const kinds = (config as PatternConfig & { backendKinds?: string[] }).backendKinds
+  return Array.isArray(kinds) && kinds.includes('redis')
+}
+
+/** True when any pattern in the (nested) graph is a `retriever`. */
+export function harnessHasRetriever<T>(patterns: ConfiguredPattern<T>[] | undefined): boolean {
+  if (!patterns || patterns.length === 0) return false
+  return patterns.some((p) => isRetrieverConfig(p.config) || harnessHasRetriever(p.children))
+}
+
+/**
+ * True when the harness contains a `retriever` wired to the redis/local-vector
+ * backend — the gate for auto-ingesting uploaded docs into the local vector
+ * store (a Supabase-only retriever reads from Supabase, so it doesn't trigger
+ * local ingest).
+ */
+export function harnessHasRedisRetriever<T>(patterns: ConfiguredPattern<T>[] | undefined): boolean {
+  if (!patterns || patterns.length === 0) return false
+  return patterns.some((p) => isRedisRetrieverConfig(p.config) || harnessHasRedisRetriever(p.children))
+}

--- a/ui/src/lib/harness-patterns/patterns/index.ts
+++ b/ui/src/lib/harness-patterns/patterns/index.ts
@@ -10,6 +10,13 @@ export { withApproval, approvalPredicates, type ApprovalPredicate, type WithAppr
 export { chain, runChain, configurePattern } from './chain.server'
 export { synthesizer } from './synthesizer.server'
 export { compactIntent, type CompactIntentConfig, type CompactIntentData } from './compactIntent.server'
+export {
+  retriever,
+  type RetrieverBackend,
+  type RetrieverConfig,
+  type RetrieverData,
+  type RetrievalHit,
+} from './retriever.server'
 export { parallel } from './parallel.server'
 export { judge, type JudgeConfig, type JudgeData, type EvaluatorFn } from './judge.server'
 export { guardrail, piiScanRail, pathAllowlistRail, driftDetectorRail, type Rail, type RailResult, type RailContext, type GuardrailConfig, type CircuitBreakerConfig } from './guardrail.server'

--- a/ui/src/lib/harness-patterns/patterns/retriever.server.ts
+++ b/ui/src/lib/harness-patterns/patterns/retriever.server.ts
@@ -1,0 +1,214 @@
+/**
+ * retriever Pattern
+ *
+ * A low-latency alternative to a tool-calling `simpleLoop`: instead of an LLM
+ * loop deciding which DB tool to call (often >30s for a Neo4j loop), the
+ * retriever forms ONE search query from context and fans it out to one or more
+ * injected DB **backends**, returning normalized matches-with-references (or
+ * none) for a downstream `synthesizer`.
+ *
+ * Typical composition (the query is pre-compacted by `compactIntent`):
+ *
+ *   harness(
+ *     router(),
+ *     routes({
+ *       retriever: chain(compactIntent(), retriever({ backends: [redisBackend] })),
+ *       neo4j: simpleLoop(neo4jController, tools.neo4j),
+ *       web:   simpleLoop(webController, tools.web),
+ *     }),
+ *     synthesizer(),
+ *   )
+ *
+ * Framework-pure: the concrete backends (redis vector, Supabase, …) are app-side
+ * and injected via config, so this file has no app dependencies. Each backend
+ * self-describes its `type` and owns its query transform — a `vector` backend
+ * embeds internally (local) or sends text for server-side embedding (Supabase).
+ *
+ * Query source: the previous pattern's compacted `scope.data.intent` if present,
+ * else the last user message; optionally widened with the last-N user turns.
+ * The matches are written to `scope.data.matches` AND emitted as a `tool_result`
+ * event so the synthesizer consumes them via `view.fromLastPattern()`.
+ */
+
+import { assertServerOnImport } from '../assert.server'
+import type {
+  PatternScope,
+  EventView,
+  ConfiguredPattern,
+  PatternConfig,
+  UserMessageEventData,
+  ToolResultEventData,
+  ErrorEventData,
+} from '../types'
+import { trackEvent, resolveConfig } from '../context.server'
+import { getErrorHint } from '../error-hints'
+
+assertServerOnImport()
+
+// ============================================================================
+// Public contract — the backend interface + result shape
+// ============================================================================
+
+/** A normalized retrieval result. `score` is a distance (lower = closer) when
+ *  the backend reports one; cross-backend comparability is best-effort. */
+export interface RetrievalHit {
+  /** Which backend produced this hit (e.g. 'redis', 'supabase'). */
+  backend: string
+  /** Stable id/reference for the match within its backend. */
+  id: string
+  /** The matched text. */
+  content: string
+  /** Optional human-facing source label (filename, table, url, …). */
+  source?: string
+  /** Distance (lower = closer) when available. */
+  score?: number
+  metadata?: Record<string, unknown>
+}
+
+/**
+ * A retrieval backend. The retriever fans the query out to each. Backends own
+ * their query transform: `vector` backends embed (locally or server-side),
+ * others (future: keyword/web/graph) use the text directly.
+ */
+export interface RetrieverBackend {
+  name: string
+  type: 'vector' | 'keyword' | 'graph' | 'web'
+  search(
+    query: { text: string; intent?: string },
+    opts: { k: number },
+  ): Promise<RetrievalHit[]>
+}
+
+export interface RetrieverConfig extends PatternConfig {
+  /** DB backends to query (injected by the agent at construction). */
+  backends: RetrieverBackend[]
+  /** Max hits to return (per backend cap + final cap). Default 5. */
+  k?: number
+  /** When there's no compacted intent, build the query from the last N user
+   *  turns instead of just the last message. Default: last message only. */
+  turnWindow?: number
+}
+
+export interface RetrieverData {
+  /** Set by an upstream `compactIntent`/`router`; preferred query source. */
+  intent?: string
+  /** Output: the normalized matches (also emitted as a tool_result). */
+  matches?: RetrievalHit[]
+}
+
+/** Marker the resolved config carries so `pattern-capabilities` can answer
+ *  "does this harness contain a retriever wired to backend X" without running
+ *  it (mirrors the code-mode `dynamicToolPattern` probe). */
+export interface RetrieverConfigMarker extends PatternConfig {
+  backendKinds?: string[]
+}
+
+// ============================================================================
+// Pattern
+// ============================================================================
+
+export function retriever<T extends RetrieverData>(
+  config: RetrieverConfig,
+): ConfiguredPattern<T> {
+  const { backends = [], k = 5, turnWindow, ...patternConfig } = config
+  const backendKinds = backends.map((b) => b.name)
+
+  const resolved = resolveConfig('retriever', { patternId: 'retriever', ...patternConfig })
+  // Stamp the backend kinds onto the resolved config for static introspection.
+  ;(resolved as RetrieverConfigMarker).backendKinds = backendKinds
+
+  const fn = async (scope: PatternScope<T>, view: EventView): Promise<PatternScope<T>> => {
+    try {
+      const intent = (scope.data as RetrieverData).intent
+      const lastUser = view.fromAll().ofType('user_message').last(1).get()[0]
+      const lastText = lastUser ? (lastUser.data as UserMessageEventData).content : ''
+
+      let text = intent ?? ''
+      if (!text) {
+        if (turnWindow && turnWindow > 0) {
+          const recent = view
+            .fromLastNTurns(turnWindow)
+            .ofType('user_message')
+            .get()
+            .map((e) => (e.data as UserMessageEventData).content)
+            .filter(Boolean)
+          text = (recent.length ? recent.join('\n') : lastText).trim()
+        } else {
+          text = lastText
+        }
+      }
+
+      if (!text || backends.length === 0) {
+        scope.data = { ...scope.data, matches: [] }
+        emitMatches(scope, [], backendKinds, text, resolved.trackHistory)
+        return scope
+      }
+
+      // Fan out to all backends concurrently; a failing backend yields [] and an
+      // error event rather than sinking the whole retrieval.
+      const perBackend = await Promise.all(
+        backends.map(async (b) => {
+          try {
+            return await b.search({ text, intent }, { k })
+          } catch (err) {
+            trackEvent(
+              scope,
+              'error',
+              {
+                error: `retriever backend "${b.name}": ${err instanceof Error ? err.message : String(err)}`,
+                severity: resolved.errorSeverity,
+              } as ErrorEventData,
+              true,
+            )
+            return [] as RetrievalHit[]
+          }
+        }),
+      )
+
+      // Merge, closest-first (hits without a score sort last), capped at k.
+      const matches = perBackend
+        .flat()
+        .sort((a, b) => (a.score ?? Infinity) - (b.score ?? Infinity))
+        .slice(0, k)
+
+      scope.data = { ...scope.data, matches }
+      emitMatches(scope, matches, backendKinds, text, resolved.trackHistory)
+      return scope
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error)
+      trackEvent(
+        scope,
+        'error',
+        { error: msg, severity: resolved.errorSeverity, hint: getErrorHint(msg) } as ErrorEventData,
+        true,
+      )
+      return scope
+    }
+  }
+
+  return { name: 'retriever', fn, config: resolved, estimateTurns: () => 0 }
+}
+
+/** Emit the retrieval as a `tool_result` so the synthesizer reads it via
+ *  `view.fromLastPattern()` (same channel a simpleLoop tool call uses). */
+function emitMatches<T>(
+  scope: PatternScope<T>,
+  matches: RetrievalHit[],
+  backendKinds: string[],
+  query: string,
+  trackHistory: Parameters<typeof trackEvent>[3],
+): void {
+  trackEvent(
+    scope,
+    'tool_result',
+    {
+      tool: 'retriever',
+      result: { matches, backends: backendKinds, query },
+      success: true,
+      summary: matches.length
+        ? `${matches.length} match(es) from ${backendKinds.join(', ') || 'no backends'}`
+        : 'no matches',
+    } as ToolResultEventData,
+    trackHistory,
+  )
+}

--- a/ui/src/lib/harness-patterns/types.ts
+++ b/ui/src/lib/harness-patterns/types.ts
@@ -687,7 +687,10 @@ export const DEFAULT_TRACK_HISTORY: Record<string, TrackHistory> = {
   routes: false,
   chain: false,
   withApproval: true,
-  compactIntent: 'intent_compacted'
+  compactIntent: 'intent_compacted',
+  // The retriever's matches are surfaced as a tool_result (the channel the
+  // synthesizer reads via view.fromLastPattern()) — same as a simpleLoop tool.
+  retriever: ['tool_result']
 }
 
 /** Default commitStrategy by pattern type */
@@ -699,7 +702,8 @@ export const DEFAULT_COMMIT_STRATEGY: Record<string, CommitStrategy> = {
   routes: 'always',
   chain: 'always',
   withApproval: 'on-success',
-  compactIntent: 'always'
+  compactIntent: 'always',
+  retriever: 'always'
 }
 
 /** Default errorSeverity by pattern type.
@@ -716,4 +720,7 @@ export const DEFAULT_ERROR_SEVERITY: Record<string, 'recoverable' | 'irrecoverab
   // compactIntent is best-effort: on failure it leaves intent unset and the
   // downstream actor falls back to the raw user message — never fatal.
   compactIntent: 'recoverable',
+  // retriever is best-effort: a backend failure yields empty matches and the
+  // synthesizer answers from whatever else is in context — never fatal.
+  retriever: 'recoverable',
 }

--- a/ui/src/lib/retriever/index.ts
+++ b/ui/src/lib/retriever/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Retriever backends — app-level wiring for the framework-pure `retriever`
+ * pattern (`harness-patterns/patterns/retriever.server.ts`).
+ *
+ * The pattern defines the {@link RetrieverBackend} contract; these factories are
+ * the concrete data sources an agent plugs into `retriever({ backends })`:
+ *   - {@link createRedisBackend}    — local Data Stash (RediSearch KNN over a
+ *     session's ingested uploads). Live.
+ *   - {@link createSupabaseBackend} — company pgvector corpus via the Supabase
+ *     MCP (text-in, server-side embed). Deferred stub (pending IT access).
+ *
+ * Server-only: both re-exported modules call `assertServerOnImport()`.
+ */
+export { createRedisBackend } from './redis-backend.server'
+export {
+  createSupabaseBackend,
+  type SupabaseBackendConfig,
+} from './supabase-backend.server'

--- a/ui/src/lib/retriever/redis-backend.server.ts
+++ b/ui/src/lib/retriever/redis-backend.server.ts
@@ -1,0 +1,67 @@
+/**
+ * Redis vector RetrieverBackend — Server Only
+ *
+ * The local-uploads retrieval path: wraps `searchDocuments` (the Data Stash
+ * RediSearch KNN over a session's ingested document chunks). Embeds the query
+ * locally (the corpus's recorded model, e.g. Qwen3 1024-d) and returns
+ * normalized {@link RetrievalHit}s.
+ *
+ * On its first search per session it runs `ensureSessionIngested` — the safety
+ * net for docs uploaded before the agent was known (so the upload-time gate
+ * couldn't fire). It's idempotent and memoized per instance, so a fully-indexed
+ * corpus pays just one `listDocuments` once per session, not per query.
+ *
+ * `sessionId` scopes the corpus. `searchFn`/`ensureFn` are injectable and
+ * `ensureIngested:false` disables the net — both for tests.
+ */
+
+import { assertServerOnImport } from '../harness-patterns/assert.server'
+import type { RetrieverBackend, RetrievalHit } from '../harness-patterns'
+import { searchDocuments, ensureSessionIngested } from '../document-ingest.server'
+
+assertServerOnImport()
+
+export function createRedisBackend(
+  sessionId: string,
+  opts: {
+    searchFn?: typeof searchDocuments
+    ensureFn?: typeof ensureSessionIngested
+    ensureIngested?: boolean
+  } = {},
+): RetrieverBackend {
+  const searchFn = opts.searchFn ?? searchDocuments
+  const ensureFn = opts.ensureFn ?? ensureSessionIngested
+  const ensureIngested = opts.ensureIngested !== false
+  let ensured = false
+  return {
+    name: 'redis',
+    type: 'vector',
+    async search({ text }, { k }): Promise<RetrievalHit[]> {
+      if (ensureIngested && !ensured) {
+        // Mark before awaiting so racing searches don't double-ensure; a
+        // transient failure won't be retried this session (the upload gate is
+        // the primary path — this is only a net).
+        ensured = true
+        try {
+          await ensureFn(sessionId)
+        } catch {
+          /* best-effort */
+        }
+      }
+      const hits = await searchFn(sessionId, text, { k })
+      return hits.map((h) => ({
+        backend: 'redis',
+        id: `${h.docId}:${h.chunkIndex}`,
+        content: h.content,
+        source: h.source,
+        score: h.score,
+        metadata: {
+          docId: h.docId,
+          chunkIndex: h.chunkIndex,
+          startOffset: h.startOffset,
+          endOffset: h.endOffset,
+        },
+      }))
+    },
+  }
+}

--- a/ui/src/lib/retriever/supabase-backend.server.ts
+++ b/ui/src/lib/retriever/supabase-backend.server.ts
@@ -1,0 +1,46 @@
+/**
+ * Supabase vector RetrieverBackend — Server Only — DEFERRED
+ *
+ * The company corpus lives in Supabase (Postgres/pgvector) and embeds
+ * **server-side** (Automatic Embeddings / Edge Functions), so this backend is
+ * **text-in**: it sends the query text and lets Supabase embed + match — no
+ * client-side embedding.
+ *
+ * Channel: the **Supabase MCP server** (run a match RPC / `... order by
+ * embedding <=> ...` SQL via `callTool`). To finish it when IT provides access:
+ *   1. Add the Supabase MCP to `configs/custom-catalog.yaml`
+ *      (`@supabase/mcp-server-supabase`; env `SUPABASE_URL`,
+ *      `SUPABASE_SERVICE_ROLE_KEY`, `SUPABASE_SCHEMA`).
+ *   2. Implement `search()` to `callTool(<supabase match tool>, { query: text, k })`
+ *      and map rows → RetrievalHit (n8n already uses this Supabase, so a match
+ *      surface likely exists).
+ *
+ * Until then `search()` throws; the retriever's per-backend guard turns that into
+ * an error event + empty results, so a misconfigured backend never sinks a run.
+ */
+
+import { assertServerOnImport } from '../harness-patterns/assert.server'
+import type { RetrieverBackend, RetrievalHit } from '../harness-patterns'
+
+assertServerOnImport()
+
+export interface SupabaseBackendConfig {
+  /** The Supabase MCP tool/RPC name that performs a text→match search. */
+  matchTool?: string
+  /** Target table/relation, if the match tool needs it. */
+  table?: string
+}
+
+export function createSupabaseBackend(_config: SupabaseBackendConfig = {}): RetrieverBackend {
+  return {
+    name: 'supabase',
+    type: 'vector',
+    async search(): Promise<RetrievalHit[]> {
+      throw new Error(
+        'Supabase retriever backend not yet implemented (pending IT access). ' +
+          'Wire the Supabase MCP (SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY) + a ' +
+          'text→match RPC, then implement search() via callTool.',
+      )
+    },
+  }
+}

--- a/ui/src/lib/sandbox/with-sandbox.server.ts
+++ b/ui/src/lib/sandbox/with-sandbox.server.ts
@@ -199,6 +199,9 @@ export function withSandbox(config?: WithSandboxConfig) {
       ...pattern,
       name: `withSandbox(${pattern.name})`,
       fn,
+      // Expose the wrapped pattern so static introspection (pattern-capabilities)
+      // can see patterns nested inside a sandbox wrapper.
+      children: [pattern],
     }
   }
 }

--- a/ui/src/routes/api/stash/upload.ts
+++ b/ui/src/routes/api/stash/upload.ts
@@ -13,12 +13,20 @@ import type { APIEvent } from '@solidjs/start/server'
 import {
   storeDocument,
   listDocuments,
+  setDocumentFlags,
+  type IngestStatus,
 } from '../../../lib/document-store.server'
+import { ingestStashDocument } from '../../../lib/document-ingest.server'
+import {
+  getOrBuildPatterns,
+  loadSession,
+} from '../../../lib/harness-client/session.server'
+import { harnessHasRedisRetriever } from '../../../lib/harness-patterns'
 import { parseUploadRequest } from '../../../lib/stash/upload-service.server'
 import { json, withUser } from '../../../lib/stash/http.server'
 
 export async function POST(event: APIEvent) {
-  return withUser(async () => {
+  return withUser(async (userId) => {
     let input
     try {
       input = await parseUploadRequest(event.request)
@@ -32,10 +40,21 @@ export async function POST(event: APIEvent) {
 
     try {
       const doc = await storeDocument(input)
+      // Harness-aware Data Stash: if this session's agent composes a retriever
+      // wired to the local redis vector store, make the upload searchable.
+      // Best-effort and decoupled from upload success — a failure here never
+      // changes the 201.
+      const ingestStatus = await maybeAutoIngest(
+        input.sessionId,
+        userId,
+        doc.id,
+        doc.encoding,
+      )
       // Return metadata only — the client already has the content it uploaded,
       // and full inlining bloats the response.
       const { content: _content, ...meta } = doc
       void _content
+      if (ingestStatus) meta.ingestStatus = ingestStatus
       return json({ ok: true, document: meta }, 201)
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'Upload failed'
@@ -43,6 +62,35 @@ export async function POST(event: APIEvent) {
       return json({ error: msg }, /too large/i.test(msg) ? 413 : 500)
     }
   })
+}
+
+/**
+ * Auto-ingest gate. Returns the ingest status to stamp on the response, or
+ * `undefined` when the upload should not be ingested (binary, no persisted
+ * session, no redis-retriever in the harness, or a resolution failure). Marks
+ * the doc `'pending'` synchronously, then ingests in the background so the
+ * upload returns immediately — embedding a large doc takes seconds. Docs
+ * uploaded before the session is persisted are covered by the retriever's
+ * lazy `ensureSessionIngested` net on first search.
+ */
+async function maybeAutoIngest(
+  sessionId: string,
+  userId: string,
+  docId: string,
+  encoding: 'utf8' | 'base64' | undefined,
+): Promise<IngestStatus | undefined> {
+  if (encoding === 'base64') return undefined // binary: not text-ingestable
+  try {
+    const loaded = await loadSession(sessionId, userId)
+    if (!loaded) return undefined
+    const patterns = await getOrBuildPatterns(sessionId, loaded.agentId)
+    if (!harnessHasRedisRetriever(patterns)) return undefined
+    await setDocumentFlags(sessionId, docId, { ingestStatus: 'pending' })
+    void ingestStashDocument(sessionId, docId).catch(() => {})
+    return 'pending'
+  } catch {
+    return undefined
+  }
 }
 
 export async function GET(event: APIEvent) {


### PR DESCRIPTION
## What

Adds a low-latency **`retriever` harness pattern** and makes the **Data Stash harness-aware**: uploads auto-ingest into the local vector store only when the agent composes a retriever wired to the redis backend.

Two needs, one change:
1. **Fast retrieval.** Pulling knowledge today means a `simpleLoop` (e.g. Neo4j) that often takes >30s. The retriever does **one embed + KNN** and hands matches-with-references to the synthesizer.
2. **Harness-aware Data Stash.** Behaviour keys off composition — sandbox hydrates `/work/in` (already, #89); a redis-wired retriever makes uploads searchable; neither is implied otherwise; both compose.

## The `retriever` pattern (`harness-patterns/patterns/retriever.server.ts`)

Framework-pure. Forms ONE query (compacted `scope.data.intent` → last user message → optional last-N turns), fans it out to injected `RetrieverBackend`s concurrently (**per-backend error isolation**), merges hits closest-first capped at `k`, sets `scope.data.matches`, and emits a `tool_result` the synthesizer reads via `view.fromLastPattern()`. Registered in the default tables (tracks `tool_result`; `recoverable` — a backend failure yields empty matches, never fatal).

```ts
router({ retriever, neo4j, web_search }),
routes({
  retriever: chain(compactIntent(), retriever({ backends: [createRedisBackend(sessionId)], k: 5 })),
  neo4j: simpleLoop(neo4jController, tools.neo4j),
  web_search: simpleLoop(webController, tools.web),
}),
synthesizer({ mode: 'thread' }),
```

## Backends (`ui/src/lib/retriever/`)

`RetrieverBackend { name, type: 'vector'|'keyword'|'graph'|'web', search() }` — `type` distinguishes vector backends (which embed) from future non-vector ones.

- **`redis`** (`createRedisBackend`, **live**) — wraps `searchDocuments` (local Data Stash KNN), embedding the query with the corpus's recorded model.
- **`supabase`** (`createSupabaseBackend`, **deferred stub**) — company pgvector via the **Supabase MCP**; **text-in** (Supabase embeds server-side, so no client-side embedding / no OpenAI provider). `search()` throws until IT provides `SUPABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY`; the per-backend guard turns that into an empty result + error event. Finishing steps are in the file's header + `DATA_STASH.md`.

## Auto-ingest gate

- `harnessHasRetriever` / `harnessHasRedisRetriever` (`pattern-capabilities.ts`) walk `ConfiguredPattern.children`. **`withSandbox` now exposes its child** so introspection sees nested patterns (`withReferences`/`routes`/`chain` already did).
- `POST /api/stash/upload`, after storing, resolves the agent (`loadSession` → `getOrBuildPatterns`); if `harnessHasRedisRetriever`, it marks the doc `ingestStatus: 'pending'` and ingests **in the background** (response returns immediately). Status (`pending`|`indexed`|`failed`) lands on `StashDocument`. Best-effort: never changes the `201`. Base64 binaries are skipped.
- **Safety net:** the redis backend runs `ensureSessionIngested` once per session on first search (idempotent via `ingestStatus`), covering docs uploaded before the agent was known.

## Example agent

`examples/retriever-agent.server.ts` (default agent + a retriever route), registered as **Retriever Agent** 🔎.

## Tests & checks

- **41 new tests**: retriever pattern (query sourcing, fan-out/merge, per-backend error isolation, `tool_result` emission, `backendKinds` stamping), redis backend (mapping, once-per-session ensure), introspection helpers, status-tracked ingest (`indexed`/`failed`/`base64`/idempotent).
- `pnpm exec tsc --noEmit`: **22 errors — all pre-existing** (none in changed files).
- `pnpm test:run`: **810 passing** (63 files).

## Live verification (for the reviewer — needs the local embedder)

Unit-tested throughout; the end-to-end path needs the **amd64 redis** + the **local embedder on :8090** (a separate process — was offline during this work):

```bash
docker compose up -d                                  # amd64 redis-stack (override file)
llama-server --embedding -m models/Qwen3-Embedding-0.6B-Q8_0.gguf --port 8090 --ctx-size 8192
USE_MIXED_CHAINS=… pnpm dev:exposed                   # or plain pnpm dev
```

1. Select **Retriever Agent**, upload a doc from `docs/` → `GET /api/stash/upload?sessionId=…` shows `ingestStatus: indexed`.
2. Ask a question answerable from the upload → fast, relevant matches+refs (one embed, no 30s loop).
3. `docker compose ps` → redis `restarts: 0`.

## Notes / scope

- `ingestStatus` is exposed on the document meta; surfacing it as a **panel chip** is left to the frozen UI-improvement lane (its territory).
- Deferred: Supabase concrete impl (pending IT access); non-vector backends (interface carries `type`); cross-backend score normalization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)