### PR TITLE
feat(sandbox): hydrate /work when the Shell boots a session first (#97 Gap 3)

### DIFF
--- a/ui/src/__tests__/lib/harness-patterns/pattern-capabilities.test.ts
+++ b/ui/src/__tests__/lib/harness-patterns/pattern-capabilities.test.ts
@@ -17,6 +17,8 @@ import {
   isRetrieverConfig,
   harnessHasRetriever,
   harnessHasRedisRetriever,
+  isSyncWorkspaceConfig,
+  harnessUsesSyncWorkspace,
 } from '../../../lib/harness-patterns/pattern-capabilities'
 import type { ConfiguredPattern, PatternConfig } from '../../../lib/harness-patterns/types'
 
@@ -157,5 +159,48 @@ describe('harnessHasRedisRetriever', () => {
 
   it('is false for a graph with no retriever at all', () => {
     expect(harnessHasRedisRetriever([pat('router', {}), pat('simpleLoop', { patternId: 'neo4j-query' })])).toBe(false)
+  })
+})
+
+describe('isSyncWorkspaceConfig', () => {
+  it('flags the sandbox durable-workspace marker', () => {
+    expect(isSyncWorkspaceConfig({ patternId: 'loop', sandboxSyncWorkspace: true } as PatternConfig)).toBe(true)
+  })
+
+  it('does NOT flag configs without the marker (or set false)', () => {
+    expect(isSyncWorkspaceConfig({ patternId: 'loop' } as PatternConfig)).toBe(false)
+    expect(isSyncWorkspaceConfig({ sandboxSyncWorkspace: false } as unknown as PatternConfig)).toBe(false)
+    expect(isSyncWorkspaceConfig({} as PatternConfig)).toBe(false)
+  })
+})
+
+describe('harnessUsesSyncWorkspace', () => {
+  it('returns false for empty / undefined', () => {
+    expect(harnessUsesSyncWorkspace(undefined)).toBe(false)
+    expect(harnessUsesSyncWorkspace([])).toBe(false)
+  })
+
+  it('detects a top-level sync-sandbox wrapper', () => {
+    expect(
+      harnessUsesSyncWorkspace([pat('withSandbox(loop)', { patternId: 'loop', sandboxSyncWorkspace: true })]),
+    ).toBe(true)
+  })
+
+  it('detects a sync-sandbox wrapper nested via children (the Sandbox·Session shape)', () => {
+    const tree = [
+      pat('compactIntent', { patternId: 'sandbox-session-intent' }),
+      pat('withSandbox(actorCritic)', { patternId: 'sandbox-session-loop', sandboxSyncWorkspace: true }, [
+        pat('actorCritic', { patternId: 'sandbox-session-loop' }),
+      ]),
+      pat('synthesizer', { patternId: 'sandbox-session-synth' }),
+    ]
+    expect(harnessUsesSyncWorkspace(tree)).toBe(true)
+  })
+
+  it('is false for a sandbox wrapper without the marker (no syncWorkspace)', () => {
+    const tree = [
+      pat('withSandbox(actorCritic)', { patternId: 'sandbox-loop' }, [pat('actorCritic', { patternId: 'sandbox-loop' })]),
+    ]
+    expect(harnessUsesSyncWorkspace(tree)).toBe(false)
   })
 })

--- a/ui/src/__tests__/lib/sandbox/pty-manager.test.ts
+++ b/ui/src/__tests__/lib/sandbox/pty-manager.test.ts
@@ -1,0 +1,136 @@
+/**
+ * PtyManager unit tests — the #97 Gap 3 hydrate-on-first-boot logic.
+ *
+ * Hermetic: node-pty (a native addon), the shared AttachmentTable, and
+ * `hydrateWorkspace` are all mocked, so no Docker / MCP SDK / pseudo-TTY is
+ * involved. We assert the one new decision — whether the Shell hydrates
+ * /work/in when it is the first to boot the session container — across the
+ * sync/non-sync and first-boot/reused axes.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// vi.mock factories are hoisted above imports; build the spies in a hoisted
+// block so the factories can close over them without a TDZ error.
+const mocks = vi.hoisted(() => ({
+  spawnMock: vi.fn(),
+  hydrateMock: vi.fn(),
+  acquireMock: vi.fn(),
+  releaseMock: vi.fn(),
+}))
+
+vi.mock('../../../lib/harness-patterns/assert.server', () => ({
+  assertServerOnImport: vi.fn(),
+}))
+
+vi.mock('node-pty', () => ({ spawn: mocks.spawnMock }))
+
+vi.mock('../../../lib/sandbox/work-artifacts.server', () => ({
+  hydrateWorkspace: mocks.hydrateMock,
+}))
+
+vi.mock('../../../lib/sandbox/with-sandbox.server', () => ({
+  getDefaultAttachments: () => ({ acquire: mocks.acquireMock, release: mocks.releaseMock }),
+}))
+
+import { PtyManager } from '../../../lib/sandbox/pty-manager.server'
+
+// ---- fakes ---------------------------------------------------------------
+
+function makeFakeIPty() {
+  return {
+    onData: vi.fn(),
+    onExit: vi.fn(),
+    write: vi.fn(),
+    resize: vi.fn(),
+    kill: vi.fn(),
+  }
+}
+
+type FakeAttachment = {
+  id: string
+  refCount: number
+  lastUsedAt: number
+  isFirstBoot: boolean
+  vm: { native: { containerId: string } }
+  transport: Record<string, unknown>
+}
+
+let attachment: FakeAttachment
+
+beforeEach(() => {
+  mocks.spawnMock.mockReset().mockImplementation(() => makeFakeIPty())
+  mocks.hydrateMock.mockReset().mockResolvedValue(0)
+  mocks.acquireMock.mockReset()
+  mocks.releaseMock.mockReset()
+
+  attachment = {
+    id: 's1',
+    refCount: 1,
+    lastUsedAt: 0,
+    isFirstBoot: true,
+    vm: { native: { containerId: 'cid-1' } },
+    transport: { vmId: 's1' },
+  }
+  mocks.acquireMock.mockResolvedValue(attachment)
+})
+
+// ---- tests ---------------------------------------------------------------
+
+describe('PtyManager.ensure — hydrate on first boot (#97 Gap 3)', () => {
+  it('hydrates /work/in when the session uses durable workspaces and this is the first boot', async () => {
+    const mgr = new PtyManager()
+    await mgr.ensure('s1', { syncWorkspace: true })
+
+    expect(mocks.hydrateMock).toHaveBeenCalledTimes(1)
+    expect(mocks.hydrateMock).toHaveBeenCalledWith(attachment.transport, 's1')
+    expect(attachment.isFirstBoot).toBe(false) // flipped so the agent turn won't re-hydrate
+    expect(mocks.spawnMock).toHaveBeenCalledTimes(1) // shell still spawned
+  })
+
+  it('does not hydrate when the container was already booted (agent ran first)', async () => {
+    attachment.isFirstBoot = false
+    const mgr = new PtyManager()
+    await mgr.ensure('s1', { syncWorkspace: true })
+
+    expect(mocks.hydrateMock).not.toHaveBeenCalled()
+    expect(mocks.spawnMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not hydrate for a non-durable-workspace session', async () => {
+    const mgr = new PtyManager()
+    await mgr.ensure('s1', { syncWorkspace: false })
+
+    expect(mocks.hydrateMock).not.toHaveBeenCalled()
+    expect(attachment.isFirstBoot).toBe(true) // untouched
+    expect(mocks.spawnMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('defaults to no hydrate when opts are omitted (older client / no agentId)', async () => {
+    const mgr = new PtyManager()
+    await mgr.ensure('s1')
+
+    expect(mocks.hydrateMock).not.toHaveBeenCalled()
+    expect(mocks.spawnMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('opens the shell even if hydrate fails (best-effort), flipping isFirstBoot like the agent path', async () => {
+    mocks.hydrateMock.mockRejectedValueOnce(new Error('gateway down'))
+    const mgr = new PtyManager()
+    await expect(mgr.ensure('s1', { syncWorkspace: true })).resolves.toBeUndefined()
+
+    expect(mocks.spawnMock).toHaveBeenCalledTimes(1)
+    expect(attachment.isFirstBoot).toBe(false)
+  })
+
+  it('only boots/hydrates once even across concurrent ensure calls', async () => {
+    const mgr = new PtyManager()
+    await Promise.all([
+      mgr.ensure('s1', { syncWorkspace: true }),
+      mgr.ensure('s1', { syncWorkspace: true }),
+    ])
+    expect(mocks.acquireMock).toHaveBeenCalledTimes(1)
+    expect(mocks.hydrateMock).toHaveBeenCalledTimes(1)
+    expect(mocks.spawnMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/ui/src/__tests__/lib/sandbox/with-sandbox.test.ts
+++ b/ui/src/__tests__/lib/sandbox/with-sandbox.test.ts
@@ -22,6 +22,7 @@ import { WarmPool } from '../../../lib/sandbox/warm-pool.server'
 import { SandboxScheduler } from '../../../lib/sandbox/scheduler.server'
 import { AttachmentTable } from '../../../lib/sandbox/attachment-table.server'
 import { DockerBackend } from '../../../lib/sandbox/docker-backend.server'
+import { harnessUsesSyncWorkspace } from '../../../lib/harness-patterns/pattern-capabilities'
 import type {
   ComputeBackend,
   HealthStatus,
@@ -491,5 +492,40 @@ describe('withSandbox default-singleton orphan reaper (#97 Gap 1)', () => {
     // withSandbox itself never reaps; only the default-singleton builder does.
     expect(reapSpy).not.toHaveBeenCalled()
     expect(backend.calls.reapOrphans).toBe(0)
+  })
+})
+
+describe('withSandbox durable-workspace capability marker (#97 Gap 3)', () => {
+  it('exposes the wrapped pattern as children', () => {
+    const backend = fakeBackend()
+    const inner = fakePattern(async (scope) => scope)
+    const wrapped = withSandbox({ backend, id: 'sess-1', syncWorkspace: true })(inner)
+    expect(wrapped.children).toEqual([inner])
+  })
+
+  it('stamps sandboxSyncWorkspace when id + syncWorkspace are both set', () => {
+    const backend = fakeBackend()
+    const inner = fakePattern(async (scope) => scope)
+    const wrapped = withSandbox({ backend, id: 'sess-1', syncWorkspace: true })(inner)
+    expect((wrapped.config as { sandboxSyncWorkspace?: boolean }).sandboxSyncWorkspace).toBe(true)
+    // Detectable by the capability walker (the registry's agentUsesSyncWorkspace path).
+    expect(harnessUsesSyncWorkspace([wrapped])).toBe(true)
+  })
+
+  it('does NOT stamp the marker without syncWorkspace (config stays transparent)', () => {
+    const backend = fakeBackend()
+    const inner = fakePattern(async (scope) => scope)
+    const wrapped = withSandbox({ backend, id: 'sess-1' })(inner)
+    expect((wrapped.config as { sandboxSyncWorkspace?: boolean }).sandboxSyncWorkspace).toBeUndefined()
+    expect(wrapped.config).toEqual(inner.config)
+    expect(harnessUsesSyncWorkspace([wrapped])).toBe(false)
+  })
+
+  it('does NOT stamp the marker for syncWorkspace without an id (a no-op at runtime)', () => {
+    const backend = fakeBackend()
+    const inner = fakePattern(async (scope) => scope)
+    const wrapped = withSandbox({ backend, syncWorkspace: true })(inner)
+    expect((wrapped.config as { sandboxSyncWorkspace?: boolean }).sandboxSyncWorkspace).toBeUndefined()
+    expect(wrapped.config).toEqual(inner.config)
   })
 })

--- a/ui/src/components/ark-ui/InteractiveTerminal.tsx
+++ b/ui/src/components/ark-ui/InteractiveTerminal.tsx
@@ -15,6 +15,9 @@ import { onMount, onCleanup, createSignal } from 'solid-js'
 
 export interface InteractiveTerminalProps {
   sessionId: string
+  /** Active agent id — forwarded to the stream route so the Shell can hydrate
+   *  /work for durable-workspace agents on a first boot it triggers (#97 Gap 3). */
+  agentId?: string
 }
 
 type ConnState = 'connecting' | 'connected' | 'closed'
