### PR TITLE
feat(agents): async POST trigger endpoint → observable actions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 # MCP config (contains secrets — use template.mcp-config.yaml as reference)
 configs/mcp-config.yaml
 
+# Action API tokens (contains secrets — use template.action-tokens.yaml as reference)
+configs/action-tokens.yaml
+
 # Python-generated files
 __pycache__/
 *.py[oc]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,5 +189,6 @@ Custom tokens: `dark-bg-{primary,secondary,tertiary}`, `dark-text-{primary,secon
 | [GitHub Project — "Harness Playground tasks"](https://github.com/users/mknw/projects/5) | Planning board / roadmap — replaced `docs/ROADMAP.md`; planning lives in GitHub Projects now |
 | [`docs/UI_ARCHITECTURE.md`](docs/UI_ARCHITECTURE.md) | Component structure, data flow, Chat-Graph linking |
 | [`docs/DATA_STASH.md`](docs/DATA_STASH.md) | Data Stash pipeline: upload → chunk → embed → search (#6/#9/#8), API routes, Redis storage, redis-stack + local-embedder requirements |
+| [`docs/AGENT_TRIGGER.md`](docs/AGENT_TRIGGER.md) | `POST /api/agents/:id` async agent trigger → action rows: contract, fire-and-forget model, `kind`/`source`/`status` columns, token auth (`configs/action-tokens.yaml`), recording playback via Data Stash, promotion gate |
 | [`ui/README.md`](ui/README.md) | UI quick start and file index |
 | [`ui/src/lib/harness-patterns/README.md`](ui/src/lib/harness-patterns/README.md) | Harness patterns full API |

--- a/configs/template.action-tokens.yaml
+++ b/configs/template.action-tokens.yaml
@@ -1,0 +1,18 @@
+# Action API tokens — reference template.
+#
+# Copy to `configs/action-tokens.yaml` (git-ignored) and fill in real secrets.
+# Each entry maps a Bearer secret presented to `POST /api/agents/:id` to the
+# userId that owns the resulting action rows. One entry per device/user.
+#
+#   curl -X POST https://host/api/agents/default \
+#     -H "Authorization: Bearer <secret>" \
+#     -F transcribed_command="add a node for Project Apollo" \
+#     -F short_description="Apollo node" \
+#     -F original_recording=@memo.m4a
+#
+# `label` is for your own bookkeeping (which device a secret belongs to); it is
+# never used at runtime. Rotate by replacing the `secret` value.
+tokens:
+  - label: "example iOS Shortcut"
+    secret: "<REPLACE_WITH_A_LONG_RANDOM_SECRET>"
+    userId: "<STACK_AUTH_USER_ID>"

--- a/docs/AGENT_TRIGGER.md
+++ b/docs/AGENT_TRIGGER.md
@@ -1,0 +1,154 @@
+# Agent Trigger Endpoint — Async POST → Action
+
+`POST /api/agents/:id` fires a **fixed agent** asynchronously and persists the run
+as an **action** in the `conversations` table — fully observable, resumable, and
+**promotable to a regular conversation** on user interaction. Built for an iOS
+Shortcut that records audio, transcribes it, and POSTs a multipart form.
+
+```
+iOS Shortcut ─▶ POST /api/agents/:id (multipart)
+                  │  Bearer secret → userId (configs/action-tokens.yaml)
+                  │  store recording ─▶ Data Stash (base64, keyed by run_id)
+                  │  seed row (kind=action, source=post, status=running)
+                  └─ 202 { run_id }         # returns immediately
+                        │
+                        └─(fire-and-forget)─▶ harness run ─▶ save (status=done|error)
+```
+
+Agents are **fixed per endpoint** — intent-routing belongs *inside* a general
+harness, never at this layer. As harnesses mature, more general ones can expose
+more routes.
+
+## Endpoint contract
+
+```
+POST /api/agents/:id
+  :id           → resolve via getAgent(id); 404 if unknown
+  Authorization: Bearer <shared-secret>   → resolves to a userId; 401 if unknown
+  Body: multipart/form-data
+    transcribed_command  (text, required) → harness input; 400 if missing
+    short_description     (text)          → sticky conversation title
+    original_recording    (file)          → stored in the Data Stash (provenance + playback)
+→ 202 { run_id }     # run_id == sessionId == conversation row id
+```
+
+Error precedence: unknown agent (404) → bad/missing secret (401) → missing
+`transcribed_command` (400) → `202`. Recording storage is **best-effort**: a
+failure (e.g. Redis down) is logged and the run still proceeds.
+
+## Modules
+
+| Module | Role |
+|--------|------|
+| `routes/api/agents/[id].ts` | The route: auth, multipart parse, recording store, seed row, fire-and-forget, `202` |
+| `lib/auth/action-tokens.server.ts` | Parse `configs/action-tokens.yaml` → `secret → userId` map (cached); `bearerSecret()` header extraction |
+| `lib/harness-client/action-runner.server.ts` | `seedActionRow` (observable `running` row) + `runAgentInBackground` (fresh harness run, off the request path). **Server-only, deliberately NOT `"use server"`** — it takes a `userId`, so exposing it as a client RPC would let a caller run as any user |
+| `lib/harness-client/actions.server.ts` | `promoteAction()` server action (flip `kind`); `ConversationSummary` carries `kind`/`source`/`status` |
+| `lib/db/conversations.server.ts` | `kind`/`source`/`status` columns; `promoteConversation`, `setConversationStatus`; `saveConversation` keeps `kind`/`source` immutable on update |
+
+## Execution model — in-process fire-and-forget (v1)
+
+1. The route authenticates, parses the multipart body, and stores the recording.
+2. `seedActionRow` inserts the row with a minimal seeded `UnifiedContext` (just
+   the command as the first `user_message` + `data.trigger`) so the action is
+   observable — with a `running` spinner — the instant `202` returns.
+3. `runAgentInBackground` runs the harness to completion **without being awaited**
+   (a fresh `harness(...)` run, *not* `continueSession` — it never re-appends to
+   the seeded placeholder). It's wrapped in `runWithUserId(userId, …)` so pattern
+   closures resolve the owner; request-scoped settings fall back to
+   `DEFAULT_SETTINGS`. On completion `saveSession` overwrites the blob and lifts
+   `status`; on an unexpected throw the row is flipped to `error`.
+
+Precedent: `routes/api/events.ts` already fires post-response async work
+(title-gen, tool-result summaries).
+
+**Caveat (be honest):** a process restart mid-run orphans a `running` row
+(detectable as stale). Crash-recovery / retries are an upgrade path — a
+Postgres-polling worker. Assumes a **persistent node server** (not serverless).
+
+## Data model — ONE table (`conversations`)
+
+An action and a conversation share the same shape (a full `UnifiedContext`), so a
+second table would force a copy on every promotion. One table → **promotion is a
+field flip**. Three columns added via idempotent `ALTER TABLE … ADD COLUMN IF NOT
+EXISTS` (so existing DBs pick them up; the `CREATE` only runs when the table is
+absent):
+
+| Column | Values | Notes |
+|--------|--------|-------|
+| `kind` | `conversation` \| `action` | Mutable — **promotion flips it**. Immutable through `saveConversation`'s upsert (only `promoteConversation` changes it) |
+| `source` | `chat` \| `post` | Immutable provenance. `saveConversation` never updates it |
+| `status` | `running` \| `paused` \| `done` \| `error` | Lifted copy of `UnifiedContext.status`, refreshed on every save, for cheap list filtering + the sidebar badge |
+
+Existing chat flow → `kind='conversation'`, `source='chat'` (defaults; backfilled
+on existing rows). POST trigger → `kind='action'`, `source='post'`.
+
+Trigger provenance lives at `ctx.data.trigger`
+(`{ transcribedCommand, shortDescription, recordingDocId, recordingFilename,
+recordingMimeType }`). `short_description` also lands in the sticky `title` column
+(the route's insert sets it; the background run's `saveSession` can't clobber it
+via the `COALESCE`-sticky rule).
+
+### Status lifecycle — a harness quirk
+
+The harness **never flips a successful run to `done`**: `runChain` leaves
+`ctx.status === 'running'` and the synthesizer emits the final `assistant_message`
+directly (`harness.server.ts`'s `status === 'done'` push is effectively dead).
+Since `saveSession` only runs *after* the harness returns, a persisted `running`
+means "completed, never flipped" → `extractStatusFromContext`
+(`session.server.ts`) maps `running → done` on save (`paused`/`error` preserved).
+The genuine in-flight `running` badge therefore comes **only** from
+`seedActionRow`, which writes the column directly. Do **not** "fix" this in the
+harness core by calling `setDone` before the assistant_message push — that would
+emit a duplicate message.
+
+## Authentication — `configs/action-tokens.yaml`
+
+Per-user secret map (git-ignored, mirrors `configs/mcp-config.yaml`). Copy
+`configs/template.action-tokens.yaml` and fill in real secrets:
+
+```yaml
+tokens:
+  - label: "iphone"                 # bookkeeping only, never used at runtime
+    secret: "<long-random-secret>"
+    userId: "<stack-auth-user-id>"
+```
+
+Parsed once and cached (`resolveActionUser`). A missing file rejects every
+request (401) with a warning. **Dev:** map a secret to `dev-bypass-user` so
+triggered actions appear in the dev UI (which runs as `BYPASS_USER` when
+`VITE_DEV_BYPASS_AUTH=true`).
+
+## Recording storage & playback — via the Data Stash
+
+The `original_recording` is stored as a **Data Stash document keyed by `run_id`**
+(`storeDocument({ sessionId: run_id, encoding: 'base64', … })`), so it surfaces
+in that conversation's **"Your Uploads"** and is playable — *not* the searchable
+ingestion pipeline (binary is skipped by ingest). See [DATA_STASH.md](DATA_STASH.md).
+
+- `upload-service.server.ts` maps audio extensions (`m4a`/`mp3`/`wav`/`aac`/`ogg`/…)
+  so a recording is classified binary → base64 (audio/* already fails `isTextMime`).
+- `DataStashPanel.tsx` gives audio docs a microphone icon + a **Play** action that
+  renders an inline `<audio controls>` pointed at
+  `GET /api/stash/document/:id?sessionId=&download`. Media elements ignore the
+  `Content-Disposition: attachment` header, so the same route serves both download
+  and playback — no new endpoint.
+
+## UI — left sidebar & promotion (`ChatSidebar.tsx`, `ChatInterface.tsx`, `routes/index.tsx`)
+
+- **Segmented filter: All / Chats / Actions** (queries `kind`).
+- **Status badge** on action rows: spinner (`running`), red (`error`), amber
+  (`paused`), subtle bolt (`done`).
+- **Promotion gate:** opening an action and sending a message prompts *"Turn this
+  action into a conversation?"*. **Confirm** → `promoteAction()` flips `kind`, then
+  the message sends. **Cancel** → the send is aborted entirely (hard gate — the
+  draft is dropped; the row stays an action). Once promoted it never gates again.
+- Background completion has no browser channel, so the route **polls
+  `listConversations()` every 5s while any action is `running`** to surface the
+  `running → done` flip.
+
+## Out of scope (follow-ups)
+
+- Completion email / push notification (per-agent settings).
+- A dedicated observability view for agent runs (the Actions filter is the interim surface).
+- Durable queue / crash-recovery worker (the fire-and-forget orphan caveat above).

--- a/docs/DATA_STASH.md
+++ b/docs/DATA_STASH.md
@@ -3,7 +3,10 @@
 The Data Stash lets users upload documents that the agent can reference and
 search. This doc covers the **store → chunk → embed → search** pipeline
 (issues #6, #9, #8). For the tool-result side of the stash (hide/archive of
-agent-produced results) see [UI_ARCHITECTURE.md](UI_ARCHITECTURE.md).
+agent-produced results) see [UI_ARCHITECTURE.md](UI_ARCHITECTURE.md). Voice
+recordings from the [agent trigger endpoint](AGENT_TRIGGER.md) are also stored
+here (base64 audio, keyed by `run_id`) for provenance + inline playback — stored
+only, not ingested.
 
 ```
 upload ─▶ store (RedisJSON) ─▶ chunk ─▶ embed (local/OpenRouter) ─▶ HNSW index

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -43,6 +43,12 @@ Source-level index: see [ui/README.md](../ui/README.md#documentation-index).
 |----------|-------------|
 | [DATA_STASH.md](DATA_STASH.md) | Document upload → chunk → embed → search pipeline (#6/#9/#8): modules, API routes, Redis storage model (incl. base64 binary, #89), embedding-space rule, redis-stack + local-embedder requirements |
 
+### Agent Trigger Endpoint
+
+| Document | Description |
+|----------|-------------|
+| [AGENT_TRIGGER.md](AGENT_TRIGGER.md) | `POST /api/agents/:id` async agent trigger → **action** rows: endpoint contract, in-process fire-and-forget model, `kind`/`source`/`status` data model, per-user token auth (`configs/action-tokens.yaml`), recording storage + playback via the Data Stash, sidebar filter + promotion gate, status-lifecycle quirk |
+
 ---
 
 ## Infrastructure Documentation
@@ -58,6 +64,7 @@ Source-level index: see [ui/README.md](../ui/README.md#documentation-index).
 - `docker-compose.yaml` — service orchestration
 - `configs/mcp-config.yaml` — MCP server connection params
 - `configs/custom-catalog.yaml` — custom MCP server definitions (Docker image-based)
+- `configs/action-tokens.yaml` — Bearer secret → userId map for `POST /api/agents/:id` (git-ignored; see `template.action-tokens.yaml` and [AGENT_TRIGGER.md](AGENT_TRIGGER.md))
 - `.mcp.json` — Claude Code MCP integration (gateway URL port 8811)
 
 ---
@@ -97,6 +104,8 @@ kg-agent/
 ├── docs/
 │   ├── INDEX.md                 # You are here
 │   ├── UI_ARCHITECTURE.md       # Frontend architecture
+│   ├── DATA_STASH.md            # Document ingestion pipeline
+│   ├── AGENT_TRIGGER.md         # POST /api/agents/:id async trigger → actions
 │   ├── DOCKER_COMPOSE.md        # Docker setup
 │   ├── MCP_GATEWAY.md           # MCP Gateway reference
 │   └── harness-patterns/        # Harness patterns documentation

--- a/ui/src/__tests__/components/ark-ui/ChatSidebar.test.ts
+++ b/ui/src/__tests__/components/ark-ui/ChatSidebar.test.ts
@@ -25,8 +25,8 @@ const { mergeThreadsWithPlaceholder } = await import('../../../components/ark-ui
 type ChatThreadSummary = import('../../../components/ark-ui/ChatSidebar').ChatThreadSummary
 
 const persisted: ChatThreadSummary[] = [
-  { id: 'a', title: 'Alpha', updatedAt: '2026-05-10T00:00:00Z' },
-  { id: 'b', title: 'Beta', updatedAt: '2026-05-09T00:00:00Z' },
+  { id: 'a', title: 'Alpha', updatedAt: '2026-05-10T00:00:00Z', kind: 'conversation', status: 'done' },
+  { id: 'b', title: 'Beta', updatedAt: '2026-05-09T00:00:00Z', kind: 'conversation', status: 'done' },
 ]
 
 describe('mergeThreadsWithPlaceholder', () => {
@@ -45,6 +45,8 @@ describe('mergeThreadsWithPlaceholder', () => {
       id: 'new-id',
       title: null,
       updatedAt: '2026-05-10T12:00:00Z',
+      kind: 'conversation',
+      status: 'done',
       isPlaceholder: true,
     })
     expect(merged[1].id).toBe('a')
@@ -53,7 +55,7 @@ describe('mergeThreadsWithPlaceholder', () => {
 
   it('drops the placeholder once a persisted row with the same id arrives', () => {
     const withRow: ChatThreadSummary[] = [
-      { id: 'new-id', title: 'First message…', updatedAt: '2026-05-10T12:00:00Z' },
+      { id: 'new-id', title: 'First message…', updatedAt: '2026-05-10T12:00:00Z', kind: 'conversation', status: 'done' },
       ...persisted,
     ]
     const merged = mergeThreadsWithPlaceholder(withRow, 'new-id')
@@ -77,6 +79,8 @@ describe('mergeThreadsWithPlaceholder', () => {
       id: `cl-${i}`,
       title: `Conversation ${i}`,
       updatedAt: '2026-05-10T00:00:00Z',
+      kind: 'conversation' as const,
+      status: 'done' as const,
     }))
     const uuid = '550e8400-e29b-41d4-a716-446655440000'
     const merged = mergeThreadsWithPlaceholder(

--- a/ui/src/__tests__/lib/auth/action-tokens.test.ts
+++ b/ui/src/__tests__/lib/auth/action-tokens.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Action token parsing + Bearer extraction.
+ *
+ * Covers the pure helpers behind `POST /api/agents/:id` auth: parsing the
+ * YAML token map and pulling the credential out of an Authorization header.
+ * The file-loading/caching path is exercised indirectly (it delegates to
+ * `parseActionTokens`).
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('../../../lib/harness-patterns/assert.server', () => ({
+  assertServerOnImport: vi.fn(),
+  assertServer: vi.fn(),
+}))
+
+import {
+  parseActionTokens,
+  bearerSecret,
+} from '../../../lib/auth/action-tokens.server'
+
+describe('parseActionTokens', () => {
+  it('maps secret → userId for well-formed entries', () => {
+    const map = parseActionTokens(`
+tokens:
+  - label: phone
+    secret: s3cr3t-A
+    userId: user-1
+  - secret: s3cr3t-B
+    userId: user-2
+`)
+    expect(map.get('s3cr3t-A')).toBe('user-1')
+    expect(map.get('s3cr3t-B')).toBe('user-2')
+    expect(map.size).toBe(2)
+  })
+
+  it('trims whitespace around secret + userId', () => {
+    const map = parseActionTokens(`
+tokens:
+  - secret: "  spaced  "
+    userId: "  user-x  "
+`)
+    expect(map.get('spaced')).toBe('user-x')
+  })
+
+  it('skips entries missing a secret or userId', () => {
+    const map = parseActionTokens(`
+tokens:
+  - secret: only-secret
+  - userId: only-user
+  - secret: ""
+    userId: blank
+  - secret: good
+    userId: u
+`)
+    expect(map.size).toBe(1)
+    expect(map.get('good')).toBe('u')
+  })
+
+  it('returns an empty map for missing/empty/invalid yaml', () => {
+    expect(parseActionTokens('').size).toBe(0)
+    expect(parseActionTokens('tokens: []').size).toBe(0)
+    expect(parseActionTokens('not: a token file').size).toBe(0)
+    expect(parseActionTokens(': : : not yaml').size).toBe(0)
+  })
+})
+
+describe('bearerSecret', () => {
+  it('extracts the credential from a Bearer header', () => {
+    expect(bearerSecret('Bearer abc123')).toBe('abc123')
+    expect(bearerSecret('bearer abc123')).toBe('abc123') // case-insensitive scheme
+    expect(bearerSecret('Bearer   padded  ')).toBe('padded')
+  })
+
+  it('returns null for missing or non-Bearer headers', () => {
+    expect(bearerSecret(null)).toBeNull()
+    expect(bearerSecret('')).toBeNull()
+    expect(bearerSecret('Basic abc')).toBeNull()
+    expect(bearerSecret('abc123')).toBeNull()
+  })
+})

--- a/ui/src/__tests__/lib/db/conversations.test.ts
+++ b/ui/src/__tests__/lib/db/conversations.test.ts
@@ -21,6 +21,8 @@ import {
   listConversations,
   deleteConversation,
   deriveTitle,
+  promoteConversation,
+  setConversationStatus,
 } from '../../../lib/db/conversations.server'
 import { closePool, query } from '../../../lib/db/client.server'
 
@@ -178,5 +180,130 @@ describe('conversations CRUD', () => {
 
     await deleteConversation(id, TEST_USER)
     expect(await loadConversation(id, TEST_USER)).toBeNull()
+  })
+})
+
+describe('action kind/source/status (agent trigger endpoint)', () => {
+  it('defaults to conversation/chat for the normal save path', async () => {
+    if (!dbAvailable) return
+    const id = `conv-${Math.random().toString(36).slice(2, 10)}`
+    await saveConversation({
+      id,
+      userId: TEST_USER,
+      agentId: 'default',
+      title: 't',
+      serializedContext: '{}',
+    })
+    const loaded = await loadConversation(id, TEST_USER)
+    expect(loaded!.kind).toBe('conversation')
+    expect(loaded!.source).toBe('chat')
+  })
+
+  it('inserts an action with source=post and refreshes status, keeping kind/source immutable on update', async () => {
+    if (!dbAvailable) return
+    const id = `act-${Math.random().toString(36).slice(2, 10)}`
+    // Route's seed insert.
+    await saveConversation({
+      id,
+      userId: TEST_USER,
+      agentId: 'default',
+      title: 'Voice action',
+      serializedContext: JSON.stringify({ events: [], status: 'running' }),
+      kind: 'action',
+      source: 'post',
+      status: 'running',
+    })
+    let loaded = await loadConversation(id, TEST_USER)
+    expect(loaded!.kind).toBe('action')
+    expect(loaded!.source).toBe('post')
+    expect(loaded!.status).toBe('running')
+
+    // Background run's completion save — passes default kind/source but the
+    // UPDATE must preserve the action's provenance while refreshing status.
+    await saveConversation({
+      id,
+      userId: TEST_USER,
+      agentId: 'default',
+      title: 'derived-from-command', // sticky → ignored
+      serializedContext: JSON.stringify({ events: [{ id: 'a' }], status: 'done' }),
+      status: 'done',
+    })
+    loaded = await loadConversation(id, TEST_USER)
+    expect(loaded!.kind).toBe('action') // NOT demoted
+    expect(loaded!.source).toBe('post')
+    expect(loaded!.status).toBe('done') // refreshed
+    expect(loaded!.title).toBe('Voice action') // sticky
+  })
+
+  it('promoteConversation flips action → conversation, scoped to user + idempotent', async () => {
+    if (!dbAvailable) return
+    const id = `act-${Math.random().toString(36).slice(2, 10)}`
+    await saveConversation({
+      id,
+      userId: TEST_USER,
+      agentId: 'default',
+      title: 't',
+      serializedContext: '{}',
+      kind: 'action',
+      source: 'post',
+      status: 'done',
+    })
+
+    // Wrong user → no-op.
+    await promoteConversation(id, 'someone-else')
+    expect((await loadConversation(id, TEST_USER))!.kind).toBe('action')
+
+    // Correct user → promoted.
+    await promoteConversation(id, TEST_USER)
+    expect((await loadConversation(id, TEST_USER))!.kind).toBe('conversation')
+
+    // Idempotent re-promote stays a conversation.
+    await promoteConversation(id, TEST_USER)
+    expect((await loadConversation(id, TEST_USER))!.kind).toBe('conversation')
+  })
+
+  it('setConversationStatus updates status without touching context (scoped to user)', async () => {
+    if (!dbAvailable) return
+    const id = `act-${Math.random().toString(36).slice(2, 10)}`
+    const ctx = JSON.stringify({ events: [], status: 'running' })
+    await saveConversation({
+      id,
+      userId: TEST_USER,
+      agentId: 'default',
+      title: 't',
+      serializedContext: ctx,
+      kind: 'action',
+      source: 'post',
+      status: 'running',
+    })
+
+    await setConversationStatus(id, 'wrong-user', 'error')
+    expect((await loadConversation(id, TEST_USER))!.status).toBe('running')
+
+    await setConversationStatus(id, TEST_USER, 'error')
+    const loaded = await loadConversation(id, TEST_USER)
+    expect(loaded!.status).toBe('error')
+    // Context blob untouched.
+    expect(loaded!.serializedContext).toBe(ctx)
+  })
+
+  it('listConversations surfaces kind/source/status', async () => {
+    if (!dbAvailable) return
+    const id = `act-${Math.random().toString(36).slice(2, 10)}`
+    await saveConversation({
+      id,
+      userId: TEST_USER,
+      agentId: 'default',
+      title: 't',
+      serializedContext: '{}',
+      kind: 'action',
+      source: 'post',
+      status: 'running',
+    })
+    const row = (await listConversations(TEST_USER)).find((r) => r.id === id)
+    expect(row).toBeDefined()
+    expect(row!.kind).toBe('action')
+    expect(row!.source).toBe('post')
+    expect(row!.status).toBe('running')
   })
 })

--- a/ui/src/__tests__/lib/db/cross-turn-persistence.test.ts
+++ b/ui/src/__tests__/lib/db/cross-turn-persistence.test.ts
@@ -248,3 +248,32 @@ describe('cross-turn persistence after conversation switch', () => {
     expect(restored.events.find((e) => e.id === 'ev-second-turn')).toBeTruthy()
   })
 })
+
+describe('status lifting on save (agent-trigger status column)', () => {
+  // The harness leaves a *successful* run as ctx.status='running' (runChain
+  // never calls setDone). saveSession is only ever called after the harness
+  // returns, so a persisted 'running' means "completed" → it must lift to
+  // 'done' for the sidebar badge. 'paused'/'error' are explicit and preserved.
+  async function savedStatus(sessionId: string, ctxStatus: string): Promise<string | undefined> {
+    const ctx = createContext('hi', {}, sessionId)
+    ;(ctx as { status: string }).status = ctxStatus
+    await saveSession(sessionId, TEST_USER, 'default', serializeContext(ctx))
+    return (await loadSession(sessionId, TEST_USER))?.status
+  }
+
+  it("lifts a completed run's 'running' status to 'done'", async () => {
+    if (!dbAvailable) return
+    expect(await savedStatus(`xt-${Math.random().toString(36).slice(2, 10)}`, 'running')).toBe('done')
+  })
+
+  it("preserves 'paused' (awaiting approval) and 'error'", async () => {
+    if (!dbAvailable) return
+    expect(await savedStatus(`xt-${Math.random().toString(36).slice(2, 10)}`, 'paused')).toBe('paused')
+    expect(await savedStatus(`xt-${Math.random().toString(36).slice(2, 10)}`, 'error')).toBe('error')
+  })
+
+  it("maps an explicit 'done' through unchanged", async () => {
+    if (!dbAvailable) return
+    expect(await savedStatus(`xt-${Math.random().toString(36).slice(2, 10)}`, 'done')).toBe('done')
+  })
+})

--- a/ui/src/__tests__/lib/stash-upload-service.test.ts
+++ b/ui/src/__tests__/lib/stash-upload-service.test.ts
@@ -30,6 +30,39 @@ describe('upload-service (Issue #6)', () => {
       expect(guessMimeType('archive.weird')).toBe('text/plain')
       expect(guessMimeType('trailing.')).toBe('text/plain')
     })
+    it('maps audio extensions (agent trigger recordings)', () => {
+      expect(guessMimeType('memo.m4a')).toBe('audio/mp4')
+      expect(guessMimeType('memo.mp3')).toBe('audio/mpeg')
+      expect(guessMimeType('memo.wav')).toBe('audio/wav')
+      expect(guessMimeType('memo.caf')).toBe('audio/x-caf')
+    })
+  })
+
+  describe('audio is treated as binary (base64)', () => {
+    it('classifies audio mimetypes as non-text', () => {
+      expect(isTextMime('audio/mp4')).toBe(false)
+      expect(isTextMime('audio/mpeg')).toBe(false)
+      expect(isTextMime('audio/wav')).toBe(false)
+    })
+    it('base64-encodes an audio recording (multipart, with content-type)', async () => {
+      const BOUNDARY = '----audioboundary'
+      const body =
+        `--${BOUNDARY}\r\n` +
+        `Content-Disposition: form-data; name="sessionId"\r\n\r\nrun-1\r\n` +
+        `--${BOUNDARY}\r\n` +
+        `Content-Disposition: form-data; name="file"; filename="voice.m4a"\r\n` +
+        `Content-Type: audio/mp4\r\n\r\n` +
+        `\x00\x01\x02binaryish\r\n` +
+        `--${BOUNDARY}--\r\n`
+      const req = new Request('http://x/api/stash/upload', {
+        method: 'POST',
+        headers: { 'Content-Type': `multipart/form-data; boundary=${BOUNDARY}` },
+        body,
+      })
+      const input = await parseUploadRequest(req)
+      expect(input.mimeType).toBe('audio/mp4')
+      expect(input.encoding).toBe('base64')
+    })
   })
 
   describe('parseUploadRequest — JSON', () => {

--- a/ui/src/__tests__/routes/api/agents.test.ts
+++ b/ui/src/__tests__/routes/api/agents.test.ts
@@ -1,0 +1,218 @@
+/**
+ * POST /api/agents/:id — auth, validation, and the fire-and-forget contract.
+ *
+ * The harness run + persistence are mocked; this asserts the route's HTTP
+ * behaviour (404/401/400/202), that it seeds the action row and kicks off the
+ * background run, and that recording storage is best-effort (a failure there
+ * still yields 202).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('../../../lib/harness-patterns/assert.server', () => ({
+  assertServerOnImport: vi.fn(),
+  assertServer: vi.fn(),
+}))
+
+type Trigger = {
+  transcribedCommand: string
+  shortDescription: string
+  recordingDocId?: string
+}
+
+const getAgent = vi.fn<(id: string) => { id: string } | undefined>()
+vi.mock('../../../lib/harness-client/registry.server', () => ({ getAgent }))
+
+const resolveActionUser = vi.fn<(secret: string | null) => string | null>()
+vi.mock('../../../lib/auth/action-tokens.server', () => ({
+  resolveActionUser,
+  // Real-ish bearer extraction so header parsing is exercised end to end.
+  bearerSecret: (h: string | null) => {
+    if (!h) return null
+    const m = /^Bearer\s+(.+)$/i.exec(h.trim())
+    return m ? m[1].trim() : null
+  },
+}))
+
+const seedActionRow =
+  vi.fn<(runId: string, userId: string, agentId: string, trigger: Trigger) => Promise<void>>(
+    async () => {},
+  )
+const runAgentInBackground =
+  vi.fn<(runId: string, userId: string, message: string, agentId: string, trigger: Trigger) => Promise<void>>(
+    async () => {},
+  )
+vi.mock('../../../lib/harness-client/action-runner.server', () => ({
+  seedActionRow,
+  runAgentInBackground,
+}))
+
+const storeDocument =
+  vi.fn<(input: { sessionId: string; filename: string; mimeType: string; content: string; encoding: string }) => Promise<{ id: string }>>(
+    async () => ({ id: 'doc-1' }),
+  )
+vi.mock('../../../lib/document-store.server', () => ({ storeDocument }))
+
+vi.mock('../../../lib/stash/upload-service.server', () => ({
+  guessMimeType: (f: string) => (f.endsWith('.m4a') ? 'audio/mp4' : 'text/plain'),
+}))
+
+vi.mock('../../../lib/session-id', () => ({ newSessionId: () => 'run-fixed' }))
+
+const { POST } = await import('../../../routes/api/agents/[id]')
+
+const BOUNDARY = '----routeboundary'
+function multipartRequest(
+  parts: Array<
+    | { name: string; value: string }
+    | { name: string; filename: string; type?: string; content: string }
+  >,
+  headers: Record<string, string> = {},
+): Request {
+  const body =
+    parts
+      .map((p) => {
+        if ('filename' in p) {
+          return (
+            `--${BOUNDARY}\r\n` +
+            `Content-Disposition: form-data; name="${p.name}"; filename="${p.filename}"\r\n` +
+            (p.type ? `Content-Type: ${p.type}\r\n` : '') +
+            `\r\n${p.content}\r\n`
+          )
+        }
+        return (
+          `--${BOUNDARY}\r\n` +
+          `Content-Disposition: form-data; name="${p.name}"\r\n\r\n${p.value}\r\n`
+        )
+      })
+      .join('') + `--${BOUNDARY}--\r\n`
+  return new Request('http://x/api/agents/default', {
+    method: 'POST',
+    headers: {
+      'Content-Type': `multipart/form-data; boundary=${BOUNDARY}`,
+      ...headers,
+    },
+    body,
+  })
+}
+
+// Minimal APIEvent shim — the route only touches params + request.
+function evt(id: string, request: Request) {
+  return { params: { id }, request } as never
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  getAgent.mockReturnValue({ id: 'default' })
+  resolveActionUser.mockReturnValue('user-1')
+  storeDocument.mockResolvedValue({ id: 'doc-1' })
+})
+
+describe('POST /api/agents/:id', () => {
+  it('404s an unknown agent before auth', async () => {
+    getAgent.mockReturnValue(undefined)
+    const res = await POST(evt('nope', multipartRequest([], { Authorization: 'Bearer s' })))
+    expect(res.status).toBe(404)
+    expect(resolveActionUser).not.toHaveBeenCalled()
+  })
+
+  it('401s a missing or unknown Bearer secret', async () => {
+    resolveActionUser.mockReturnValue(null)
+    const res = await POST(
+      evt('default', multipartRequest([{ name: 'transcribed_command', value: 'hi' }])),
+    )
+    expect(res.status).toBe(401)
+    expect(seedActionRow).not.toHaveBeenCalled()
+  })
+
+  it('400s when transcribed_command is missing', async () => {
+    const res = await POST(
+      evt(
+        'default',
+        multipartRequest([{ name: 'short_description', value: 'x' }], {
+          Authorization: 'Bearer s',
+        }),
+      ),
+    )
+    expect(res.status).toBe(400)
+    expect(seedActionRow).not.toHaveBeenCalled()
+  })
+
+  it('202s, stores the recording, seeds the row, and fires the run', async () => {
+    const res = await POST(
+      evt(
+        'default',
+        multipartRequest(
+          [
+            { name: 'transcribed_command', value: 'add a node' },
+            { name: 'short_description', value: 'Apollo' },
+            { name: 'original_recording', filename: 'memo.m4a', type: 'audio/mp4', content: 'BYTES' },
+          ],
+          { Authorization: 'Bearer s' },
+        ),
+      ),
+    )
+    expect(res.status).toBe(202)
+    expect(await res.json()).toEqual({ run_id: 'run-fixed' })
+
+    // Recording stored in the Data Stash under the run id, as base64 binary.
+    expect(storeDocument).toHaveBeenCalledTimes(1)
+    expect(storeDocument.mock.calls[0][0]).toMatchObject({
+      sessionId: 'run-fixed',
+      filename: 'memo.m4a',
+      mimeType: 'audio/mp4',
+      encoding: 'base64',
+    })
+
+    // Row seeded with the trigger provenance (incl. recording doc id).
+    expect(seedActionRow).toHaveBeenCalledTimes(1)
+    const [runId, userId, agentId, trigger] = seedActionRow.mock.calls[0]
+    expect(runId).toBe('run-fixed')
+    expect(userId).toBe('user-1')
+    expect(agentId).toBe('default')
+    expect(trigger).toMatchObject({
+      transcribedCommand: 'add a node',
+      shortDescription: 'Apollo',
+      recordingDocId: 'doc-1',
+    })
+
+    // Background run kicked off with the command.
+    expect(runAgentInBackground).toHaveBeenCalledTimes(1)
+    expect(runAgentInBackground.mock.calls[0][2]).toBe('add a node')
+  })
+
+  it('still 202s when recording storage fails (best-effort provenance)', async () => {
+    storeDocument.mockRejectedValue(new Error('redis down'))
+    const res = await POST(
+      evt(
+        'default',
+        multipartRequest(
+          [
+            { name: 'transcribed_command', value: 'cmd' },
+            { name: 'original_recording', filename: 'memo.m4a', type: 'audio/mp4', content: 'B' },
+          ],
+          { Authorization: 'Bearer s' },
+        ),
+      ),
+    )
+    expect(res.status).toBe(202)
+    // Row still seeded, but without a recording doc id.
+    const trigger = seedActionRow.mock.calls[0][3]
+    expect(trigger.recordingDocId).toBeUndefined()
+    expect(runAgentInBackground).toHaveBeenCalledTimes(1)
+  })
+
+  it('works without a recording (text-only trigger)', async () => {
+    const res = await POST(
+      evt(
+        'default',
+        multipartRequest([{ name: 'transcribed_command', value: 'cmd' }], {
+          Authorization: 'Bearer s',
+        }),
+      ),
+    )
+    expect(res.status).toBe(202)
+    expect(storeDocument).not.toHaveBeenCalled()
+    expect(seedActionRow).toHaveBeenCalledTimes(1)
+  })
+})

--- a/ui/src/components/ark-ui/ChatInterface.tsx
+++ b/ui/src/components/ark-ui/ChatInterface.tsx
@@ -17,7 +17,7 @@
  *   calls into the correct controller even after the user switches threads.
  */
 
-import { createSignal, createEffect, createMemo, onMount } from 'solid-js'
+import { createSignal, createEffect, createMemo, onMount, Show } from 'solid-js'
 import { ChatMessages, type Message } from './ChatMessages'
 import { ChatInput } from './ChatInput'
 import { AgentSelector } from './AgentSelector'
@@ -26,6 +26,7 @@ import type { ChainProgressController } from './useChainProgress'
 import {
   approveAction,
   rejectAction,
+  promoteAction,
   loadConversation,
   extractGraphFromResult,
   extractGraphElements,
@@ -80,6 +81,10 @@ export interface ChatInterfaceProps {
    *  `title_updated` SSE event after the first-turn LLM title resolves.
    *  Route patches its threads cache in-place; no refetch required. */
   onTitleUpdated?: (sessionId: string, title: string) => void
+  /** Fired after an action is promoted to a conversation (the user confirmed
+   *  sending into it). The parent flips the row's `kind` in its threads cache
+   *  so it moves from the Actions segment to Chats. */
+  onPromoted?: (sessionId: string) => void
   /** Monotonic token forwarded to ChatInput — every change focuses the
    *  composer textarea (used to land focus there after `+ New Chat`). */
   focusInputToken?: number
@@ -99,6 +104,13 @@ const WELCOME_MESSAGE: Message = {
 export const ChatInterface = (props: ChatInterfaceProps) => {
   const [messages, setMessages] = createSignal<Message[]>([])
   const [selectedAgent, setSelectedAgent] = createSignal('default')
+  // Row kind for the open thread — gates the promotion confirm on send. A
+  // brand-new chat (load throws) stays 'conversation'. Set from loadConversation.
+  const [currentKind, setCurrentKind] = createSignal<'conversation' | 'action'>('conversation')
+  // Pending promotion: holds the drafted message while the confirm modal is up.
+  // null → modal closed. Declining clears it WITHOUT sending (hard gate).
+  const [promotionDraft, setPromotionDraft] = createSignal<string | null>(null)
+  const [promoting, setPromoting] = createSignal(false)
   // Report the selected agent up to the parent (initial 'default', then on load
   // and on every change) so agent-aware UI like the Tools panel can react.
   createEffect(() => props.onSelectedAgentChange?.(selectedAgent()))
@@ -128,9 +140,14 @@ export const ChatInterface = (props: ChatInterfaceProps) => {
     prevEventCount = 0
     props.onResetForNewSession?.()
 
+    // Default to 'conversation' until the load resolves — a brand-new chat
+    // (load rejects) must never gate its first send.
+    setCurrentKind('conversation')
+
     loadConversation(sid)
       .then((loaded) => {
         setSelectedAgent(loaded.agentId)
+        setCurrentKind(loaded.kind)
         setMessages(
           loaded.messages.map((m) => ({
             id: m.id,
@@ -173,7 +190,42 @@ export const ChatInterface = (props: ChatInterfaceProps) => {
     props.onAgentChangeRequestsNewSession?.()
   }
 
-  const handleSendMessage = async (content: string) => {
+  // Promotion gate: sending into an `action` first asks the user to confirm
+  // turning it into a conversation. Declining cancels the send entirely (the
+  // draft is dropped — the user chose not to interact). Once promoted, the
+  // thread is a normal conversation and never gates again.
+  const handleSendMessage = (content: string) => {
+    if (currentKind() === 'action') {
+      setPromotionDraft(content)
+      return
+    }
+    void runSend(content)
+  }
+
+  const confirmPromotion = async () => {
+    const content = promotionDraft()
+    if (content == null || promoting()) return
+    setPromoting(true)
+    try {
+      await promoteAction(props.sessionId)
+      setCurrentKind('conversation')
+      props.onPromoted?.(props.sessionId)
+      setPromotionDraft(null)
+      void runSend(content)
+    } catch (err) {
+      console.error('[ChatInterface] promotion failed:', err)
+      // Leave the modal open so the user can retry or cancel.
+    } finally {
+      setPromoting(false)
+    }
+  }
+
+  const cancelPromotion = () => {
+    // Hard gate: drop the drafted message without sending.
+    setPromotionDraft(null)
+  }
+
+  const runSend = async (content: string) => {
     // Snapshot the active sessionId at submit time. The user may switch
     // threads mid-stream; without this, late-arriving events would corrupt
     // whichever thread happens to be in view (#47).
@@ -508,6 +560,69 @@ export const ChatInterface = (props: ChatInterfaceProps) => {
           focusToken={props.focusInputToken}
         />
       </div>
+
+      {/* Promotion confirm — shown when the user sends into an action. */}
+      <Show when={promotionDraft() != null}>
+        <div
+          data-role="promotion-confirm"
+          style={{
+            position: 'fixed',
+            inset: '0',
+            'z-index': '200',
+            display: 'flex',
+            'align-items': 'center',
+            'justify-content': 'center',
+            background: 'rgba(0,0,0,0.55)',
+          }}
+          onClick={cancelPromotion}
+        >
+          <div
+            onClick={(e) => e.stopPropagation()}
+            bg="dark-bg-secondary"
+            border="1 neon-cyan/30"
+            rounded="lg"
+            p="5"
+            shadow="2xl"
+            style={{ 'max-width': '24rem', margin: '1rem' }}
+          >
+            <div flex="~" items="center" gap="2" m="b-2">
+              <span class="i-mdi-lightning-bolt-outline" style={{ width: '20px', height: '20px', color: '#22d3ee' }} />
+              <span text="sm dark-text-primary" font="medium">Turn this action into a conversation?</span>
+            </div>
+            <p text="xs dark-text-secondary" m="b-4" style={{ 'line-height': '1.5' }}>
+              Sending a message will promote this triggered action into a regular
+              conversation. If you cancel, the message won't be sent and it stays
+              an action.
+            </p>
+            <div flex="~" gap="2" justify="end">
+              <button
+                onClick={cancelPromotion}
+                disabled={promoting()}
+                p="x-3 y-1.5"
+                rounded="md"
+                text="xs dark-text-secondary"
+                bg="transparent hover:dark-bg-hover"
+                border="1 dark-border-secondary"
+                transition="all"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={confirmPromotion}
+                disabled={promoting()}
+                p="x-3 y-1.5"
+                rounded="md"
+                text="xs white"
+                bg="cyber-700 hover:cyber-600"
+                font="medium"
+                transition="all"
+              >
+                {promoting() ? 'Promoting…' : 'Promote & send'}
+              </button>
+            </div>
+          </div>
+        </div>
+      </Show>
     </div>
   )
 }

--- a/ui/src/components/ark-ui/ChatSidebar.tsx
+++ b/ui/src/components/ark-ui/ChatSidebar.tsx
@@ -2,16 +2,28 @@ import { For, Show, createSignal } from 'solid-js'
 import { SettingsPanel } from './SettingsPanel'
 import { regenerateConversationTitle } from '../../lib/harness-client'
 
+/** Mirror of the server's ConversationKind/Status (kept local so the sidebar
+ *  has no server-module import). */
+export type ThreadKind = 'conversation' | 'action'
+export type ThreadStatus = 'running' | 'paused' | 'done' | 'error'
+
 export interface ChatThreadSummary {
   id: string
   title: string | null
   /** ISO 8601 timestamp from the server. */
   updatedAt: string
+  /** 'conversation' (chat) | 'action' (POST-triggered). Drives the filter. */
+  kind: ThreadKind
+  /** Lifted run status — drives the in-flight spinner / error badge. */
+  status: ThreadStatus
   /** Optimistic client-side row for a brand-new chat that hasn't been
    *  persisted yet. Replaced in place once the real row appears in the
    *  threadsResource refetch. */
   isPlaceholder?: boolean
 }
+
+/** The sidebar's segmented filter. */
+export type ThreadFilter = 'all' | 'conversation' | 'action'
 
 const PLACEHOLDER_TITLE = 'new chat'
 
@@ -35,9 +47,22 @@ export function mergeThreadsWithPlaceholder(
     id: placeholderId,
     title: null,
     updatedAt: nowIso(),
+    // A freshly-minted "+ New Chat" is always a chat conversation.
+    kind: 'conversation',
+    status: 'done',
     isPlaceholder: true,
   }
   return [placeholder, ...threads]
+}
+
+/** Filter threads by the selected segment. The optimistic placeholder is a
+ *  conversation, so it shows under 'all' and 'conversation' but not 'action'. */
+export function filterThreads(
+  threads: ChatThreadSummary[],
+  filter: ThreadFilter,
+): ChatThreadSummary[] {
+  if (filter === 'all') return threads
+  return threads.filter(t => t.kind === filter)
 }
 
 const formatTimestamp = (iso: string): string => {
@@ -69,9 +94,65 @@ interface ChatSidebarProps {
   onTitleRegenerated?: (sessionId: string, title: string) => void
 }
 
+/** A small status indicator for action rows: spinner while running, red dot on
+ *  error, amber dot when paused (awaiting approval). Done actions / all
+ *  conversations render nothing. */
+const StatusBadge = (props: { kind: ThreadKind; status: ThreadStatus }) => {
+  if (props.kind !== 'action') return null
+  if (props.status === 'running') {
+    return (
+      <span
+        title="Running"
+        aria-label="running"
+        class="i-mdi-loading animate-spin"
+        style={{ width: '14px', height: '14px', color: '#22d3ee', 'flex-shrink': 0 }}
+      />
+    )
+  }
+  if (props.status === 'error') {
+    return (
+      <span
+        title="Failed"
+        aria-label="error"
+        class="i-mdi-alert-circle-outline"
+        style={{ width: '14px', height: '14px', color: '#f87171', 'flex-shrink': 0 }}
+      />
+    )
+  }
+  if (props.status === 'paused') {
+    return (
+      <span
+        title="Awaiting approval"
+        aria-label="paused"
+        class="i-mdi-pause-circle-outline"
+        style={{ width: '14px', height: '14px', color: '#f59e0b', 'flex-shrink': 0 }}
+      />
+    )
+  }
+  // Done action — a subtle bolt marks it as POST-triggered without shouting.
+  return (
+    <span
+      title="Action (completed)"
+      aria-label="action"
+      class="i-mdi-lightning-bolt-outline"
+      style={{ width: '13px', height: '13px', color: '#71717a', 'flex-shrink': 0 }}
+    />
+  )
+}
+
+const FILTER_LABELS: ReadonlyArray<{ value: ThreadFilter; label: string }> = [
+  { value: 'all', label: 'All' },
+  { value: 'conversation', label: 'Chats' },
+  { value: 'action', label: 'Actions' },
+]
+
 export const ChatSidebar = (props: ChatSidebarProps) => {
   // Per-thread pending state for the ↻ button — keyed by sessionId.
   const [pendingRegen, setPendingRegen] = createSignal<ReadonlySet<string>>(new Set())
+  // Segmented Actions/Conversations/All filter (#agent-trigger). Local state —
+  // the parent passes the full thread list; we filter for display.
+  const [filter, setFilter] = createSignal<ThreadFilter>('all')
+  const visibleThreads = () => filterThreads(props.threads, filter())
 
   const handleRegenerate = async (e: MouseEvent, threadId: string) => {
     // Stop the click from also selecting the thread.
@@ -137,17 +218,43 @@ export const ChatSidebar = (props: ChatSidebarProps) => {
       {/* Thread List */}
       {!props.collapsed && (
         <>
+          {/* Segmented filter: All / Chats / Actions */}
+          <div p="x-2 t-2" flex="~" gap="1">
+            <For each={FILTER_LABELS}>
+              {(opt) => {
+                const active = () => filter() === opt.value
+                return (
+                  <button
+                    onClick={() => setFilter(opt.value)}
+                    flex="1"
+                    p="y-1"
+                    rounded="md"
+                    text={active() ? 'xs neon-cyan' : 'xs dark-text-tertiary'}
+                    bg={active() ? 'cyber-700/30' : 'transparent hover:dark-bg-hover'}
+                    border={active() ? '1 neon-cyan/40' : '1 transparent'}
+                    transition="all"
+                    font="medium"
+                    aria-pressed={active() ? 'true' : 'false'}
+                  >
+                    {opt.label}
+                  </button>
+                )
+              }}
+            </For>
+          </div>
           <div flex="1" overflow="auto">
             <Show
-              when={props.threads.length > 0}
+              when={visibleThreads().length > 0}
               fallback={
                 <div p="4" text="xs dark-text-tertiary">
-                  No conversations yet. Send a message to start.
+                  {filter() === 'action'
+                    ? 'No actions yet. Trigger one via POST /api/agents/:id.'
+                    : 'No conversations yet. Send a message to start.'}
                 </div>
               }
             >
               <div p="2" space="y-1">
-                <For each={props.threads}>
+                <For each={visibleThreads()}>
                   {(thread) => {
                     const isSelected = () => thread.id === props.selectedId
                     const isRegenerating = () => pendingRegen().has(thread.id)
@@ -167,15 +274,18 @@ export const ChatSidebar = (props: ChatSidebarProps) => {
                         relative=""
                         class="group"
                       >
-                        <div
-                          text={thread.isPlaceholder ? 'sm dark-text-tertiary' : 'sm dark-text-primary'}
-                          font={thread.isPlaceholder ? 'normal italic' : 'medium'}
-                          truncate
-                          pr="6"
-                        >
-                          {thread.isPlaceholder
-                            ? PLACEHOLDER_TITLE
-                            : thread.title ?? '(untitled)'}
+                        <div flex="~" items="center" gap="1.5" pr="6">
+                          <StatusBadge kind={thread.kind} status={thread.status} />
+                          <div
+                            text={thread.isPlaceholder ? 'sm dark-text-tertiary' : 'sm dark-text-primary'}
+                            font={thread.isPlaceholder ? 'normal italic' : 'medium'}
+                            truncate
+                            flex="1"
+                          >
+                            {thread.isPlaceholder
+                              ? PLACEHOLDER_TITLE
+                              : thread.title ?? '(untitled)'}
+                          </div>
                         </div>
                         <div text="xs dark-text-tertiary" m="t-1">
                           {formatTimestamp(thread.updatedAt)}

--- a/ui/src/components/ark-ui/DataStashPanel.tsx
+++ b/ui/src/components/ark-ui/DataStashPanel.tsx
@@ -83,16 +83,33 @@ function getRefLabel(tool: string, eventId: string): string {
   return `${key}:${shortId}`
 }
 
+/** Audio extensions we render with a player (matches upload-service MIME map). */
+const AUDIO_EXT_RE = /\.(m4a|mp3|wav|aac|ogg|oga|opus|flac|caf)$/i
+
+/** Whether a document is playable audio (a voice recording from the agent
+ *  trigger endpoint, or any uploaded audio file). */
+function isAudioDoc(doc: StashDocumentMeta): boolean {
+  return doc.mimeType.toLowerCase().startsWith('audio/') || AUDIO_EXT_RE.test(doc.filename)
+}
+
 /** Icon for an uploaded document, chosen from its MIME type / extension. */
 function getDocIcon(mimeType: string, filename: string): string {
   const m = mimeType.toLowerCase()
   const f = filename.toLowerCase()
+  if (m.startsWith('audio/') || AUDIO_EXT_RE.test(f)) return 'i-mdi-microphone'
   if (m.includes('json') || f.endsWith('.json')) return 'i-mdi-code-json'
   if (m.includes('csv') || m.includes('tab-separated') || f.endsWith('.csv')) return 'i-mdi-table-large'
   if (m.includes('markdown') || f.endsWith('.md')) return 'i-mdi-language-markdown-outline'
   if (m.includes('pdf') || f.endsWith('.pdf')) return 'i-mdi-file-pdf-box'
   if (m.includes('html') || m.includes('xml')) return 'i-mdi-file-code-outline'
   return 'i-mdi-file-document-outline'
+}
+
+/** URL that streams a document's raw bytes (base64-decoded for binary). Used as
+ *  the `<audio>` src — the `?download` Content-Disposition is ignored by media
+ *  elements, so the same route serves both download and playback. */
+function docDownloadUrl(id: string, sessionId: string): string {
+  return `/api/stash/document/${encodeURIComponent(id)}?sessionId=${encodeURIComponent(sessionId)}&download`
 }
 
 /** Format a byte count compactly (e.g. 2.4 KB). */
@@ -386,12 +403,16 @@ const IconGallery = (props: { items: ToolResultItem[]; onAction: (id: string, ac
 
 const DocChip = (props: {
   doc: StashDocumentMeta
+  sessionId: string
   onAction: (id: string, action: DocAction) => Promise<void>
 }) => {
   const d = () => props.doc
   const grayed = () => !!(d().hidden || d().archived)
   const [loading, setLoading] = createSignal(false)
   const [menuOpen, setMenuOpen] = createSignal(false)
+  // Inline audio player toggle (recordings from the agent trigger endpoint).
+  const [playing, setPlaying] = createSignal(false)
+  const isAudio = () => isAudioDoc(d())
 
   const handle = async (action: DocAction) => {
     setMenuOpen(false)
@@ -477,6 +498,31 @@ const DocChip = (props: {
             'box-shadow': '0 4px 16px rgba(0,0,0,0.4)',
           }}
         >
+          {/* Play toggle — local (audio only), not a server action. */}
+          <Show when={isAudio()}>
+            <button
+              onClick={() => {
+                setPlaying((p) => !p)
+                setMenuOpen(false)
+              }}
+              style={{
+                display: 'block',
+                width: '100%',
+                padding: '5px 10px',
+                'text-align': 'left',
+                background: 'transparent',
+                border: 'none',
+                'border-radius': '4px',
+                'font-size': '11px',
+                color: '#22d3ee',
+                cursor: 'pointer',
+              }}
+              onMouseEnter={(e) => (e.currentTarget.style.background = '#22222f')}
+              onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
+            >
+              {playing() ? 'Hide player' : 'Play'}
+            </button>
+          </Show>
           <For each={menuActions()}>
             {(btn) => (
               <button
@@ -508,6 +554,19 @@ const DocChip = (props: {
           style={{ position: 'fixed', inset: '0', 'z-index': '99' }}
           onClick={() => setMenuOpen(false)}
         />
+      </Show>
+
+      {/* Inline audio player — toggled from the Play menu item. Sits below the
+          chip; the ?download route streams the recording's bytes. */}
+      <Show when={isAudio() && playing()}>
+        <div style={{ position: 'absolute', top: '100%', left: '0', 'z-index': '101', 'margin-top': '2px' }}>
+          <audio
+            controls
+            autoplay
+            src={docDownloadUrl(d().id, props.sessionId)}
+            style={{ width: '180px', height: '32px' }}
+          />
+        </div>
       </Show>
     </div>
   )
@@ -733,7 +792,7 @@ export const DataStashPanel = (props: DataStashPanelProps) => {
         <Show when={docs().length > 0}>
           <div flex="~ wrap" gap="2" p="x-3 y-2">
             <For each={docs()}>
-              {(doc) => <DocChip doc={doc} onAction={handleDocAction} />}
+              {(doc) => <DocChip doc={doc} sessionId={props.sessionId} onAction={handleDocAction} />}
             </For>
           </div>
         </Show>

--- a/ui/src/lib/auth/action-tokens.server.ts
+++ b/ui/src/lib/auth/action-tokens.server.ts
@@ -1,0 +1,108 @@
+/**
+ * Action API tokens — Server Only
+ *
+ * Resolves the `Authorization: Bearer <secret>` presented to
+ * `POST /api/agents/:id` into the userId that owns the resulting action rows.
+ *
+ * Secrets live in a git-ignored `configs/action-tokens.yaml` (mirroring
+ * `configs/mcp-config.yaml`); see `configs/template.action-tokens.yaml` for the
+ * shape. The file is parsed once and cached for the process lifetime — like
+ * `server-catalog.server.ts`, config is treated as static within a run.
+ *
+ * Shape:
+ *   tokens:
+ *     - label: "iphone"            # optional, bookkeeping only
+ *       secret: "<long-random>"
+ *       userId: "<stack-auth-id>"
+ */
+
+import { readFileSync, existsSync } from "node:fs";
+import path from "node:path";
+import { parse as parseYaml } from "yaml";
+import { assertServerOnImport } from "../harness-patterns/assert.server";
+
+assertServerOnImport();
+
+interface TokenEntry {
+  secret: string;
+  userId: string;
+  label?: string;
+}
+
+/**
+ * Parse the YAML text into a `secret → userId` map. Pure (no filesystem) so it
+ * can be unit-tested directly. Tolerant of a missing/empty `tokens` list and
+ * skips entries without a non-empty `secret` and `userId`.
+ */
+export function parseActionTokens(yamlText: string): Map<string, string> {
+  const out = new Map<string, string>();
+  let doc: unknown;
+  try {
+    doc = parseYaml(yamlText);
+  } catch {
+    return out;
+  }
+  const tokens = (doc as { tokens?: unknown })?.tokens;
+  if (!Array.isArray(tokens)) return out;
+  for (const raw of tokens) {
+    const entry = raw as Partial<TokenEntry>;
+    const secret = typeof entry.secret === "string" ? entry.secret.trim() : "";
+    const userId = typeof entry.userId === "string" ? entry.userId.trim() : "";
+    if (secret && userId) out.set(secret, userId);
+  }
+  return out;
+}
+
+/** `process.cwd()` is the `ui/` dir, so repo-root `configs/` is one level up.
+ *  Mirror `server-catalog.server.ts`'s candidate resolution. */
+function resolveConfigPath(file: string): string | null {
+  const candidates = [
+    path.resolve(process.cwd(), "..", "configs", file),
+    path.resolve(process.cwd(), "configs", file),
+    path.resolve(process.cwd(), "..", "..", "configs", file),
+  ];
+  return candidates.find((p) => existsSync(p)) ?? null;
+}
+
+let tokenCache: Map<string, string> | null = null;
+
+function loadTokens(): Map<string, string> {
+  if (tokenCache) return tokenCache;
+  const file = resolveConfigPath("action-tokens.yaml");
+  if (!file) {
+    console.warn(
+      "[action-tokens] configs/action-tokens.yaml not found — POST /api/agents/:id will reject all requests. Copy configs/template.action-tokens.yaml to set it up.",
+    );
+    tokenCache = new Map();
+    return tokenCache;
+  }
+  try {
+    tokenCache = parseActionTokens(readFileSync(file, "utf8"));
+  } catch (err) {
+    console.error("[action-tokens] failed to read action-tokens.yaml:", err);
+    tokenCache = new Map();
+  }
+  return tokenCache;
+}
+
+/**
+ * Resolve a Bearer secret to its userId, or null when unknown/blank. A blank
+ * secret never matches (we never store blank keys), so an absent header maps to
+ * null rather than the first entry.
+ */
+export function resolveActionUser(secret: string | null | undefined): string | null {
+  if (!secret) return null;
+  return loadTokens().get(secret) ?? null;
+}
+
+/** Extract the Bearer credential from an `Authorization` header, or null. */
+export function bearerSecret(authHeader: string | null): string | null {
+  if (!authHeader) return null;
+  const m = /^Bearer\s+(.+)$/i.exec(authHeader.trim());
+  return m ? m[1].trim() : null;
+}
+
+/** Test-only: drop the cached config so a test can swap the file under it. */
+export function __resetActionTokenCache(): void {
+  tokenCache = null;
+}

--- a/ui/src/lib/db/client.server.ts
+++ b/ui/src/lib/db/client.server.ts
@@ -42,6 +42,23 @@ const SCHEMA_SQL = `
   );
   CREATE INDEX IF NOT EXISTS conversations_user_updated_idx
     ON conversations (user_id, updated_at DESC);
+
+  -- Agent-trigger endpoint: a row is either a chat 'conversation' or a
+  -- POST-triggered 'action'. These columns are added via ALTER (not in the
+  -- CREATE above) so EXISTING databases pick them up too — the CREATE only runs
+  -- when the table is absent. The defaults backfill existing rows correctly:
+  -- everything created before this migration is a completed chat conversation.
+  --   kind    — mutable; promotion flips 'action' -> 'conversation'.
+  --   source  — immutable provenance ('chat' | 'post').
+  --   status  — copy of UnifiedContext.status, for cheap list filtering + badge.
+  ALTER TABLE conversations
+    ADD COLUMN IF NOT EXISTS kind   TEXT NOT NULL DEFAULT 'conversation';
+  ALTER TABLE conversations
+    ADD COLUMN IF NOT EXISTS source TEXT NOT NULL DEFAULT 'chat';
+  ALTER TABLE conversations
+    ADD COLUMN IF NOT EXISTS status TEXT NOT NULL DEFAULT 'done';
+  CREATE INDEX IF NOT EXISTS conversations_user_kind_updated_idx
+    ON conversations (user_id, kind, updated_at DESC);
 `
 
 async function initSchema(): Promise<void> {

--- a/ui/src/lib/db/conversations.server.ts
+++ b/ui/src/lib/db/conversations.server.ts
@@ -10,6 +10,13 @@ import { query } from './client.server'
 
 assertServerOnImport()
 
+/** Whether a row is a chat conversation or a POST-triggered agent action. */
+export type ConversationKind = 'conversation' | 'action'
+/** Immutable provenance: where the row originated. */
+export type ConversationSource = 'chat' | 'post'
+/** Lifted copy of UnifiedContext.status for cheap list filtering + UI badge. */
+export type ConversationStatus = 'running' | 'paused' | 'done' | 'error'
+
 export interface ConversationRow {
   id: string
   userId: string
@@ -17,6 +24,9 @@ export interface ConversationRow {
   title: string | null
   /** Stringified UnifiedContext (matches serializeContext() output). */
   serializedContext: string
+  kind: ConversationKind
+  source: ConversationSource
+  status: ConversationStatus
   createdAt: Date
   updatedAt: Date
 }
@@ -25,6 +35,9 @@ export interface ConversationListItem {
   id: string
   agentId: string
   title: string | null
+  kind: ConversationKind
+  source: ConversationSource
+  status: ConversationStatus
   updatedAt: Date
 }
 
@@ -35,6 +48,9 @@ interface DbRow {
   title: string | null
   /** pg returns JSONB columns as already-parsed JS objects. */
   context: unknown
+  kind: ConversationKind
+  source: ConversationSource
+  status: ConversationStatus
   created_at: Date
   updated_at: Date
 }
@@ -43,6 +59,9 @@ interface DbListRow {
   id: string
   agent_id: string
   title: string | null
+  kind: ConversationKind
+  source: ConversationSource
+  status: ConversationStatus
   updated_at: Date
 }
 
@@ -53,6 +72,9 @@ function rowToConversation(row: DbRow): ConversationRow {
     agentId: row.agent_id,
     title: row.title,
     serializedContext: JSON.stringify(row.context),
+    kind: row.kind,
+    source: row.source,
+    status: row.status,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   }
@@ -67,7 +89,7 @@ export async function loadConversation(
   userId: string
 ): Promise<ConversationRow | null> {
   const { rows } = await query<DbRow>(
-    'SELECT id, user_id, agent_id, title, context, created_at, updated_at FROM conversations WHERE id = $1 AND user_id = $2',
+    'SELECT id, user_id, agent_id, title, context, kind, source, status, created_at, updated_at FROM conversations WHERE id = $1 AND user_id = $2',
     [id, userId]
   )
   if (rows.length === 0) return null
@@ -82,22 +104,47 @@ export interface SaveConversationInput {
   title: string | null
   /** Full serializeContext() output. Stored as JSONB. */
   serializedContext: string
+  /**
+   * Lifted copy of the context status, refreshed on every save so the sidebar
+   * can filter/badge without deserializing the blob. Defaults to 'running'.
+   */
+  status?: ConversationStatus
+  /**
+   * Row kind. Only honoured on INSERT — `kind` is immutable through this upsert
+   * path (promotion uses {@link promoteConversation}), so an existing action
+   * stays an action across the background run's status saves. Default
+   * 'conversation' (the chat path).
+   */
+  kind?: ConversationKind
+  /**
+   * Immutable provenance. Only honoured on INSERT (never updated). Default
+   * 'chat'. The POST-trigger route passes 'post'.
+   */
+  source?: ConversationSource
 }
 
 /**
- * Upsert a conversation row. Title is sticky: once set it never changes via
- * this path (use a dedicated rename action when we ship one).
+ * Upsert a conversation row.
+ *
+ * Stickiness on UPDATE (ON CONFLICT):
+ *   - `title`           — sticky via COALESCE (a dedicated rename overrides it).
+ *   - `kind` / `source` — NOT in the UPDATE set, so they keep their INSERT
+ *     values. This is what lets the route insert `kind='action'` once and have
+ *     the background run's later status saves preserve it. Promotion is the
+ *     only mutator of `kind` (see {@link promoteConversation}).
+ *   - `status`          — always refreshed from the latest context.
  */
 export async function saveConversation(
   input: SaveConversationInput
 ): Promise<void> {
   await query(
-    `INSERT INTO conversations (id, user_id, agent_id, title, context)
-     VALUES ($1, $2, $3, $4, $5::jsonb)
+    `INSERT INTO conversations (id, user_id, agent_id, title, context, kind, source, status)
+     VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7, $8)
      ON CONFLICT (id) DO UPDATE SET
        agent_id   = EXCLUDED.agent_id,
        context    = EXCLUDED.context,
        title      = COALESCE(conversations.title, EXCLUDED.title),
+       status     = EXCLUDED.status,
        updated_at = NOW()`,
     [
       input.id,
@@ -105,7 +152,43 @@ export async function saveConversation(
       input.agentId,
       input.title,
       input.serializedContext,
+      input.kind ?? 'conversation',
+      input.source ?? 'chat',
+      input.status ?? 'running',
     ]
+  )
+}
+
+/**
+ * Promote an action to a regular conversation (flip `kind`). Scoped by
+ * user_id, so a wrong userId silently no-ops. Idempotent — promoting an
+ * already-promoted row is a harmless no-op write.
+ */
+export async function promoteConversation(
+  id: string,
+  userId: string
+): Promise<void> {
+  await query(
+    `UPDATE conversations SET kind = 'conversation', updated_at = NOW()
+     WHERE id = $1 AND user_id = $2 AND kind = 'action'`,
+    [id, userId]
+  )
+}
+
+/**
+ * Update only the lifted `status` column (no context write). Used by the
+ * background runner's failure path to flip a stuck 'running' row to 'error'
+ * when the run threw before producing a serialized context. Scoped by user_id.
+ */
+export async function setConversationStatus(
+  id: string,
+  userId: string,
+  status: ConversationStatus
+): Promise<void> {
+  await query(
+    `UPDATE conversations SET status = $1, updated_at = NOW()
+     WHERE id = $2 AND user_id = $3`,
+    [status, id, userId]
   )
 }
 
@@ -116,13 +199,16 @@ export async function listConversations(
   userId: string
 ): Promise<ConversationListItem[]> {
   const { rows } = await query<DbListRow>(
-    'SELECT id, agent_id, title, updated_at FROM conversations WHERE user_id = $1 ORDER BY updated_at DESC LIMIT 200',
+    'SELECT id, agent_id, title, kind, source, status, updated_at FROM conversations WHERE user_id = $1 ORDER BY updated_at DESC LIMIT 200',
     [userId]
   )
   return rows.map((r) => ({
     id: r.id,
     agentId: r.agent_id,
     title: r.title,
+    kind: r.kind,
+    source: r.source,
+    status: r.status,
     updatedAt: r.updated_at,
   }))
 }

--- a/ui/src/lib/harness-client/action-runner.server.ts
+++ b/ui/src/lib/harness-client/action-runner.server.ts
@@ -1,0 +1,118 @@
+/**
+ * POST-triggered Action Runner — Server Only
+ *
+ * In-process fire-and-forget execution for the `POST /api/agents/:id` endpoint.
+ *
+ * Deliberately NOT a `"use server"` module: every export of a `"use server"`
+ * file becomes a client-callable RPC endpoint, and these functions take a
+ * `userId` parameter (the route resolves it from the Bearer secret). Exposing
+ * them as RPCs would let a client run an agent as any user. Keeping them here —
+ * imported only by the route — means they're plain server-side functions.
+ *
+ * Flow (see `routes/api/agents/[id].ts`):
+ *   1. Route authenticates + parses multipart, stores the recording in the
+ *      Data Stash, then calls `seedActionRow` to insert the observable row.
+ *   2. Route calls `runAgentInBackground` WITHOUT awaiting and returns 202.
+ *   3. This module runs the harness to completion and persists the result.
+ */
+
+import { assertServerOnImport } from "../harness-patterns/assert.server";
+import { harness, createContext, serializeContext } from "../harness-patterns";
+import { getOrBuildPatterns, saveSession, type SessionData } from "./session.server";
+import { runWithUserId } from "./request-user.server";
+import {
+  saveConversation as dbSaveConversation,
+  setConversationStatus as dbSetConversationStatus,
+} from "../db/conversations.server";
+
+assertServerOnImport();
+
+/**
+ * Trigger provenance, stored at `ctx.data.trigger` for POST-triggered runs.
+ * The recording itself lives in the Data Stash (keyed by the run id) — here we
+ * only keep the raw transcription, the human-readable description, and a
+ * pointer to the stored recording document.
+ */
+export interface ActionTrigger {
+  /** Raw `transcribed_command` — the harness input verbatim. */
+  transcribedCommand: string;
+  /** `short_description` — also lifted to the sticky `title` column. */
+  shortDescription: string;
+  /** Data Stash document id of the stored `original_recording` (if stored). */
+  recordingDocId?: string;
+  /** Original recording filename, for display. */
+  recordingFilename?: string;
+  /** Original recording MIME type, for the audio player. */
+  recordingMimeType?: string;
+}
+
+/**
+ * Insert the initial `action` row so the run is observable (status spinner)
+ * the instant the route returns 202 — before the background harness completes.
+ *
+ * The seeded context is a minimal, valid `UnifiedContext` carrying just the
+ * trigger command as the first user_message (so the thread replays it) plus
+ * `data.trigger`. The background run produces its own context and overwrites
+ * this blob via `saveSession`; the row's `kind`/`source`/sticky `title`
+ * survive that overwrite (see `saveConversation`).
+ */
+export async function seedActionRow(
+  runId: string,
+  userId: string,
+  agentId: string,
+  trigger: ActionTrigger,
+): Promise<void> {
+  const ctx = createContext(
+    trigger.transcribedCommand,
+    { trigger } as Partial<SessionData>,
+    runId,
+  );
+  await dbSaveConversation({
+    id: runId,
+    userId,
+    agentId,
+    title: trigger.shortDescription || null,
+    serializedContext: serializeContext(ctx),
+    kind: "action",
+    source: "post",
+    status: "running",
+  });
+}
+
+/**
+ * Run an agent to completion for a POST-triggered action, off the request
+ * path. The route inserts the row (via {@link seedActionRow}) and calls this
+ * WITHOUT awaiting, so the HTTP response is already sent. On completion the
+ * serialized context + lifted status are persisted; on an unexpected throw the
+ * row is flipped to `error` so it never sticks on `running`.
+ *
+ * Always a fresh first run — it never `continueSession`s the seeded
+ * placeholder (which would duplicate the user_message). Wrapped in
+ * `runWithUserId` so pattern closures resolve the owner; settings fall back to
+ * `DEFAULT_SETTINGS` (no request-scoped settings off the request path). The
+ * harness itself never throws (it catches internally and returns an `error`
+ * status), so the catch here only guards pattern-construction failures.
+ */
+export async function runAgentInBackground(
+  runId: string,
+  userId: string,
+  message: string,
+  agentId: string,
+  trigger: ActionTrigger,
+): Promise<void> {
+  try {
+    await runWithUserId(userId, async () => {
+      const patterns = await getOrBuildPatterns(runId, agentId);
+      const agent = harness(...patterns);
+      const result = await agent(message, runId, {
+        trigger,
+      } as Partial<SessionData>);
+      await saveSession(runId, userId, agentId, result.serialized);
+    });
+  } catch (err) {
+    console.error(`[action] background run failed for ${runId}:`, err);
+    // The seeded row exists with status='running'; flip it so the UI doesn't
+    // spin forever. Best-effort — a DB failure here is already logged above.
+    await dbSetConversationStatus(runId, userId, "error").catch(() => {});
+  }
+}

--- a/ui/src/lib/harness-client/actions.server.ts
+++ b/ui/src/lib/harness-client/actions.server.ts
@@ -26,7 +26,13 @@ import {
   type SessionData,
 } from "./session.server";
 import { getAgent, getAgentMetadata } from "./registry.server";
-import { listConversations as dbListConversations } from "../db/conversations.server";
+import {
+  listConversations as dbListConversations,
+  promoteConversation as dbPromoteConversation,
+  type ConversationKind,
+  type ConversationSource,
+  type ConversationStatus,
+} from "../db/conversations.server";
 import type { HarnessSettings } from "../settings";
 import { runWithSettings } from "../settings-context.server";
 import { getAuthenticatedUser } from "../auth/server";
@@ -130,6 +136,16 @@ async function runTurn(
 }
 
 /**
+ * Promote an action to a regular conversation (flip `kind`). Bound to the
+ * sidebar's confirm-on-send gate. Scoped to the current user. Self-
+ * authenticating — safe to expose as a server action.
+ */
+export async function promoteAction(sessionId: string): Promise<void> {
+  const user = await requireUser();
+  await dbPromoteConversation(sessionId, user.id);
+}
+
+/**
  * Approve a pending action.
  */
 export async function approveAction(
@@ -201,6 +217,12 @@ export interface ConversationSummary {
   id: string;
   agentId: string;
   title: string | null;
+  /** 'conversation' | 'action' — drives the sidebar's segmented filter. */
+  kind: ConversationKind;
+  /** 'chat' | 'post' — immutable provenance. */
+  source: ConversationSource;
+  /** Lifted status — drives the in-flight spinner/badge. */
+  status: ConversationStatus;
   /** ISO 8601 — Date doesn't survive server-action serialization unscathed. */
   updatedAt: string;
 }
@@ -225,6 +247,9 @@ export async function listConversations(): Promise<ConversationSummary[]> {
     id: r.id,
     agentId: r.agentId,
     title: r.title,
+    kind: r.kind,
+    source: r.source,
+    status: r.status,
     updatedAt: r.updatedAt.toISOString(),
   }));
 }
@@ -238,6 +263,10 @@ export interface LoadedConversation {
   id: string;
   agentId: string;
   messages: ReplayedMessage[];
+  /** Row kind — the chat view reads this to gate the promotion confirm on
+   *  send (only actions prompt). Authoritative (from the DB), unlike the
+   *  possibly-stale sidebar threads cache. */
+  kind: ConversationKind;
   /** Serialized UnifiedContext. The events array can be replayed by the UI
    *  to repopulate the graph and observability panel. */
   serialized: string;
@@ -261,6 +290,7 @@ export async function loadConversation(
     id: sessionId,
     agentId: loaded.agentId,
     messages,
+    kind: loaded.kind,
     serialized: loaded.serializedContext,
   };
 }

--- a/ui/src/lib/harness-client/index.ts
+++ b/ui/src/lib/harness-client/index.ts
@@ -11,6 +11,7 @@ export {
   processMessageWithAgent,
   approveAction,
   rejectAction,
+  promoteAction,
   clearSession,
   getAgentList,
   listConversations,

--- a/ui/src/lib/harness-client/session.server.ts
+++ b/ui/src/lib/harness-client/session.server.ts
@@ -24,6 +24,8 @@ import {
   saveConversation,
   deleteConversation,
   deriveTitle,
+  type ConversationKind,
+  type ConversationStatus,
 } from '../db/conversations.server'
 
 assertServerOnImport()
@@ -88,6 +90,11 @@ export function evictPatterns(sessionId: string): void {
 export interface LoadedSession {
   serializedContext: string
   agentId: string
+  /** Row kind — the promotion gate reads this to decide whether sending into
+   *  the thread should prompt "turn this action into a conversation?". */
+  kind: ConversationKind
+  /** Lifted status copy — surfaced so callers don't re-deserialize the blob. */
+  status: ConversationStatus
 }
 
 /** Load a serialized context for (sessionId, userId), or null if not found. */
@@ -97,7 +104,12 @@ export async function loadSession(
 ): Promise<LoadedSession | null> {
   const row = await loadConversation(sessionId, userId)
   if (!row) return null
-  return { serializedContext: row.serializedContext, agentId: row.agentId }
+  return {
+    serializedContext: row.serializedContext,
+    agentId: row.agentId,
+    kind: row.kind,
+    status: row.status,
+  }
 }
 
 /**
@@ -112,12 +124,18 @@ export async function saveSession(
   serializedContext: string
 ): Promise<void> {
   const title = extractTitleFromContext(serializedContext)
+  const status = extractStatusFromContext(serializedContext)
   await saveConversation({
     id: sessionId,
     userId,
     agentId,
     title,
     serializedContext,
+    status,
+    // kind/source omitted → only used on the row's first INSERT (a fresh chat
+    // defaults to 'conversation'/'chat'). For an already-inserted action row
+    // the ON CONFLICT UPDATE leaves kind/source untouched, so this save just
+    // refreshes context + status without demoting the action.
   })
 }
 
@@ -158,6 +176,31 @@ function extractTitleFromContext(serializedContext: string): string | null {
     return deriveTitle(content)
   } catch {
     return null
+  }
+}
+
+/**
+ * Lift `status` out of the serialized context so it can be stored in its own
+ * column, mapping it to the terminal value a *persisted* turn should carry.
+ *
+ * Key subtlety: the harness never flips a successful run to 'done' — `runChain`
+ * leaves `ctx.status === 'running'` and the synthesizer emits the final
+ * assistant_message directly (harness.server.ts's `status === 'done'` push is
+ * effectively dead). Since `saveSession` is only ever called *after* the
+ * harness returns, a persisted 'running' means "completed, never flipped" → we
+ * store it as 'done'. The genuinely in-flight 'running' badge comes solely from
+ * `seedActionRow`, which writes the column directly and bypasses this path.
+ * 'paused' (awaiting approval) and 'error' are explicit and preserved as-is.
+ */
+function extractStatusFromContext(serializedContext: string): ConversationStatus {
+  try {
+    const ctx = deserializeContext<Record<string, unknown>>(serializedContext)
+    const status = ctx.status as ConversationStatus | undefined
+    if (status === 'paused' || status === 'error') return status
+    // 'running' (completed-but-unflipped), 'done', or anything unexpected → done.
+    return 'done'
+  } catch {
+    return 'done'
   }
 }
 

--- a/ui/src/lib/stash/upload-service.server.ts
+++ b/ui/src/lib/stash/upload-service.server.ts
@@ -49,6 +49,18 @@ const MIME_BY_EXT: Record<string, string> = {
   webp: 'image/webp',
   zip: 'application/zip',
   parquet: 'application/vnd.apache.parquet',
+  // Audio — the agent-trigger endpoint stores voice recordings here. Mapped so
+  // a file arriving without a usable `blob.type` is still classified binary
+  // (audio/* fails isTextMime → base64) rather than corrupted as UTF-8 text.
+  m4a: 'audio/mp4',
+  mp3: 'audio/mpeg',
+  wav: 'audio/wav',
+  aac: 'audio/aac',
+  ogg: 'audio/ogg',
+  oga: 'audio/ogg',
+  opus: 'audio/opus',
+  flac: 'audio/flac',
+  caf: 'audio/x-caf',
 }
 
 /** Best-effort MIME from a filename extension; defaults to `text/plain`. */

--- a/ui/src/routes/api/agents/[id].ts
+++ b/ui/src/routes/api/agents/[id].ts
@@ -1,0 +1,133 @@
+/**
+ * Agent Trigger Endpoint
+ *
+ *   POST /api/agents/:id
+ *     Authorization: Bearer <shared-secret>   → resolves to a userId
+ *     Body: multipart/form-data
+ *       transcribed_command  (text) → harness input
+ *       short_description     (text) → sticky conversation title
+ *       original_recording    (file) → stored in the Data Stash for provenance
+ *                                        + playback (keyed by the run id)
+ *   → 202 { run_id }     # run_id == sessionId == conversation row id
+ *
+ * Fires a fixed agent (per :id) asynchronously, in-process: the row is
+ * persisted as a `kind='action'` conversation (status='running'), the run is
+ * kicked off WITHOUT awaiting, and 202 returns immediately. See
+ * `action-runner.server.ts` for the execution model and `INSTRUCTIONS.md` for
+ * the design + the persistent-node-server caveat.
+ */
+
+import type { APIEvent } from "@solidjs/start/server";
+import { getAgent } from "../../../lib/harness-client/registry.server";
+import {
+  bearerSecret,
+  resolveActionUser,
+} from "../../../lib/auth/action-tokens.server";
+import {
+  seedActionRow,
+  runAgentInBackground,
+  type ActionTrigger,
+} from "../../../lib/harness-client/action-runner.server";
+import { storeDocument } from "../../../lib/document-store.server";
+import { guessMimeType } from "../../../lib/stash/upload-service.server";
+import { newSessionId } from "../../../lib/session-id";
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export async function POST(event: APIEvent) {
+  const agentId = event.params.id;
+
+  // 1. Unknown agent → 404, before doing anything else.
+  if (!getAgent(agentId)) {
+    return json({ error: `Unknown agent: ${agentId}` }, 404);
+  }
+
+  // 2. Bearer secret → userId (per-device map in configs/action-tokens.yaml).
+  const userId = resolveActionUser(
+    bearerSecret(event.request.headers.get("authorization")),
+  );
+  if (!userId) {
+    return json({ error: "Unauthorized" }, 401);
+  }
+
+  // 3. Parse the multipart body.
+  let form: FormData;
+  try {
+    form = await event.request.formData();
+  } catch {
+    return json({ error: "multipart/form-data body required" }, 400);
+  }
+
+  const transcribedCommand = String(
+    form.get("transcribed_command") ?? "",
+  ).trim();
+  if (!transcribedCommand) {
+    return json({ error: "transcribed_command is required" }, 400);
+  }
+  const shortDescription = String(form.get("short_description") ?? "").trim();
+
+  const runId = newSessionId();
+
+  // 4. Store the recording in the Data Stash (keyed by runId, so it surfaces in
+  //    that conversation's "Your Uploads" and is playable via ?download).
+  //    Best-effort: a storage failure (e.g. Redis down) must not block the run.
+  let recording: Pick<
+    ActionTrigger,
+    "recordingDocId" | "recordingFilename" | "recordingMimeType"
+  > = {};
+  const file = form.get("original_recording");
+  if (
+    file != null &&
+    typeof file !== "string" &&
+    typeof (file as Blob).arrayBuffer === "function"
+  ) {
+    const blob = file as File;
+    const filename = blob.name || "recording";
+    const mimeType = blob.type || guessMimeType(filename);
+    try {
+      const bytes = Buffer.from(await blob.arrayBuffer()).toString("base64");
+      const doc = await storeDocument({
+        sessionId: runId,
+        filename,
+        mimeType,
+        content: bytes,
+        encoding: "base64",
+      });
+      recording = {
+        recordingDocId: doc.id,
+        recordingFilename: filename,
+        recordingMimeType: mimeType,
+      };
+    } catch (err) {
+      console.error(`[action] failed to store recording for ${runId}:`, err);
+    }
+  }
+
+  const trigger: ActionTrigger = {
+    transcribedCommand,
+    shortDescription,
+    ...recording,
+  };
+
+  // 5. Insert the observable row before returning, so the action is visible
+  //    (with a running spinner) the moment the caller gets its 202.
+  try {
+    await seedActionRow(runId, userId, agentId, trigger);
+  } catch (err) {
+    console.error(`[action] failed to seed action row for ${runId}:`, err);
+    return json({ error: "Failed to create action" }, 500);
+  }
+
+  // 6. Fire-and-forget the harness run. Intentionally NOT awaited — the run
+  //    persists its own result/status on completion (persistent-node-server
+  //    assumption; see INSTRUCTIONS.md).
+  void runAgentInBackground(runId, userId, transcribedCommand, agentId, trigger);
+
+  // 7. 202 Accepted — run_id is the sessionId / conversation row id.
+  return json({ run_id: runId }, 202);
+}

--- a/ui/src/routes/index.tsx
+++ b/ui/src/routes/index.tsx
@@ -50,6 +50,26 @@ export default function Home() {
     mutateThreads(list => (list ?? []).map(t => (t.id === sid ? { ...t, title } : t)))
   }
 
+  // Promotion: flip the row's kind in-place so it moves from Actions to Chats.
+  const handlePromoted = (sid: string) => {
+    mutateThreads(list =>
+      (list ?? []).map(t => (t.id === sid ? { ...t, kind: 'conversation' as const } : t)),
+    )
+  }
+
+  // Background actions complete off any browser channel, so poll the list while
+  // at least one action is still `running` to surface the running→done flip.
+  // The effect re-runs on every threads() change; it only arms an interval when
+  // a running action exists, and clears it as soon as none remain.
+  createEffect(() => {
+    const hasRunningAction = (threads() ?? []).some(
+      t => t.kind === 'action' && t.status === 'running',
+    )
+    if (!hasRunningAction) return
+    const interval = setInterval(() => refetchThreads(), 5000)
+    onCleanup(() => clearInterval(interval))
+  })
+
   // ===========================================================================
   // Per-session progress + run state (#47)
   // ===========================================================================
@@ -276,6 +296,7 @@ export default function Home() {
                 registerAbortController={registerAbortController}
                 unregisterAbortController={unregisterAbortController}
                 onTitleUpdated={handleTitleUpdated}
+                onPromoted={handlePromoted}
                 focusInputToken={focusInputToken()}
               />
             </div>


### PR DESCRIPTION
## What

Adds **`POST /api/agents/:id`** — fire a fixed harness agent asynchronously (in-process fire-and-forget), returning `202 { run_id }` immediately and persisting the run as an **action** in the existing `conversations` table. Actions are fully observable, resumable, and **promotable to a regular conversation** on user interaction. Built for an iOS Shortcut that records audio, transcribes it, and POSTs a multipart form.

```
POST /api/agents/:id  (multipart: transcribed_command, short_description, original_recording)
  Bearer secret → userId   → store recording (Data Stash) → seed action row → 202 { run_id }
                                                                    └─(fire-and-forget)→ run → save
```

## Design (converged with review before build)

- **One table.** Actions and conversations share the same `UnifiedContext` shape, so a second table would force a copy on every promotion. Instead: three new columns on `conversations` — `kind` (`conversation`|`action`, mutable — promotion flips it), `source` (`chat`|`post`, immutable provenance), `status` (lifted copy for cheap list filtering + badge). **Promotion = a field flip, no data movement.**
- **Per-user Bearer secret map** in `configs/action-tokens.yaml` (git-ignored; `template.action-tokens.yaml` committed).
- **Declined promotion = cancel the send** (hard gate).
- **Recording → Data Stash** (base64, keyed by `run_id`) for provenance + inline playback — reuses the #89/#95 binary storage + `?download` route; not the searchable ingest path.

## Changes

- **DB** (`db/client.server.ts`, `db/conversations.server.ts`): idempotent `ALTER TABLE … ADD COLUMN IF NOT EXISTS` (+ index) so existing DBs migrate; `kind`/`source` immutable on upsert, `status` always refreshed; `promoteConversation` / `setConversationStatus`.
- **Runner** (`harness-client/action-runner.server.ts`): server-only, **deliberately not `"use server"`** (it takes a `userId`, so it must not be a client RPC). Seeds an observable `running` row, runs a fresh harness under `runWithUserId`, saves on completion, flips to `error` on throw.
- **Route + auth** (`routes/api/agents/[id].ts`, `lib/auth/action-tokens.server.ts`): 404 unknown agent → 401 bad secret → 400 missing command → 202. Recording storage is best-effort (Redis down ≠ failure).
- **UI**: All/Chats/Actions sidebar filter, status badge, promotion confirm-on-send modal, 5s poll while any action runs; audio Play affordance in the Data Stash panel.

## Notable discovery

The harness **never flips a successful run to `done`** — `runChain` leaves `ctx.status === 'running'` and the synthesizer emits the final message directly. The new `status` column is the first consumer to care. Fixed **in the data layer** (`extractStatusFromContext` maps `running → done` on save; only `seedActionRow` writes a genuine in-flight `running`) rather than touching the harness core — a core `setDone` would duplicate the synthesizer's assistant message. Documented + regression-tested.

## Verification

- `pnpm exec tsc --noEmit`: **unchanged** — 22 pre-existing errors, **0 in changed files** (confirmed via stash-diff).
- `pnpm test:run`: **843 pass** (post-sync baseline 820; +23 new across route auth/contract, token parsing, audio MIME, kind/source/status round-trip + promotion, and the running→done status lift).
- **Live end-to-end** (own dev server, real Anthropic + Neo4j): 404/401/400/202 all correct; action row `running → done`; recording stored, listed, and streamable via `?download`; sticky title; the `ALTER TABLE` migration verified against a **pre-existing** table.

## Caveats / out of scope (follow-ups)

- In-process fire-and-forget assumes a **persistent node server**; a mid-run restart orphans a `running` row. Durable queue / crash-recovery worker is the upgrade path, not v1.
- Completion email/push and a dedicated action observability view are deferred (the Actions filter is the interim surface).

## Docs

`docs/AGENT_TRIGGER.md` (new) + entries in `docs/INDEX.md`, `CLAUDE.md`, and a cross-link from `docs/DATA_STASH.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
