### PR TITLE
feat(sandbox): startup orphan reaper + health-check on attachment reuse (#97)

### DIFF
--- a/docs/sandbox/README.md
+++ b/docs/sandbox/README.md
@@ -81,7 +81,26 @@ not a synthetic `tool_result`. See [`docs/DATA_STASH.md`](../DATA_STASH.md).
 ## Reap leftovers
 
 The harness calls `--rm` so a stop auto-removes, and on graceful shutdown the
-warm pool destroys everything. **Crashes or kill -9 can leave orphans.**
+warm pool destroys everything. **Crashes or kill -9 can leave orphans** — the
+in-memory `AttachmentTable` + `WarmPool` that would have torn the `--rm`
+containers down die with the process, so idle containers keep running and pile
+up against `globalCap`.
+
+**Automatic reap on startup ([#97](https://github.com/mknw/harness-playground/issues/97)
+Gap 1):** the next process clears the previous generation itself. The first
+time the default sandbox singletons are built (`getDefaultBackend` in
+[`with-sandbox.server.ts`](../../ui/src/lib/sandbox/with-sandbox.server.ts)),
+`DockerBackend.reapOrphans()` runs once — fire-and-forget, before any sandbox
+is allocated — and logs `[sandbox] reaped N orphaned container(s) …` when it
+removes anything. So a normal dev-server restart already cleans up after a
+prior crash; you rarely need the manual command below.
+
+> **Caveat:** the auto-reap removes **all** `kg-sandbox=1` containers, including
+> ones a *concurrent* harness process on the same Docker host might own. That's
+> correct for single-process dev (the v0 shape); a multi-process deployment
+> would need to gate it behind a setting / grace window (noted on #97).
+
+Manual reap (same scope, e.g. to clean up without restarting):
 
 ```sh
 # Nuke every sandbox container (running or stopped):

--- a/ui/src/__tests__/lib/sandbox/attachment-table.test.ts
+++ b/ui/src/__tests__/lib/sandbox/attachment-table.test.ts
@@ -64,6 +64,7 @@ function makeBackend(overrides: Partial<ComputeBackend> = {}): ComputeBackend {
     }),
     connectMcp: vi.fn(async (vm: VMHandle) => makeTransport(vm.id)),
     health: vi.fn(async (): Promise<HealthStatus> => ({ state: 'healthy' })),
+    reapOrphans: vi.fn(async () => 0),
     ...overrides,
   }
   return backend
@@ -135,6 +136,77 @@ describe('AttachmentTable.acquire', () => {
     expect(a).not.toBe(b)
     expect(backend.boot).toHaveBeenCalledTimes(2)
     expect(table.size()).toBe(2)
+  })
+})
+
+describe('AttachmentTable.acquire health-check on reuse (#97 Gap 2)', () => {
+  it('health-checks the live entry on reuse and skips reboot when healthy', async () => {
+    const backend = makeBackend()
+    const pool = new WarmPool(backend, { caps: { base: 1 }, idleEvictMs: 60_000 })
+    const table = new AttachmentTable(backend, pool, { idleMs: 60_000 })
+
+    const first = await table.acquire('alpha', 'base', {})
+    const second = await table.acquire('alpha', 'base', {})
+
+    expect(second).toBe(first)
+    expect(first.refCount).toBe(2)
+    // Probed exactly once — only the reuse hit checks; the first (miss) boots.
+    expect(backend.health).toHaveBeenCalledTimes(1)
+    expect(backend.boot).toHaveBeenCalledTimes(1)
+    expect(backend.connectMcp).toHaveBeenCalledTimes(1)
+  })
+
+  it('evicts a dead entry and reboots a fresh attachment under the same id', async () => {
+    const health = vi.fn(async (): Promise<HealthStatus> => ({ state: 'healthy' }))
+    const backend = makeBackend({ health })
+    const pool = new WarmPool(backend, { caps: { base: 2 }, idleEvictMs: 60_000 })
+    const table = new AttachmentTable(backend, pool, { idleMs: 60_000 })
+
+    const first = await table.acquire('alpha', 'base', {})
+    const firstTransport = first.transport as FakeTransport
+    const firstVm = first.vm
+
+    // The container dies out from under us (crash / external `docker rm`).
+    health.mockResolvedValueOnce({ state: 'gone' })
+    const second = await table.acquire('alpha', 'base', {})
+
+    expect(second).not.toBe(first) // a fresh attachment, not the dead one
+    expect(second.id).toBe('alpha') // same id
+    expect(second.refCount).toBe(1)
+    expect(second.isFirstBoot).toBe(true) // re-hydration trigger for syncWorkspace
+    expect(firstTransport.closes).toBe(1) // stale transport torn down
+    expect(backend.destroy).toHaveBeenCalledWith(firstVm) // dead VM force-removed
+    expect(backend.boot).toHaveBeenCalledTimes(2) // rebooted
+    expect(table.has('alpha')).toBe(true)
+    expect(table.size()).toBe(1) // exactly one entry — no leak
+  })
+
+  it('treats an unhealthy (non-running) container as evictable too', async () => {
+    const health = vi.fn(async (): Promise<HealthStatus> => ({ state: 'healthy' }))
+    const backend = makeBackend({ health })
+    const pool = new WarmPool(backend, { caps: { base: 2 }, idleEvictMs: 60_000 })
+    const table = new AttachmentTable(backend, pool, { idleMs: 60_000 })
+
+    const first = await table.acquire('alpha', 'base', {})
+    health.mockResolvedValueOnce({ state: 'unhealthy', detail: 'exited' })
+    const second = await table.acquire('alpha', 'base', {})
+
+    expect(second).not.toBe(first)
+    expect(backend.boot).toHaveBeenCalledTimes(2)
+  })
+
+  it('reboots when the health probe itself throws (defensive)', async () => {
+    const health = vi.fn(async (): Promise<HealthStatus> => ({ state: 'healthy' }))
+    const backend = makeBackend({ health })
+    const pool = new WarmPool(backend, { caps: { base: 2 }, idleEvictMs: 60_000 })
+    const table = new AttachmentTable(backend, pool, { idleMs: 60_000 })
+
+    const first = await table.acquire('alpha', 'base', {})
+    health.mockRejectedValueOnce(new Error('docker daemon gone'))
+    const second = await table.acquire('alpha', 'base', {})
+
+    expect(second).not.toBe(first)
+    expect(backend.boot).toHaveBeenCalledTimes(2)
   })
 })
 

--- a/ui/src/__tests__/lib/sandbox/docker-backend.test.ts
+++ b/ui/src/__tests__/lib/sandbox/docker-backend.test.ts
@@ -348,3 +348,48 @@ describe('DockerBackend.reset', () => {
     await expect(backend.reset(handle)).rejects.toThrow(/boot failed/)
   })
 })
+
+describe('DockerBackend.reapOrphans', () => {
+  it('force-removes every kg-sandbox-labelled container and returns the count', async () => {
+    spawnPlan = (cmd, args) => {
+      if (args[0] === 'ps') return { stdout: 'abc123\ndef456\n', code: 0 }
+      return { stdout: '', code: 0 }
+    }
+    const backend = await makeBackend()
+    const n = await backend.reapOrphans()
+    expect(n).toBe(2)
+
+    // Listing is scoped to the family label so it never touches other containers.
+    const ps = spawnCalls.find((c) => c.args[0] === 'ps')!
+    expect(ps.args).toEqual(['ps', '-aq', '--filter', 'label=kg-sandbox=1'])
+
+    // A single force-remove passes every found id.
+    const rm = spawnCalls.find((c) => c.args[0] === 'rm')!
+    expect(rm.args).toEqual(['rm', '-f', 'abc123', 'def456'])
+  })
+
+  it('returns 0 and skips the remove when nothing is labelled', async () => {
+    spawnPlan = (cmd, args) => (args[0] === 'ps' ? { stdout: '', code: 0 } : { stdout: '', code: 0 })
+    const backend = await makeBackend()
+    expect(await backend.reapOrphans()).toBe(0)
+    expect(spawnCalls.some((c) => c.args[0] === 'rm')).toBe(false)
+  })
+
+  it('returns 0 (no throw) when the docker engine is unavailable', async () => {
+    spawnPlan = (cmd, args) =>
+      args[0] === 'ps' ? { stderr: 'cannot connect to docker daemon', code: 1 } : { stdout: '', code: 0 }
+    const backend = await makeBackend()
+    await expect(backend.reapOrphans()).resolves.toBe(0)
+    expect(spawnCalls.some((c) => c.args[0] === 'rm')).toBe(false)
+  })
+
+  it('still reports the found count when the remove partially fails', async () => {
+    spawnPlan = (cmd, args) => {
+      if (args[0] === 'ps') return { stdout: 'abc123\n', code: 0 }
+      if (args[0] === 'rm') return { stderr: 'No such container', code: 1 }
+      return { stdout: '', code: 0 }
+    }
+    const backend = await makeBackend()
+    await expect(backend.reapOrphans()).resolves.toBe(1)
+  })
+})

--- a/ui/src/__tests__/lib/sandbox/warm-pool.test.ts
+++ b/ui/src/__tests__/lib/sandbox/warm-pool.test.ts
@@ -42,6 +42,7 @@ function makeBackend(overrides: Partial<ComputeBackend> = {}): ComputeBackend {
       throw new Error('not used in warm-pool tests')
     }),
     health: vi.fn(async (_vm: VMHandle): Promise<HealthStatus> => ({ state: 'healthy' })),
+    reapOrphans: vi.fn(async () => 0),
     ...overrides,
   }
   return backend

--- a/ui/src/__tests__/lib/sandbox/with-sandbox.test.ts
+++ b/ui/src/__tests__/lib/sandbox/with-sandbox.test.ts
@@ -6,17 +6,22 @@
  * close + destroy), cleanup discipline on partial failure, and the
  * visibility guarantee that the inner pattern sees the transport via ALS.
  */
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 
 vi.mock('../../../lib/harness-patterns/assert.server', () => ({
   assertServerOnImport: vi.fn(),
 }))
 
-import { withSandbox } from '../../../lib/sandbox/with-sandbox.server'
+import {
+  withSandbox,
+  getDefaultAttachments,
+  __resetSandboxDefaultsForTests,
+} from '../../../lib/sandbox/with-sandbox.server'
 import { getActiveSandbox } from '../../../lib/sandbox/scope.server'
 import { WarmPool } from '../../../lib/sandbox/warm-pool.server'
 import { SandboxScheduler } from '../../../lib/sandbox/scheduler.server'
 import { AttachmentTable } from '../../../lib/sandbox/attachment-table.server'
+import { DockerBackend } from '../../../lib/sandbox/docker-backend.server'
 import type {
   ComputeBackend,
   HealthStatus,
@@ -36,12 +41,13 @@ type Calls = {
   destroy: VMHandle[]
   connectMcp: VMHandle[]
   closes: number
+  reapOrphans: number
 }
 
 function fakeBackend(opts?: {
   connectMcpFails?: boolean
 }): ComputeBackend & { calls: Calls } {
-  const calls: Calls = { boot: [], destroy: [], connectMcp: [], closes: 0 }
+  const calls: Calls = { boot: [], destroy: [], connectMcp: [], closes: 0, reapOrphans: 0 }
   const handle: VMHandle = {
     id: 'sbx-test',
     backend: 'docker',
@@ -81,6 +87,10 @@ function fakeBackend(opts?: {
     },
     async health(): Promise<HealthStatus> {
       return { state: 'healthy' }
+    },
+    async reapOrphans() {
+      calls.reapOrphans += 1
+      return 0
     },
   }
   return backend
@@ -439,5 +449,47 @@ describe('withSandbox id/fresh (step 6)', () => {
 
     await wrap.fn(fakeScope({}), fakeView)
     expect(kit.backend.calls.boot.length).toBe(before) // no extra boot
+  })
+})
+
+describe('withSandbox default-singleton orphan reaper (#97 Gap 1)', () => {
+  // These tests build the process-shared default singletons (everything else in
+  // this file injects backends), so reset module state around each one and stub
+  // the real reaper — it would otherwise shell out to `docker` (not hermetic).
+  afterEach(() => {
+    vi.restoreAllMocks()
+    __resetSandboxDefaultsForTests()
+  })
+
+  it('reaps orphans exactly once when the default singletons are first built', async () => {
+    __resetSandboxDefaultsForTests()
+    const reapSpy = vi.spyOn(DockerBackend.prototype, 'reapOrphans').mockResolvedValue(0)
+
+    // First default-singleton access constructs the shared DockerBackend and
+    // fires the one-shot reaper before anything is allocated.
+    getDefaultAttachments()
+    expect(reapSpy).toHaveBeenCalledTimes(1)
+
+    // Subsequent accesses reuse the singleton — the reaper does not re-fire.
+    getDefaultAttachments()
+    getDefaultAttachments()
+    expect(reapSpy).toHaveBeenCalledTimes(1)
+
+    // Let the fire-and-forget reap settle so the stub isn't torn down mid-flight.
+    await Promise.resolve()
+  })
+
+  it('does not reap on the injected-backend path (tests / non-default)', async () => {
+    __resetSandboxDefaultsForTests()
+    const reapSpy = vi.spyOn(DockerBackend.prototype, 'reapOrphans').mockResolvedValue(0)
+
+    const backend = fakeBackend()
+    const inner = fakePattern(async (scope) => scope)
+    await withSandbox({ backend })(inner).fn(fakeScope({}), fakeView)
+
+    // Neither the default DockerBackend nor the injected backend was reaped —
+    // withSandbox itself never reaps; only the default-singleton builder does.
+    expect(reapSpy).not.toHaveBeenCalled()
+    expect(backend.calls.reapOrphans).toBe(0)
   })
 })

--- a/ui/src/lib/sandbox/attachment-table.server.ts
+++ b/ui/src/lib/sandbox/attachment-table.server.ts
@@ -19,7 +19,14 @@
  */
 
 import { assertServerOnImport } from '../harness-patterns/assert.server'
-import type { ComputeBackend, McpTransport, RootfsId, RuntimeConfig, VMHandle } from './types'
+import type {
+  ComputeBackend,
+  HealthStatus,
+  McpTransport,
+  RootfsId,
+  RuntimeConfig,
+  VMHandle,
+} from './types'
 import type { WarmPool } from './warm-pool.server'
 
 assertServerOnImport()
@@ -66,9 +73,22 @@ export class AttachmentTable {
 
     const existing = this.table.get(id)
     if (existing) {
-      existing.refCount += 1
-      existing.lastUsedAt = Date.now()
-      return existing
+      // Liveness check before reuse (#97 Gap 2). A container can die out from
+      // under us between turns — host crash, external `docker rm`, OOM-kill.
+      // Reusing its dead transport would fail every tool call and wedge the
+      // session until idle-evict. On a non-healthy verdict, tear the stale
+      // entry down and fall through to a fresh boot; the new attachment is
+      // `isFirstBoot=true`, so the `withSandbox` syncWorkspace path re-hydrates
+      // /work transparently (#89). Costs ~1 `docker inspect` per reuse.
+      const health = await this.backend
+        .health(existing.vm)
+        .catch((): HealthStatus => ({ state: 'gone' }))
+      if (health.state === 'healthy') {
+        existing.refCount += 1
+        existing.lastUsedAt = Date.now()
+        return existing
+      }
+      await this.evictStale(existing)
     }
     const pending = this.inFlight.get(id)
     if (pending) {
@@ -109,6 +129,19 @@ export class AttachmentTable {
   release(att: Attachment): void {
     att.refCount = Math.max(0, att.refCount - 1)
     att.lastUsedAt = Date.now()
+  }
+
+  /**
+   * Drop a dead attachment found by the reuse health-check (#97 Gap 2).
+   * Unlike `destroyById`/`release`, this does NOT route through the pool: the
+   * container is already gone/unhealthy, so there is nothing to recycle —
+   * `backend.destroy` (idempotent `docker rm -f`) clears any lingering record.
+   * Removing it from the table lets the caller fall through to a fresh boot.
+   */
+  private async evictStale(att: Attachment): Promise<void> {
+    this.table.delete(att.id)
+    await att.transport.close().catch(() => {})
+    await this.backend.destroy(att.vm).catch(() => {})
   }
 
   /**

--- a/ui/src/lib/sandbox/docker-backend.server.ts
+++ b/ui/src/lib/sandbox/docker-backend.server.ts
@@ -219,6 +219,37 @@ export class DockerBackend implements ComputeBackend {
     return DockerMcpTransport.open(vm.id, containerId(vm))
   }
 
+  /**
+   * Reap every sandbox container on the host (running or stopped). Each is
+   * tagged `kg-sandbox=1` by `runContainer`, so the labelled force-remove is
+   * safe by construction — it never touches non-sandbox containers. Mirrors
+   * the manual recipe in docs/sandbox/README.md → "Reap leftovers".
+   *
+   * Caveat (#97): this removes ALL labelled containers, including any a
+   * *concurrent* harness process on the same Docker host owns. Correct for
+   * single-process dev (the only v0 shape); gate behind a setting / grace
+   * window if multi-process sharing of one host becomes real.
+   */
+  async reapOrphans(): Promise<number> {
+    let listed: string
+    try {
+      listed = await docker(['ps', '-aq', '--filter', 'label=kg-sandbox=1'])
+    } catch {
+      // Docker engine unavailable ⇒ nothing reapable. Not a startup failure.
+      return 0
+    }
+    const ids = listed
+      .split('\n')
+      .map((s) => s.trim())
+      .filter(Boolean)
+    if (ids.length === 0) return 0
+    await docker(['rm', '-f', ...ids]).catch(() => {
+      // Best-effort: a container may have exited/auto-removed between the
+      // `ps` and the `rm`. The id count still reflects what we found.
+    })
+    return ids.length
+  }
+
   async health(vm: VMHandle): Promise<HealthStatus> {
     const cid = containerId(vm)
     try {

--- a/ui/src/lib/sandbox/types.ts
+++ b/ui/src/lib/sandbox/types.ts
@@ -116,6 +116,16 @@ export interface ComputeBackend {
   /** Tunneled connection to the in-VM MCP servers. */
   connectMcp(vm: VMHandle): Promise<McpTransport>
   health(vm: VMHandle): Promise<HealthStatus>
+  /**
+   * Remove sandbox containers orphaned by a *previous* process. A dev-server
+   * crash / kill -9 loses the in-memory AttachmentTable + WarmPool that would
+   * have torn its `--rm` containers down, so they keep running idle and pile
+   * up against `globalCap`. Implementations identify their own containers by a
+   * stable label and force-remove them. Returns the count removed. Called once
+   * at process start, before any sandbox is acquired — see
+   * with-sandbox.server.ts → `reapOrphansOnce` and #97 Gap 1.
+   */
+  reapOrphans(): Promise<number>
 }
 
 // ============================================================================

--- a/ui/src/lib/sandbox/with-sandbox.server.ts
+++ b/ui/src/lib/sandbox/with-sandbox.server.ts
@@ -81,10 +81,41 @@ let defaultBackend: ComputeBackend | null = null
 let defaultPool: WarmPool | null = null
 let defaultScheduler: SandboxScheduler | null = null
 let defaultAttachments: AttachmentTable | null = null
+let orphansReaped = false
 
 function getDefaultBackend(): ComputeBackend {
-  if (!defaultBackend) defaultBackend = new DockerBackend()
+  if (!defaultBackend) {
+    defaultBackend = new DockerBackend()
+    // First default-singleton build == process start. Clear any sandbox
+    // containers a previous (crashed / kill -9'd) process orphaned before we
+    // start allocating against the cap. Only the default (production) backend
+    // is reaped; tests inject their own backend and never reach here.
+    reapOrphansOnce(defaultBackend)
+  }
   return defaultBackend
+}
+
+/**
+ * Fire the backend's orphan reaper exactly once per process, fire-and-forget
+ * so the first acquire isn't latency-bound by it (#97 Gap 1). The reaper is
+ * safe by construction (label-scoped); see `DockerBackend.reapOrphans` for the
+ * multi-process caveat. Logs the count when it removes anything.
+ */
+function reapOrphansOnce(backend: ComputeBackend): void {
+  if (orphansReaped) return
+  orphansReaped = true
+  void backend
+    .reapOrphans()
+    .then((n) => {
+      if (n > 0) {
+        console.warn(`[sandbox] reaped ${n} orphaned container(s) from a prior process`)
+      }
+    })
+    .catch((err) => {
+      console.warn(
+        `[sandbox] orphan reap failed: ${err instanceof Error ? err.message : String(err)}`,
+      )
+    })
 }
 function getDefaultPool(): WarmPool {
   if (!defaultPool) {
@@ -111,6 +142,18 @@ export function getDefaultAttachments(): AttachmentTable {
     })
   }
   return defaultAttachments
+}
+
+/**
+ * Test seam: drop the lazy default singletons and re-arm the one-shot orphan
+ * reaper so a test can observe a fresh first-build. Production never calls this.
+ */
+export function __resetSandboxDefaultsForTests(): void {
+  defaultBackend = null
+  defaultPool = null
+  defaultScheduler = null
+  defaultAttachments = null
+  orphansReaped = false
 }
 
 /**


### PR DESCRIPTION
## Summary

**#97 Gaps 1+2** — sandbox attachment-lifecycle hardening (the next PR after #89 durable workspaces).

### Gap 1 — startup orphan reaper
A dev-server crash / `kill -9` loses the in-memory `AttachmentTable` + `WarmPool`, so its `--rm` containers keep running idle and pile up against `globalCap` (saw 12 once, cap 16 → near-wedge); the lazy idle sweep can't help because its process is gone.

- New `ComputeBackend.reapOrphans(): Promise<number>`. `DockerBackend` lists `kg-sandbox=1`-labelled containers (`docker ps -aq --filter label=kg-sandbox=1`) and force-removes them in one pass; engine-down → returns 0 (not a startup failure).
- `with-sandbox.server.ts` fires it **once per process**, fire-and-forget, on the first default-singleton build (`getDefaultBackend`), guarded by a module flag. Only the default (production) backend is reaped — injected (test) backends never reach it.
- Label-scoped so it's safe by construction. **Caveat:** reap-all-on-boot is wrong if two harness processes share one Docker host — correct for single-process dev (the v0 shape); gate behind a setting / grace window if multi-process becomes real (noted in code + docs).

### Gap 2 — health-check on attachment reuse
`AttachmentTable.acquire` reuse-hit bumped refCount with no liveness check, so a container that died between turns (crash / external `docker rm` / OOM) wedged the session on a dead transport until idle-evict.

- The reuse-hit branch now `await backend.health(vm)` (catch → treat as gone). Healthy → reuse as before; otherwise evict (close transport + idempotent `destroy`, drop from table) and fall through to a fresh boot.
- The fresh attachment is `isFirstBoot=true`, so the #89 `syncWorkspace` path re-hydrates `/work` transparently. Bonus: the cold-reconnect path is now testable via a plain `docker rm -f <sbx>` (no full restart). ~1 `docker inspect` per reuse.

## Tests
Hermetic, mirroring the existing mock-backend style (no Docker, no MCP SDK):
- `docker-backend.test.ts` +4 (reap removes & counts; empty → 0/no-rm; engine-down → 0; partial rm-failure still counts)
- `attachment-table.test.ts` +4 (healthy reuse skips reboot & probes once; gone → evict + reboot fresh `isFirstBoot` attachment, stale transport closed, dead VM destroyed, no leak; unhealthy → evict; health-throw → reboot)
- `with-sandbox.test.ts` +2 (reaper fires exactly once on first default build; injected path never reaps)

`pnpm exec tsc --noEmit` clean (no new errors); `pnpm test:run` → **787 pass / 60 files**.

## Verified live (2026-06-28)
- **Gap 1:** restarted dev server, fabricated 2 orphans, sent a Sandbox·Session message → `[sandbox] reaped 2 orphaned container(s) from a prior process` logged + orphans gone.
- **Gap 2:** wrote `/work/out/notes.txt`, `docker rm -f`'d the session container mid-conversation; next turn rebooted a fresh `sbx-*` and re-hydrated `/work/in/notes.txt` from the DataStash.

## Follow-up (not in this PR)
- **#97 Gap 3** — Shell/PtyManager attach bypasses hydrate (`pty-manager.server.ts` acquires directly, never calls `hydrateWorkspace`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)