@@ -82,10 +85,14 @@ export const InteractiveTerminal = (props: InteractiveTerminalProps) => {
       }).catch(() => {})
     })
 
-    // PTY output down. Each frame is a JSON-encoded raw byte string.
-    const es = new EventSource(
-      `/api/sandbox/pty/stream?sessionId=${encodeURIComponent(sessionId)}`,
-    )
+    // PTY output down. Each frame is a JSON-encoded raw byte string. Forward
+    // the agent id so the server can hydrate /work for durable-workspace agents
+    // when this Shell is the first to boot the container (#97 Gap 3).
+    const agentId = props.agentId
+    const streamUrl =
+      `/api/sandbox/pty/stream?sessionId=${encodeURIComponent(sessionId)}` +
+      (agentId ? `&agentId=${encodeURIComponent(agentId)}` : '')
+    const es = new EventSource(streamUrl)
     es.onopen = () => {
       setState('connected')
       postResize()

--- a/ui/src/components/ark-ui/SupportPanel.tsx
+++ b/ui/src/components/ark-ui/SupportPanel.tsx
@@ -316,7 +316,7 @@ export const SupportPanel = (props: SupportPanelProps) => {
 
           {/* Terminal Tab — read-only feed + interactive shell (#79) */}
           <Tabs.Content value="terminal" h="full">
-            <TerminalPanel events={props.contextEvents ?? []} sessionId={props.sessionId} />
+            <TerminalPanel events={props.contextEvents ?? []} sessionId={props.sessionId} agentId={props.agentId} />
           </Tabs.Content>
 
           {/* Actions Tab (Future) */}

--- a/ui/src/components/ark-ui/TerminalPanel.tsx
+++ b/ui/src/components/ark-ui/TerminalPanel.tsx
@@ -49,6 +49,9 @@ export interface TerminalPanelProps {
   events: ContextEvent[]
   /** Active session id — required to open an interactive shell. */
   sessionId?: string
+  /** Active agent id — lets the Shell hydrate /work for durable-workspace
+   *  agents when it boots the container first (#97 Gap 3). */
+  agentId?: string
 }
 
 function isSandboxTool(name: unknown): name is string {
@@ -279,7 +282,7 @@ export const TerminalPanel = (props: TerminalPanelProps) => {
       >
         {/* Interactive shell — mounts the xterm bound to this session's PTY */}
         <div flex="1" overflow="hidden">
-          <InteractiveTerminal sessionId={props.sessionId!} />
+          <InteractiveTerminal sessionId={props.sessionId!} agentId={props.agentId} />
         </div>
       </Show>
     </div>

--- a/ui/src/lib/harness-client/registry.server.ts
+++ b/ui/src/lib/harness-client/registry.server.ts
@@ -10,7 +10,7 @@
 "use server";
 
 import type { ConfiguredPattern } from "../harness-patterns";
-import { usesCodeMode } from "../harness-patterns";
+import { usesCodeMode, harnessUsesSyncWorkspace } from "../harness-patterns";
 import type { SessionData } from "./session.server";
 
 // ============================================================================
@@ -117,6 +117,42 @@ export async function agentUsesCodeMode(
     return result;
   } catch {
     return agentId === "code-mode";
+  }
+}
+
+/** Memoized by agentId — same rationale as `codeModeCapabilityCache`: the
+ *  `withSandbox({ syncWorkspace })` flag is part of the static pattern shape,
+ *  independent of sessionId. */
+const syncWorkspaceCapabilityCache = new Map<string, boolean>();
+
+/**
+ * Whether an agent composes a **durable-workspace sandbox**
+ * (`withSandbox({ id, syncWorkspace: true })`) anywhere in its (possibly
+ * nested) pattern graph. The interactive Shell uses this to hydrate `/work/in`
+ * from the Data Stash when it is the first to boot the session container, so a
+ * Shell opened before the agent's first turn still sees prior files (#97 Gap 3).
+ *
+ * Structural detection (`harnessUsesSyncWorkspace`) + memoized by agentId,
+ * mirroring `agentUsesCodeMode`. On a `createPatterns` failure we return false
+ * and do NOT cache, so the next call re-attempts a real detection.
+ */
+export async function agentUsesSyncWorkspace(
+  agentId: string,
+  sessionId: string,
+): Promise<boolean> {
+  const cached = syncWorkspaceCapabilityCache.get(agentId);
+  if (cached !== undefined) return cached;
+
+  const agent = getAgent(agentId);
+  if (!agent) return false;
+
+  try {
+    const patterns = await agent.createPatterns(sessionId);
+    const result = harnessUsesSyncWorkspace(patterns);
+    syncWorkspaceCapabilityCache.set(agentId, result);
+    return result;
+  } catch {
+    return false;
   }
 }
 

--- a/ui/src/lib/harness-patterns/index.ts
+++ b/ui/src/lib/harness-patterns/index.ts
@@ -114,6 +114,8 @@ export {
   isRetrieverConfig,
   harnessHasRetriever,
   harnessHasRedisRetriever,
+  isSyncWorkspaceConfig,
+  harnessUsesSyncWorkspace,
 } from './pattern-capabilities'
 
 // ============================================================================

--- a/ui/src/lib/harness-patterns/pattern-capabilities.ts
+++ b/ui/src/lib/harness-patterns/pattern-capabilities.ts
@@ -92,3 +92,22 @@ export function harnessHasRedisRetriever<T>(patterns: ConfiguredPattern<T>[] | u
   if (!patterns || patterns.length === 0) return false
   return patterns.some((p) => isRedisRetrieverConfig(p.config) || harnessHasRedisRetriever(p.children))
 }
+
+/** True when a pattern's resolved config carries the durable-workspace marker
+ *  that `withSandbox({ id, syncWorkspace: true })` stamps. The marker rides on
+ *  the wrapped pattern's config (the wrapper is not a leaf factory), so read it
+ *  via a widening cast like the retriever's `backendKinds`. */
+export function isSyncWorkspaceConfig(config: PatternConfig): boolean {
+  return (config as PatternConfig & { sandboxSyncWorkspace?: boolean }).sandboxSyncWorkspace === true
+}
+
+/**
+ * True when any pattern in the (nested) graph is a durable-workspace sandbox
+ * wrapper. The interactive Shell uses this (via `agentUsesSyncWorkspace`) to
+ * decide whether to hydrate `/work/in` when it is the first to boot the
+ * session container (#97 Gap 3).
+ */
+export function harnessUsesSyncWorkspace<T>(patterns: ConfiguredPattern<T>[] | undefined): boolean {
+  if (!patterns || patterns.length === 0) return false
+  return patterns.some((p) => isSyncWorkspaceConfig(p.config) || harnessUsesSyncWorkspace(p.children))
+}

--- a/ui/src/lib/sandbox/pty-manager.server.ts
+++ b/ui/src/lib/sandbox/pty-manager.server.ts
@@ -23,6 +23,7 @@
 import { assertServerOnImport } from '../harness-patterns/assert.server'
 import { DEFAULT_SETTINGS } from '../settings'
 import { getDefaultAttachments } from './with-sandbox.server'
+import { hydrateWorkspace } from './work-artifacts.server'
 import type { Attachment } from './attachment-table.server'
 import type { RuntimeConfig } from './types'
 import * as pty from 'node-pty'
@@ -47,19 +48,30 @@ interface PtySession {
   closeTimer?: ReturnType<typeof setTimeout>
 }
 
-class PtyManager {
+/** Options for `ensure` — carried from the PTY stream route. */
+export interface PtyEnsureOptions {
+  /**
+   * Whether this session's agent uses durable workspaces (#89). When true and
+   * this Shell is the first to boot the container, hydrate `/work/in` from the
+   * Data Stash so a Shell opened before the agent's first turn still sees prior
+   * files (#97 Gap 3). Resolved by the route via `agentUsesSyncWorkspace`.
+   */
+  syncWorkspace?: boolean
+}
+
+export class PtyManager {
   private readonly sessions = new Map<string, PtySession>()
   private readonly starting = new Map<string, Promise<PtySession>>()
 
   /** Ensure a live PTY exists for the session (boot + spawn on first call). */
-  async ensure(sessionId: string): Promise<void> {
+  async ensure(sessionId: string, opts: PtyEnsureOptions = {}): Promise<void> {
     if (this.sessions.has(sessionId)) return
     const pending = this.starting.get(sessionId)
     if (pending) {
       await pending
       return
     }
-    const p = this.start(sessionId)
+    const p = this.start(sessionId, opts)
     this.starting.set(sessionId, p)
     try {
       await p
@@ -68,7 +80,7 @@ class PtyManager {
     }
   }
 
-  private async start(sessionId: string): Promise<PtySession> {
+  private async start(sessionId: string, opts: PtyEnsureOptions): Promise<PtySession> {
     const runtime: RuntimeConfig = {
       memoryMB: DEFAULT_SETTINGS.sandbox.defaultMemoryMB,
       timeoutSec: DEFAULT_SETTINGS.sandbox.defaultTimeoutSec,
@@ -76,6 +88,18 @@ class PtyManager {
     }
     const attachments = getDefaultAttachments()
     const attachment = await attachments.acquire(sessionId, 'base', runtime)
+
+    // #97 Gap 3: if the Shell is the first to boot the session container (the
+    // agent hasn't run a turn yet) and the session uses durable workspaces,
+    // hydrate /work/in from the Data Stash so the user sees prior files. The
+    // shared `isFirstBoot` flag coordinates with withSandbox's agent-side
+    // hydrate — whoever boots first hydrates; the other skips. Best-effort: a
+    // hydrate failure (e.g. gateway down) must never block opening the shell.
+    if (opts.syncWorkspace && attachment.isFirstBoot) {
+      await hydrateWorkspace(attachment.transport, sessionId).catch(() => {})
+      attachment.isFirstBoot = false
+    }
+
     const containerId = (attachment.vm.native as { containerId: string }).containerId
 
     const cols = 80

--- a/ui/src/lib/sandbox/with-sandbox.server.ts
+++ b/ui/src/lib/sandbox/with-sandbox.server.ts
@@ -28,6 +28,7 @@ import { hydrateWorkspace, snapshotOutputs, promoteOutputs } from './work-artifa
 import type { ComputeBackend, RootfsId, RuntimeConfig } from './types'
 import type {
   ConfiguredPattern,
+  PatternConfig,
   PatternScope,
   EventView,
 } from '../harness-patterns/types'
@@ -200,6 +201,10 @@ export function withSandbox(config?: WithSandboxConfig) {
     const id = config?.id
     const fresh = config?.fresh === true
     const syncWorkspace = config?.syncWorkspace === true
+    // Durable-workspace sync only runs on the id-addressable path (hydrate on
+    // first boot, promote on exit — see runWithIdAttachment). The capability
+    // marker below reflects that reality: syncWorkspace without an id is a no-op.
+    const willSyncWorkspace = syncWorkspace && id !== undefined
 
     const fn = async (
       scope: PatternScope<T>,
@@ -245,6 +250,15 @@ export function withSandbox(config?: WithSandboxConfig) {
       // Expose the wrapped pattern so static introspection (pattern-capabilities)
       // can see patterns nested inside a sandbox wrapper.
       children: [pattern],
+      // When durable workspaces are active, stamp a marker the registry's
+      // `agentUsesSyncWorkspace` reads so the interactive Shell knows to hydrate
+      // /work on a first boot it triggers (#97 Gap 3). Stamped only when it will
+      // sync, so the wrapper stays config-transparent otherwise; the spread
+      // suppresses the excess-property check (mirrors the retriever's
+      // `backendKinds`).
+      ...(willSyncWorkspace
+        ? { config: { ...pattern.config, sandboxSyncWorkspace: true } as PatternConfig }
+        : {}),
     }
   }
 }

--- a/ui/src/routes/api/sandbox/pty/stream.ts
+++ b/ui/src/routes/api/sandbox/pty/stream.ts
@@ -13,6 +13,7 @@
  */
 import type { APIEvent } from '@solidjs/start/server'
 import { ptyManager } from '../../../../lib/sandbox/pty-manager.server'
+import { agentUsesSyncWorkspace } from '../../../../lib/harness-client/registry.server'
 import { getAuthenticatedUser } from '../../../../lib/auth/server'
 import { isBypassEnabled } from '../../../../lib/auth/dev-bypass'
 
@@ -24,6 +25,7 @@ async function requireAuth(): Promise<void> {
 export async function GET(event: APIEvent) {
   const url = new URL(event.request.url)
   const sessionId = url.searchParams.get('sessionId')
+  const agentId = url.searchParams.get('agentId')
   if (!sessionId) {
     return new Response('sessionId is required', { status: 400 })
   }
@@ -35,7 +37,13 @@ export async function GET(event: APIEvent) {
   }
 
   try {
-    await ptyManager.ensure(sessionId)
+    // If the session's agent uses durable workspaces, the PtyManager hydrates
+    // /work/in when this Shell is the first to boot the container (#97 Gap 3).
+    // Best-effort: a capability-resolution hiccup must not block the terminal.
+    const syncWorkspace = agentId
+      ? await agentUsesSyncWorkspace(agentId, sessionId).catch(() => false)
+      : false
+    await ptyManager.ensure(sessionId, { syncWorkspace })
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err)
     return new Response(`failed to start sandbox terminal: ${msg}`, { status: 500 })


### PR DESCRIPTION
## Summary

**#97 Gap 3** — the last of the sandbox attachment-lifecycle gaps (after Gaps 1+2 in #103). Closes the durable-workspace hole on the interactive Shell path.

**Bug:** `PtyManager.start` acquired the session attachment but never hydrated. A Shell opened *before* the agent's first turn booted the container with an empty `/work/in` — uploads and prior deliverables only appeared once the agent ran a turn.

**Fix:** the Shell hydrates `/work/in` on first boot, double-gated by:
1. the shared `Attachment.isFirstBoot` flag — coordinates with `withSandbox`'s agent-side hydrate so whoever boots the container first hydrates and the other skips; and
2. whether the session's agent actually uses durable workspaces, resolved as a capability.

## Capability-driven wiring
Mirrors #98 (`agentUsesCodeMode`) and #102 (retriever introspection):
- **`withSandbox`** stamps a `sandboxSyncWorkspace` marker on the wrapped pattern's config (and exposes the wrapped pattern as `children`) when `id` + `syncWorkspace` are both set — transparent otherwise, so a non-sync wrapper is unchanged.
- **`pattern-capabilities`** — `isSyncWorkspaceConfig` / `harnessUsesSyncWorkspace` walk the graph.
- **registry** — `agentUsesSyncWorkspace(agentId, sessionId)`, memoized by agentId (the flag is part of the static pattern shape).
- **PTY stream route** reads a new `?agentId` param, resolves the capability, and passes `{ syncWorkspace }` to `ptyManager.ensure`.
- **frontend** threads `agentId` SupportPanel → TerminalPanel → InteractiveTerminal onto the stream URL.
- **`PtyManager.start`** hydrates via the attachment's transport when `syncWorkspace && isFirstBoot` — best-effort (a hydrate failure never blocks opening the shell), flipping `isFirstBoot` like the agent path.

## Tests
Hermetic, no Docker / MCP SDK / pseudo-TTY:
- `pattern-capabilities.test.ts` +8 (`isSyncWorkspaceConfig`; `harnessUsesSyncWorkspace` incl. the nested Sandbox·Session shape and a no-marker sandbox wrapper)
- `with-sandbox.test.ts` +4 (marker stamped with `id`+`syncWorkspace`; not stamped without `syncWorkspace` / without `id`; `children` exposed; config stays transparent)
- new `pty-manager.test.ts` (mocks node-pty + attachments + `hydrateWorkspace`): hydrate across sync/non-sync × first-boot/reused, default-no-opts, hydrate-failure-still-opens, concurrent-ensure-boots-once

`pnpm exec tsc --noEmit` clean (no new errors); `pnpm test:run` → **836 pass / 64 files**.

## Verified live (2026-06-29)
Opened the Shell on a Sandbox·Session conversation with a prior `/work/out` deliverable, container not running, *before* sending a turn → `/work/in` was hydrated from the Data Stash (was empty before this fix).

## Notes
The narrow reap-vs-first-boot race (#103) is unaffected. With Gap 3 merged, all three #97 attachment-lifecycle gaps are closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)