### PR TITLE
feat(data-stash): retriever follow-ups — citations, inline viewer, perf, markdown chunking, direct-Redis ingest

### DIFF
--- a/docs/DATA_STASH.md
+++ b/docs/DATA_STASH.md
@@ -50,17 +50,19 @@ The Data Stash adapts to the agent's harness composition:
 
 **Safety net.** Docs uploaded *before* the agent was known (session not yet persisted) miss the gate. The redis backend runs `ensureSessionIngested` on its first search per session (idempotent via `ingestStatus`), so they still become searchable on first retrieval.
 
-**The pattern** (`harness-patterns/patterns/retriever.server.ts`) is framework-pure: it forms ONE query (compacted `scope.data.intent` → last user message → optional last-N turns), fans it out to injected `RetrieverBackend`s concurrently (per-backend error isolation), merges hits closest-first capped at `k`, sets `scope.data.matches`, and emits a `tool_result` the synthesizer consumes. It's a low-latency alternative to a tool-calling `simpleLoop` — one embed + KNN instead of a >30s LLM loop. Typical wiring (see `harness-client/examples/retriever-agent.server.ts`):
+**The pattern** (`harness-patterns/patterns/retriever.server.ts`) is framework-pure: it forms ONE query, fans it out to injected `RetrieverBackend`s concurrently (per-backend error isolation), merges hits closest-first capped at `k`, sets `scope.data.matches`, and emits a `tool_result` the synthesizer consumes. It's a low-latency alternative to a tool-calling `simpleLoop` — one embed + KNN instead of a >30s LLM loop. Typical wiring (see `harness-client/examples/retriever-agent.server.ts`):
 
 ```ts
 router({ retriever, neo4j, web_search }),
 routes({
-  retriever: chain(compactIntent(), retriever({ backends: [createRedisBackend(sessionId)], k: 5 })),
+  retriever: retriever({ backends: [createRedisBackend(sessionId)], k: 5, generateQuery: true }),
   neo4j: simpleLoop(neo4jController, tools.neo4j),
   web_search: simpleLoop(webController, tools.web),
 }),
 synthesizer({ mode: 'thread' }),
 ```
+
+**Query formulation.** By default the query is the user's **raw last message** — their own words embed better than a paraphrase (a generic rewrite like *"search the documents for all sections that discuss X"* dilutes the vector). `generateQuery: true` rewrites it with a cheap `RetrieveQuery` (Haiku) call **only when the turn has history** — to resolve back-references (*"more on that"*, *"those sections"*) into a self-contained query; turn-1 messages are searched verbatim. `turnWindow: N` is a no-LLM alternative that concatenates the last N user turns.
 
 **Backends** (`ui/src/lib/retriever/`) implement `RetrieverBackend { name, type, search() }`:
 

--- a/ui/.env.example
+++ b/ui/.env.example
@@ -47,3 +47,21 @@ VITE_DEV_BYPASS_AUTH='true'
 # useful for reproducing production-chain bugs, or when Anthropic quota
 # becomes the bottleneck. See `ui/src/lib/harness-patterns/clients.server.ts`.
 # USE_MIXED_CHAINS='1'
+
+# ----- Data Stash: direct Redis (ingest/search speedup) -----
+#
+# The Data Stash vector pipeline (chunk → embed → index → KNN) normally goes
+# through the MCP gateway, whose serial stdio pipe (~1.6s/call) makes ingest
+# slow (~200s for a large doc). Set to '1' to route the Data Stash APP path
+# through a direct ioredis connection instead (sub-millisecond per call, ingest
+# in < 1s). Only affects the Data Stash — agentic MCP tool use still goes
+# through the gateway. Hits the SAME redis-stack the gateway writes, so the
+# vector schema is compatible. Requires redis-stack reachable (see below) and,
+# on arm64 colima, the linux/amd64 override (docs/DATA_STASH.md).
+# STASH_DIRECT_REDIS='1'
+#
+# Connection for the direct client (defaults shown; dev redis is auth-less).
+# REDIS_HOST_DIRECT='localhost'   # falls back to REDIS_HOST, then 'localhost'
+# REDIS_PORT='6379'
+# REDIS_PWD=''                    # falls back to REDIS_PASSWORD
+# REDIS_SSL='false'               # 'true' to connect over TLS

--- a/ui/baml_src/retrieve-query.baml
+++ b/ui/baml_src/retrieve-query.baml
@@ -1,0 +1,42 @@
+// RetrieveQuery — rewrite a back-referencing follow-up into a concise search
+// query for semantic (vector) retrieval. Used by the `retriever` pattern when
+// `generateQuery` is set AND the conversation has history; turn-1 messages are
+// searched verbatim (no call). Distinct from CompactIntent, which produces a
+// verbose imperative instruction — here we want embedding-friendly keywords, not
+// "search the documents for sections that discuss …".
+
+function RetrieveQuery(
+  history: Message[],
+  latest: string
+) -> string {
+  client DescribeAnthropic
+  prompt #"
+    {{ _.role("system") }}
+    You turn a user's latest message into a concise SEARCH QUERY for semantic
+    (vector) retrieval over a document corpus. The query is embedded and matched
+    against document chunks — it is NOT read by a person and is NOT a command.
+
+    RULES:
+    - Output the salient search terms: the key nouns, entities, and concepts.
+    - Resolve back-references ("it", "that", "those sections", "the same topic",
+      "more on this") into concrete terms drawn from the history.
+    - Do NOT add framing like "search for", "find", "documents about", "sections
+      that discuss/mention" — that wording only dilutes the embedding.
+    - Keep it short (a phrase or a few keywords). Preserve the user's meaning;
+      do not invent topics the message/history doesn't imply.
+    - Output ONLY the query text. No preamble, no quotes, no explanation.
+
+    {% if history|length > 0 %}
+    CONVERSATION SO FAR (most recent last):
+    {% for m in history %}
+    {{ m.role|upper }}: {{ m.content }}
+
+    {% endfor %}
+    {% endif %}
+
+    {{ _.role("user") }}
+    Latest message: {{ latest }}
+
+    {{ ctx.output_format }}
+  "#
+}

--- a/ui/baml_src/synthesizer.baml
+++ b/ui/baml_src/synthesizer.baml
@@ -59,6 +59,9 @@ function Synthesize(
     - Highlight key findings and relationships
     - If errors occurred, explain what went wrong clearly and suggest alternatives
     - For structured data, summarize patterns rather than dumping raw output
+    - When you draw on content retrieved from an uploaded document, name its
+      source file (the result's `source`, e.g. "According to INDEX.md, …") so the
+      reader can open the citation
     - Suggest follow-up questions when relevant
   "#
 }

--- a/ui/package.json
+++ b/ui/package.json
@@ -30,6 +30,7 @@
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^6.0.0",
     "cytoscape": "^3.33.2",
+    "ioredis": "^5.10.1",
     "marked": "^17.0.6",
     "neo4j-driver": "^6.0.1",
     "node-pty": "^1.1.0",

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       cytoscape:
         specifier: ^3.33.2
         version: 3.33.2
+      ioredis:
+        specifier: ^5.10.1
+        version: 5.10.1
       marked:
         specifier: ^17.0.6
         version: 17.0.6

--- a/ui/src/__tests__/integration/redis-direct.test.ts
+++ b/ui/src/__tests__/integration/redis-direct.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Direct-Redis integration smoke — a real create → upsert → KNN round-trip
+ * against a live redis-stack via the direct ioredis client. SKIPPED unless
+ * `REDIS_DIRECT_IT=1` (needs redis-stack on :6379, arm64 → linux/amd64 override).
+ *
+ *   REDIS_DIRECT_IT=1 pnpm vitest run src/__tests__/integration/redis-direct.test.ts
+ *
+ * Proves the FT.CREATE / hset(vector-blob) / FT.SEARCH commands are correct
+ * against real RediSearch. Gateway↔direct cross-compatibility (a gateway-written
+ * vector read back by direct search) is verified live in the app.
+ */
+
+import { describe, it, expect, afterAll, vi } from 'vitest'
+
+vi.mock('../../lib/harness-patterns/assert.server', () => ({
+  assertServerOnImport: vi.fn(),
+  assertServer: vi.fn(),
+}))
+
+import { directCallTool, getRedis, closeRedisDirect } from '../../lib/redis-direct.server'
+import { createVectorStore } from '../../lib/vector-store.server'
+
+const RUN = process.env.REDIS_DIRECT_IT === '1'
+
+describe.skipIf(!RUN)('redis-direct integration (live redis-stack)', () => {
+  const indexName = 'stash_it_idx_test'
+  const prefix = 'stash_it_test:'
+  const store = createVectorStore({ indexName, prefix, dim: 4, callTool: directCallTool })
+
+  afterAll(async () => {
+    try {
+      await getRedis().call('FT.DROPINDEX', indexName, 'DD') // DD also deletes the docs
+    } catch {
+      /* index may not exist */
+    }
+    await closeRedisDirect()
+  })
+
+  it('round-trips create → upsert → KNN search, closest first', async () => {
+    await store.ensureIndex()
+    await store.upsert('docA:0', [1, 0, 0, 0], { content: 'alpha', doc_id: 'docA', chunk_index: 0 }, 300)
+    await store.upsert('docB:0', [0, 1, 0, 0], { content: 'beta', doc_id: 'docB', chunk_index: 0 }, 300)
+
+    const hits = await store.search([0.9, 0.1, 0, 0], 5)
+    expect(hits.length).toBeGreaterThanOrEqual(2)
+    expect(hits[0].payload.content).toBe('alpha') // nearest to the query
+    expect(hits.map((h) => h.payload.content)).toContain('beta')
+    expect(hits[0].id).toBe('docA:0') // _vid recovered from meta
+  })
+})

--- a/ui/src/__tests__/lib/chunking.test.ts
+++ b/ui/src/__tests__/lib/chunking.test.ts
@@ -97,6 +97,61 @@ describe('chunking (Issue #9)', () => {
     })
   })
 
+  describe('heading binding (markdown)', () => {
+    it('keeps a heading in the same chunk as its following paragraph', () => {
+      const text = '# Architecture\n\nThe system uses a layered design.'
+      const chunks = chunkByParagraph(text, { maxChars: 1000, overlap: 0 })
+      expect(chunks).toHaveLength(1)
+      expect(chunks[0].content).toContain('# Architecture')
+      expect(chunks[0].content).toContain('The system uses a layered design.')
+      assertOffsetInvariant(text, chunks)
+      assertContiguousIndices(chunks)
+    })
+
+    it('prepends two consecutive headings to the paragraph they introduce', () => {
+      const text = '# Top\n\n## Sub\n\nBody text here.'
+      const chunks = chunkByParagraph(text, { maxChars: 1000, overlap: 0 })
+      expect(chunks).toHaveLength(1)
+      expect(chunks[0].content).toContain('# Top')
+      expect(chunks[0].content).toContain('## Sub')
+      expect(chunks[0].content).toContain('Body text here.')
+      assertOffsetInvariant(text, chunks)
+      assertContiguousIndices(chunks)
+    })
+
+    it('puts the heading on the first window only when the section overflows', () => {
+      const body = 'x'.repeat(60)
+      const text = `## Architecture\n\n${body}` // 77 chars > maxChars
+      const chunks = chunkByParagraph(text, { maxChars: 40, overlap: 0 })
+      expect(chunks.length).toBeGreaterThan(1)
+      expect(chunks[0].content.startsWith('## Architecture')).toBe(true)
+      for (let i = 1; i < chunks.length; i++) {
+        expect(chunks[i].content).not.toContain('## Architecture')
+      }
+      assertOffsetInvariant(text, chunks)
+      assertContiguousIndices(chunks)
+    })
+
+    it('keeps a trailing heading with no body rather than dropping it', () => {
+      const text = 'Some body paragraph.\n\n# Dangling'
+      const chunks = chunkByParagraph(text, { maxChars: 1000, overlap: 0 })
+      expect(chunks.map((c) => c.content).join('\n')).toContain('# Dangling')
+      assertOffsetInvariant(text, chunks)
+      assertContiguousIndices(chunks)
+    })
+
+    it('is a no-op on headingless prose (paragraphs still split normally)', () => {
+      const text = 'First paragraph here.\n\nSecond paragraph here.'
+      const chunks = chunkByParagraph(text, { maxChars: 25, overlap: 0 })
+      expect(chunks.map((c) => c.content)).toEqual([
+        'First paragraph here.',
+        'Second paragraph here.',
+      ])
+      assertOffsetInvariant(text, chunks)
+      assertContiguousIndices(chunks)
+    })
+  })
+
   describe('chunkBySentence', () => {
     it('splits on sentence punctuation and packs to maxChars', () => {
       const text = 'First sentence. Second one! Third here? Fourth final.'

--- a/ui/src/__tests__/lib/document-ingest-status.test.ts
+++ b/ui/src/__tests__/lib/document-ingest-status.test.ts
@@ -163,23 +163,26 @@ describe('ensureSessionIngested', () => {
     expect(embedSpy.mock.calls.length).toBe(callsAfterFirst) // nothing re-embedded
   })
 
-  it('retries failed docs (transient) and skips only indexed + binary', async () => {
+  it('ingests failed + absent, skips indexed + pending + binary', async () => {
     const { embedFn } = makeEmbedder('m', 3)
     const embedSpy = vi.fn(embedFn)
     await seed(fake, 'already', 'Already indexed text.')
     await setDocumentFlags('s1', 'already', { ingestStatus: 'indexed' }, fake.callTool)
     await seed(fake, 'old-failed', 'Previously failed (embedder was down).')
     await setDocumentFlags('s1', 'old-failed', { ingestStatus: 'failed' }, fake.callTool)
+    await seed(fake, 'in-flight', 'Being ingested by the upload gate.')
+    await setDocumentFlags('s1', 'in-flight', { ingestStatus: 'pending' }, fake.callTool)
     await seed(fake, 'bin', Buffer.from('b').toString('base64'), { encoding: 'base64' })
     await seed(fake, 'fresh', 'Fresh content here.')
 
     await ensureSessionIngested('s1', { callTool: fake.callTool, embedFn: embedSpy })
 
-    expect((await getDocument('s1', 'fresh', fake.callTool))?.ingestStatus).toBe('indexed')
+    expect((await getDocument('s1', 'fresh', fake.callTool))?.ingestStatus).toBe('indexed') // absent → ingested
     // A prior failure is transient — retried and recovered now the embedder's up.
     expect((await getDocument('s1', 'old-failed', fake.callTool))?.ingestStatus).toBe('indexed')
-    expect((await getDocument('s1', 'already', fake.callTool))?.ingestStatus).toBe('indexed') // skipped (already)
+    expect((await getDocument('s1', 'already', fake.callTool))?.ingestStatus).toBe('indexed') // skipped
+    expect((await getDocument('s1', 'in-flight', fake.callTool))?.ingestStatus).toBe('pending') // skipped (gate owns it)
     expect((await getDocument('s1', 'bin', fake.callTool))?.ingestStatus).toBeUndefined() // skipped (binary)
-    expect(embedSpy).toHaveBeenCalledTimes(2) // old-failed + fresh
+    expect(embedSpy).toHaveBeenCalledTimes(2) // old-failed + fresh only
   })
 })

--- a/ui/src/__tests__/lib/document-ingest-status.test.ts
+++ b/ui/src/__tests__/lib/document-ingest-status.test.ts
@@ -163,10 +163,12 @@ describe('ensureSessionIngested', () => {
     expect(embedSpy.mock.calls.length).toBe(callsAfterFirst) // nothing re-embedded
   })
 
-  it('skips terminal (failed) and binary (base64) docs, ingesting only the fresh one', async () => {
+  it('retries failed docs (transient) and skips only indexed + binary', async () => {
     const { embedFn } = makeEmbedder('m', 3)
     const embedSpy = vi.fn(embedFn)
-    await seed(fake, 'old-failed', 'x')
+    await seed(fake, 'already', 'Already indexed text.')
+    await setDocumentFlags('s1', 'already', { ingestStatus: 'indexed' }, fake.callTool)
+    await seed(fake, 'old-failed', 'Previously failed (embedder was down).')
     await setDocumentFlags('s1', 'old-failed', { ingestStatus: 'failed' }, fake.callTool)
     await seed(fake, 'bin', Buffer.from('b').toString('base64'), { encoding: 'base64' })
     await seed(fake, 'fresh', 'Fresh content here.')
@@ -174,8 +176,10 @@ describe('ensureSessionIngested', () => {
     await ensureSessionIngested('s1', { callTool: fake.callTool, embedFn: embedSpy })
 
     expect((await getDocument('s1', 'fresh', fake.callTool))?.ingestStatus).toBe('indexed')
-    expect((await getDocument('s1', 'old-failed', fake.callTool))?.ingestStatus).toBe('failed') // untouched
-    expect((await getDocument('s1', 'bin', fake.callTool))?.ingestStatus).toBeUndefined() // skipped
-    expect(embedSpy).toHaveBeenCalledTimes(1) // only 'fresh'
+    // A prior failure is transient — retried and recovered now the embedder's up.
+    expect((await getDocument('s1', 'old-failed', fake.callTool))?.ingestStatus).toBe('indexed')
+    expect((await getDocument('s1', 'already', fake.callTool))?.ingestStatus).toBe('indexed') // skipped (already)
+    expect((await getDocument('s1', 'bin', fake.callTool))?.ingestStatus).toBeUndefined() // skipped (binary)
+    expect(embedSpy).toHaveBeenCalledTimes(2) // old-failed + fresh
   })
 })

--- a/ui/src/__tests__/lib/document-store.test.ts
+++ b/ui/src/__tests__/lib/document-store.test.ts
@@ -123,6 +123,23 @@ describe('document-store (Issue #6)', () => {
       expect(doc.uploadedAt).toBeGreaterThanOrEqual(before)
     })
 
+    it('omits ingestStatus by default but persists it when supplied', async () => {
+      const plain = await storeDocument(
+        { sessionId: 's1', filename: 'a.txt', mimeType: 'text/plain', content: 'x' },
+        fake.callTool,
+      )
+      expect(plain.ingestStatus).toBeUndefined()
+
+      // The upload gate persists 'pending' in this FIRST write so a status poll
+      // can't read a no-status gap and flicker; it must round-trip from Redis.
+      const pending = await storeDocument(
+        { sessionId: 's1', filename: 'b.txt', mimeType: 'text/plain', content: 'y', ingestStatus: 'pending' },
+        fake.callTool,
+      )
+      expect(pending.ingestStatus).toBe('pending')
+      expect((await getDocument('s1', pending.id, fake.callTool))?.ingestStatus).toBe('pending')
+    })
+
     it('writes to the namespaced key and registers the session index with a TTL', async () => {
       const doc = await storeDocument(
         { sessionId: 's1', filename: 'a.txt', mimeType: 'text/plain', content: 'x', id: 'fixed-id' },

--- a/ui/src/__tests__/lib/harness-patterns/patterns/retriever.test.ts
+++ b/ui/src/__tests__/lib/harness-patterns/patterns/retriever.test.ts
@@ -266,11 +266,41 @@ describe('retriever', () => {
     expect(trs).toHaveLength(1)
     expect(trs[0].tool).toBe('retriever')
     expect(trs[0].success).toBe(true)
-    const payload = trs[0].result as { matches: RetrievalHit[]; backends: string[]; query: string }
+    const payload = trs[0].result as {
+      matches: RetrievalHit[]
+      backends: string[]
+      query: string
+      references: unknown[]
+    }
     expect(payload.matches).toHaveLength(1)
     expect(payload.backends).toEqual(['redis'])
     expect(payload.query).toBe('the query')
+    expect(Array.isArray(payload.references)).toBe(true) // no locator on plain hits
     expect(trs[0].summary).toContain('1 match')
+  })
+
+  it('builds typed references from hits that carry a source locator', async () => {
+    const located: RetrievalHit = {
+      backend: 'redis',
+      id: 'doc1:2',
+      content: 'the matched chunk',
+      source: 'notes.md',
+      score: 0.2,
+      docId: 'doc1',
+      chunkIndex: 2,
+      startOffset: 10,
+      endOffset: 42,
+    }
+    // A web-style hit with no locator must NOT produce a reference.
+    const unlocated: RetrievalHit = { backend: 'web', id: 'u1', content: 'x', score: 0.1 }
+    const backend = mockBackend('redis', [located, unlocated])
+    const { result } = await run({}, [userMsg('q')], { backends: [backend], k: 5 })
+    const refs = (result.events.find((e) => e.type === 'tool_result')!.data as {
+      result: { references: RetrievalHit[] }
+    }).result.references
+    expect(refs).toEqual([
+      { source: 'notes.md', docId: 'doc1', chunkIndex: 2, startOffset: 10, endOffset: 42, score: 0.2 },
+    ])
   })
 
   it('reports "no matches" (empty) without erroring when backends find nothing', async () => {

--- a/ui/src/__tests__/lib/harness-patterns/patterns/retriever.test.ts
+++ b/ui/src/__tests__/lib/harness-patterns/patterns/retriever.test.ts
@@ -24,6 +24,31 @@ vi.mock('../../../../lib/harness-patterns/assert.server', () => ({
   assertServer: vi.fn(),
 }))
 
+// Mock the BAML client (the retriever dynamically imports it for RetrieveQuery).
+vi.mock('../../../../../baml_client', () => ({
+  b: { RetrieveQuery: vi.fn(async () => 'rewritten search query') },
+}))
+
+// Collector must be a real class so `new Collector()` works + has `.last`.
+vi.mock('@boundaryml/baml', () => {
+  class MockCollector {
+    last = {
+      rawLlmResponse: 'raw',
+      usage: { inputTokens: 10, outputTokens: 4 },
+      calls: [
+        {
+          httpRequest: { body: { messages: [] } },
+          provider: 'anthropic',
+          clientName: 'DescribeAnthropic',
+          selected: true,
+        },
+      ],
+    }
+    constructor(_name?: string) {}
+  }
+  return { Collector: MockCollector }
+})
+
 type Ev = { type: EventType; ts: number; patternId: string; data: unknown }
 
 function ctxOf(events: Ev[]): UnifiedContext<Record<string, unknown>> {
@@ -46,7 +71,8 @@ async function load() {
   )
   const { createScope } = await import('../../../../lib/harness-patterns/context.server')
   const { createEventView } = await import('../../../../lib/harness-patterns/patterns')
-  return { retriever, createScope, createEventView }
+  const { b } = await import('../../../../../baml_client')
+  return { retriever, createScope, createEventView, b }
 }
 
 /** A mock backend that records the query it received and returns canned hits. */
@@ -84,12 +110,12 @@ async function run(
   events: Ev[],
   config: Parameters<Awaited<ReturnType<typeof load>>['retriever']>[0],
 ) {
-  const { retriever, createScope, createEventView } = await load()
+  const { retriever, createScope, createEventView, b } = await load()
   const pattern = retriever(config)
   const scope = createScope(PATTERN_ID, scopeData)
   const view = createEventView(ctxOf(events), pattern.config.viewConfig, PATTERN_ID)
   const result = await pattern.fn(scope, view)
-  return { pattern, result }
+  return { pattern, result, baml: b }
 }
 
 function toolResults(events: ContextEvent[]): ToolResultEventData[] {
@@ -121,39 +147,90 @@ describe('retriever', () => {
     ])
   })
 
-  it('queries with the compacted intent when present (preferred source)', async () => {
-    const b = mockBackend('redis', [hit('redis', 'a', 0.1)])
-    const { result } = await run(
-      { intent: 'find the quarterly revenue figure' },
+  it('uses the raw last user message as the query by default (ignores scope.data.intent)', async () => {
+    const backend = mockBackend('redis', [hit('redis', 'a', 0.1)])
+    const { result, baml } = await run(
+      { intent: 'some classified intent' },
       [userMsg('what was it again?')],
-      { backends: [b], k: 5 },
+      { backends: [backend], k: 5 },
     )
-    expect(b.calls).toHaveLength(1)
-    expect(b.calls[0].text).toBe('find the quarterly revenue figure')
-    expect(b.calls[0].intent).toBe('find the quarterly revenue figure')
+    expect(backend.calls).toHaveLength(1)
+    // The user's own words are the query — NOT the router/compacted intent.
+    expect(backend.calls[0].text).toBe('what was it again?')
+    // intent is still passed through as a context hint.
+    expect(backend.calls[0].intent).toBe('some classified intent')
+    expect(baml.RetrieveQuery).not.toHaveBeenCalled() // no rewrite without generateQuery
     expect((result.data as { matches?: RetrievalHit[] }).matches).toHaveLength(1)
   })
 
-  it('falls back to the last user message when there is no intent', async () => {
-    const b = mockBackend('redis', [])
+  it('uses the latest user message across multiple turns', async () => {
+    const backend = mockBackend('redis', [])
     const { result } = await run({}, [userMsg('first'), userMsg('latest question')], {
-      backends: [b],
+      backends: [backend],
     })
-    expect(b.calls[0].text).toBe('latest question')
-    expect(b.calls[0].intent).toBeUndefined()
+    expect(backend.calls[0].text).toBe('latest question')
+    expect(backend.calls[0].intent).toBeUndefined()
     expect((result.data as { matches?: RetrievalHit[] }).matches).toEqual([])
   })
 
-  it('widens the query to the last N user turns when turnWindow is set', async () => {
-    const b = mockBackend('redis', [])
-    await run(
+  it('widens the query to the last N user turns when turnWindow is set (no LLM)', async () => {
+    const backend = mockBackend('redis', [])
+    const { baml } = await run(
       {},
       [userMsg('alpha', 1), userMsg('beta', 2), userMsg('gamma', 3)],
-      { backends: [b], turnWindow: 3 },
+      { backends: [backend], turnWindow: 3 },
     )
-    // Joined recent user turns (no intent present).
-    expect(b.calls[0].text).toContain('alpha')
-    expect(b.calls[0].text).toContain('gamma')
+    expect(backend.calls[0].text).toContain('alpha')
+    expect(backend.calls[0].text).toContain('gamma')
+    expect(baml.RetrieveQuery).not.toHaveBeenCalled()
+  })
+
+  it('with generateQuery + history, rewrites the query via RetrieveQuery', async () => {
+    const backend = mockBackend('redis', [])
+    const { baml } = await run(
+      {},
+      [
+        userMsg('what is RAG?', 1),
+        { type: 'assistant_message', ts: 2, patternId: 'synth', data: { content: 'RAG is…' } },
+        userMsg('tell me more about that', 3),
+      ],
+      { backends: [backend], generateQuery: true },
+    )
+    expect(baml.RetrieveQuery).toHaveBeenCalledTimes(1)
+    const [history, latest] = vi.mocked(baml.RetrieveQuery).mock.calls[0]
+    expect(latest).toBe('tell me more about that')
+    expect(history.length).toBe(2) // prior user + assistant
+    expect(backend.calls[0].text).toBe('rewritten search query')
+  })
+
+  it('with generateQuery but NO history (turn 1), searches verbatim — no LLM call', async () => {
+    const backend = mockBackend('redis', [])
+    const { baml } = await run({}, [userMsg('what is RAG?')], {
+      backends: [backend],
+      generateQuery: true,
+    })
+    expect(baml.RetrieveQuery).not.toHaveBeenCalled()
+    expect(backend.calls[0].text).toBe('what is RAG?')
+  })
+
+  it('falls back to the raw message + tracks an error when RetrieveQuery throws', async () => {
+    const { retriever, createScope, createEventView, b } = await load()
+    vi.mocked(b.RetrieveQuery).mockRejectedValueOnce(new Error('describe model down'))
+    const backend = mockBackend('redis', [hit('redis', 'a', 0.1)])
+    const pattern = retriever({ backends: [backend], generateQuery: true, patternId: PATTERN_ID })
+    const scope = createScope(PATTERN_ID, {})
+    const view = createEventView(
+      ctxOf([userMsg('first', 1), userMsg('again', 2)]),
+      pattern.config.viewConfig,
+      PATTERN_ID,
+    )
+    const result = await pattern.fn(scope, view)
+    // Degrades to the raw latest message and still searches.
+    expect(backend.calls[0].text).toBe('again')
+    expect((result.data as { matches: RetrievalHit[] }).matches).toHaveLength(1)
+    const errors = result.events.filter((e) => e.type === 'error')
+    expect(errors.length).toBeGreaterThan(0)
+    expect(JSON.stringify(errors[0].data)).toContain('describe model down')
   })
 
   it('fans out to all backends and merges closest-first, capped at k', async () => {
@@ -181,9 +258,9 @@ describe('retriever', () => {
   })
 
   it('emits a tool_result the synthesizer can read, with matches + backends + query', async () => {
-    const b = mockBackend('redis', [hit('redis', 'a', 0.1)])
-    const { result } = await run({ intent: 'the query' }, [userMsg('x')], {
-      backends: [b],
+    const backend = mockBackend('redis', [hit('redis', 'a', 0.1)])
+    const { result } = await run({}, [userMsg('the query')], {
+      backends: [backend],
     })
     const trs = toolResults(result.events)
     expect(trs).toHaveLength(1)

--- a/ui/src/__tests__/lib/harness-patterns/patterns/synthesizer.test.ts
+++ b/ui/src/__tests__/lib/harness-patterns/patterns/synthesizer.test.ts
@@ -337,6 +337,56 @@ describe('synthesizer execution', () => {
     expect(JSON.stringify(errorEvents[0].data)).toContain('Synthesis failed')
   })
 
+  it('thread mode: keeps a bare tool_result with no preceding controller_action (the retriever)', async () => {
+    // Regression: the retriever emits a single tool_result and NO
+    // controller_action. The old reconstruction only attached a tool_result to
+    // an existing iteration (created by a controller_action), so the result was
+    // dropped → loopHistory had 0 iterations → Synthesize got nothing → the
+    // synthesizer answered from nothing ("after the retriever, nothing happens").
+    const { synthesizer } = await import('../../../../lib/harness-patterns/patterns/synthesizer.server')
+    const { createScope } = await import('../../../../lib/harness-patterns/context.server')
+    const { createEventView } = await import('../../../../lib/harness-patterns/patterns')
+
+    let captured: import('../../../../lib/harness-patterns/types').SynthesizerInput | undefined
+    const pattern = synthesizer({
+      mode: 'thread',
+      synthesize: async (input) => {
+        captured = input
+        return `iters=${input.loopHistory?.iterations.length ?? 0}`
+      },
+    })
+
+    const scope = createScope('test', {})
+    const now = Date.now()
+    const matches = [{ backend: 'redis', id: 'doc:0', content: 'Harness patterns are covered in §3.' }]
+    const mockContext = {
+      sessionId: 'test',
+      createdAt: now,
+      events: [
+        { type: 'user_message' as const, ts: now, patternId: 'harness', data: { content: 'which sections cover harness patterns?' } },
+        { type: 'pattern_enter' as const, ts: now + 1, patternId: 'retriever', data: { pattern: 'retriever' } },
+        { type: 'tool_result' as const, ts: now + 2, patternId: 'retriever', data: { tool: 'retriever', result: { matches, backends: ['redis'], query: 'harness patterns' }, success: true } },
+        { type: 'pattern_exit' as const, ts: now + 3, patternId: 'retriever', data: { status: 'completed' } },
+      ],
+      status: 'running' as const,
+      data: {},
+      input: 'which sections cover harness patterns?',
+    }
+    const view = createEventView(mockContext)
+
+    const result = await pattern.fn(scope, view)
+
+    // The bare tool_result becomes a standalone turn carrying the matches.
+    expect(captured?.loopHistory?.iterations).toHaveLength(1)
+    expect(captured?.loopHistory?.iterations[0].result).toEqual({
+      matches,
+      backends: ['redis'],
+      query: 'harness patterns',
+    })
+    expect(captured?.loopHistory?.iterations[0].action.tool_name).toBe('retriever')
+    expect(result.data.synthesizedResponse).toBe('iters=1')
+  })
+
   it('should build input from events for thread mode', async () => {
     const { synthesizer } = await import('../../../../lib/harness-patterns/patterns/synthesizer.server')
     const { createScope } = await import('../../../../lib/harness-patterns/context.server')

--- a/ui/src/__tests__/lib/redis-direct.test.ts
+++ b/ui/src/__tests__/lib/redis-direct.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Direct-Redis adapter tests — `makeDirectCallTool` (the ioredis-backed
+ * `CallTool` used by the Data Stash when `STASH_DIRECT_REDIS=1`).
+ *
+ * A hand-rolled fake ioredis (no socket) drives each tool case; the assertions
+ * check the return SHAPES the existing parsers rely on — most importantly that
+ * a `vector_search_hash` reply flows through the real `createVectorStore`/
+ * `parseHits` to identical `VectorHit`s, and that the FLOAT32 blob is
+ * byte-exact (so a direct KNN matches gateway-written vectors).
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('../../lib/harness-patterns/assert.server', () => ({
+  assertServerOnImport: vi.fn(),
+  assertServer: vi.fn(),
+}))
+// redis-direct imports the gateway callTool for `stashCallTool`'s off-branch;
+// stub it so no real gateway is touched on import.
+vi.mock('../../lib/harness-patterns/mcp-client.server', () => ({
+  callTool: vi.fn(async () => ({ success: false, data: null, error: 'no gateway' })),
+}))
+
+import { makeDirectCallTool } from '../../lib/redis-direct.server'
+import { createVectorStore, encodeMeta } from '../../lib/vector-store.server'
+import type { Redis } from 'ioredis'
+
+// ----------------------------------------------------------------------------
+// Fake ioredis — records ops; canned replies for module commands.
+// ----------------------------------------------------------------------------
+function makeFakeIoredis(opts: { jsonGet?: unknown; smembers?: string[] } = {}) {
+  const ops: Array<[string, unknown[]]> = []
+  let ftSearch: unknown = [0]
+  let ftCreateErr: Error | null = null
+  const fake = {
+    ops,
+    setFtSearch(r: unknown) {
+      ftSearch = r
+    },
+    setFtCreateErr(e: Error | null) {
+      ftCreateErr = e
+    },
+    call: async (cmd: string, ...args: unknown[]) => {
+      ops.push([`call:${cmd}`, args])
+      switch (cmd) {
+        case 'FT.CREATE':
+          if (ftCreateErr) throw ftCreateErr
+          return 'OK'
+        case 'FT.SEARCH':
+          return ftSearch
+        case 'JSON.SET':
+          return 'OK'
+        case 'JSON.GET':
+          return opts.jsonGet ?? null
+        default:
+          return null
+      }
+    },
+    hset: async (...args: unknown[]) => {
+      ops.push(['hset', args])
+      return 1
+    },
+    sadd: async (...args: unknown[]) => {
+      ops.push(['sadd', args])
+      return 1
+    },
+    smembers: async (...args: unknown[]) => {
+      ops.push(['smembers', args])
+      return opts.smembers ?? []
+    },
+    srem: async (...args: unknown[]) => {
+      ops.push(['srem', args])
+      return 1
+    },
+    del: async (...args: unknown[]) => {
+      ops.push(['del', args])
+      return 1
+    },
+    expire: async (...args: unknown[]) => {
+      ops.push(['expire', args])
+      return 1
+    },
+  }
+  return fake
+}
+
+const asRedis = (f: ReturnType<typeof makeFakeIoredis>) => f as unknown as Redis
+
+describe('redis-direct adapter', () => {
+  it('set_vector_in_hash stores a byte-exact little-endian FLOAT32 blob', async () => {
+    const fake = makeFakeIoredis()
+    const ct = makeDirectCallTool(asRedis(fake))
+    const res = await ct('set_vector_in_hash', { name: 'stashvec:s:t:d:0', vector: [1, 2, 3.5] })
+    expect(res).toEqual({ success: true, data: true })
+
+    const hset = fake.ops.find(([m]) => m === 'hset')!
+    const [key, field, value] = hset[1] as [string, string, Buffer]
+    expect(key).toBe('stashvec:s:t:d:0')
+    expect(field).toBe('vector')
+    const expected = Buffer.alloc(12)
+    expected.writeFloatLE(1, 0)
+    expected.writeFloatLE(2, 4)
+    expected.writeFloatLE(3.5, 8)
+    expect(Buffer.isBuffer(value)).toBe(true)
+    expect((value as Buffer).equals(expected)).toBe(true)
+  })
+
+  it('vector_search_hash → parseHits yields identical VectorHits (via createVectorStore)', async () => {
+    const fake = makeFakeIoredis()
+    const store = createVectorStore({
+      indexName: 'idx',
+      prefix: 'stashvec:s:t:',
+      dim: 3,
+      callTool: makeDirectCallTool(asRedis(fake)),
+    })
+    // Flat RESP2 reply: [total, key, [field, val, ...]].
+    fake.setFtSearch([
+      1,
+      'stashvec:s:t:d1:0',
+      ['meta', encodeMeta({ content: 'hello', doc_id: 'd1', chunk_index: 0, _vid: 'd1:0' }), 'score', '0.25'],
+    ])
+    const hits = await store.search([1, 2, 3], 5)
+    expect(hits).toHaveLength(1)
+    expect(hits[0].id).toBe('d1:0')
+    expect(hits[0].payload.content).toBe('hello')
+    expect(hits[0].score).toBe(0.25)
+  })
+
+  it('vector_search_hash returns [] for an empty result set', async () => {
+    const fake = makeFakeIoredis()
+    const store = createVectorStore({
+      indexName: 'idx',
+      prefix: 'p:',
+      dim: 3,
+      callTool: makeDirectCallTool(asRedis(fake)),
+    })
+    fake.setFtSearch([0])
+    expect(await store.search([1, 2, 3], 5)).toEqual([])
+  })
+
+  it('create_vector_index_hash tolerates "already exists" but rethrows other errors', async () => {
+    const fake = makeFakeIoredis()
+    const store = createVectorStore({
+      indexName: 'idx',
+      prefix: 'p:',
+      dim: 3,
+      callTool: makeDirectCallTool(asRedis(fake)),
+    })
+    fake.setFtCreateErr(new Error('Index already exists'))
+    await expect(store.ensureIndex()).resolves.toBeUndefined()
+
+    fake.setFtCreateErr(new Error('WRONGTYPE bad key'))
+    await expect(store.ensureIndex()).rejects.toThrow(/WRONGTYPE|Failed to create/)
+  })
+
+  it('json_get returns {data:null} for a missing key', async () => {
+    const ct = makeDirectCallTool(asRedis(makeFakeIoredis({ jsonGet: null })))
+    expect(await ct('json_get', { name: 'nope', path: '$' })).toEqual({ success: true, data: null })
+  })
+
+  it('json_set returns "OK" and applies expire when given', async () => {
+    const fake = makeFakeIoredis()
+    const ct = makeDirectCallTool(asRedis(fake))
+    const res = await ct('json_set', { name: 'k', path: '$', value: '{"a":1}', expire_seconds: 60 })
+    expect(res).toEqual({ success: true, data: 'OK' })
+    expect(fake.ops.some(([m, a]) => m === 'expire' && (a as unknown[])[0] === 'k')).toBe(true)
+  })
+
+  it('delete uses args.key (not args.name)', async () => {
+    const fake = makeFakeIoredis()
+    const ct = makeDirectCallTool(asRedis(fake))
+    await ct('delete', { key: 'stash:doc:s:d1' })
+    const del = fake.ops.find(([m]) => m === 'del')!
+    expect((del[1] as unknown[])[0]).toBe('stash:doc:s:d1')
+  })
+
+  it('smembers passes through the set members as an array', async () => {
+    const ct = makeDirectCallTool(asRedis(makeFakeIoredis({ smembers: ['a', 'b'] })))
+    expect(await ct('smembers', { name: 'stash:docs:s' })).toEqual({ success: true, data: ['a', 'b'] })
+  })
+})

--- a/ui/src/__tests__/lib/reference-extractor.test.ts
+++ b/ui/src/__tests__/lib/reference-extractor.test.ts
@@ -1,0 +1,79 @@
+/**
+ * reference-extractor — pulls the retriever's typed references out of the event
+ * stream (client-safe; mirrors graph-extractor). Types are erased at runtime, so
+ * this exercises the pure extraction logic with plain event objects.
+ */
+import { describe, it, expect } from 'vitest'
+import { extractReferences, referencesForDoc } from '../../lib/harness-client/reference-extractor'
+import type { ContextEvent, RetrievalReference } from '../../lib/harness-patterns'
+
+function retrieverResult(references: RetrievalReference[]): ContextEvent {
+  return {
+    type: 'tool_result',
+    ts: 1,
+    patternId: 'retriever',
+    data: { tool: 'retriever', success: true, result: { query: 'q', backends: ['redis'], matches: [], references } },
+  } as unknown as ContextEvent
+}
+
+const ref = (docId: string, source: string, startOffset: number, endOffset: number, chunkIndex = 0): RetrievalReference => ({
+  source,
+  docId,
+  chunkIndex,
+  startOffset,
+  endOffset,
+})
+
+describe('extractReferences', () => {
+  it('returns [] when there is no retriever tool_result', () => {
+    const events = [
+      { type: 'user_message', ts: 1, patternId: 'h', data: { content: 'hi' } },
+      { type: 'tool_result', ts: 2, patternId: 'neo4j-query', data: { tool: 'read_neo4j_cypher', success: true, result: {} } },
+    ] as unknown as ContextEvent[]
+    expect(extractReferences(events)).toEqual([])
+  })
+
+  it('pulls references from the retriever tool_result', () => {
+    const refs = [ref('d1', 'a.md', 0, 10), ref('d2', 'b.md', 5, 20)]
+    expect(extractReferences([retrieverResult(refs)])).toEqual(refs)
+  })
+
+  it('uses the MOST RECENT retriever result across turns', () => {
+    const older = retrieverResult([ref('d1', 'old.md', 0, 5)])
+    const newer = retrieverResult([ref('d2', 'new.md', 0, 5)])
+    const events = [older, { type: 'user_message', ts: 3, patternId: 'h', data: { content: 'q2' } }, newer] as unknown as ContextEvent[]
+    expect(extractReferences(events)).toEqual([ref('d2', 'new.md', 0, 5)])
+  })
+
+  it('ignores non-retriever tool_results', () => {
+    const events = [
+      { type: 'tool_result', ts: 1, patternId: 'web', data: { tool: 'search', success: true, result: { hits: [] } } },
+    ] as unknown as ContextEvent[]
+    expect(extractReferences(events)).toEqual([])
+  })
+
+  it('tolerates a retriever result with no references field', () => {
+    const bad = { type: 'tool_result', ts: 1, patternId: 'retriever', data: { tool: 'retriever', success: true, result: { query: 'q' } } } as unknown as ContextEvent
+    expect(extractReferences([bad])).toEqual([])
+  })
+})
+
+describe('referencesForDoc', () => {
+  it('filters to one doc and sorts by start offset', () => {
+    const events = [
+      retrieverResult([
+        ref('d1', 'a.md', 40, 60, 2),
+        ref('d2', 'b.md', 0, 10),
+        ref('d1', 'a.md', 0, 12, 0),
+        ref('d1', 'a.md', 20, 30, 1),
+      ]),
+    ]
+    const out = referencesForDoc(events, 'd1')
+    expect(out.map((r) => r.startOffset)).toEqual([0, 20, 40])
+    expect(out.every((r) => r.docId === 'd1')).toBe(true)
+  })
+
+  it('returns [] for a doc with no references', () => {
+    expect(referencesForDoc([retrieverResult([ref('d1', 'a.md', 0, 5)])], 'ghost')).toEqual([])
+  })
+})

--- a/ui/src/__tests__/lib/retriever/redis-backend.test.ts
+++ b/ui/src/__tests__/lib/retriever/redis-backend.test.ts
@@ -47,7 +47,7 @@ describe('createRedisBackend', () => {
     expect(searchFn).toHaveBeenCalledWith('sess-42', 'how do refunds work?', { k: 7 })
   })
 
-  it('normalizes SearchHit → RetrievalHit (id, provenance metadata)', async () => {
+  it('normalizes SearchHit → RetrievalHit with first-class locator fields', async () => {
     const b = createRedisBackend('s1', {
       searchFn: vi.fn(async () => SAMPLE),
       ensureIngested: false,
@@ -60,7 +60,10 @@ describe('createRedisBackend', () => {
         content: 'the matched chunk',
         source: 'notes.txt',
         score: 0.13,
-        metadata: { docId: 'doc1', chunkIndex: 2, startOffset: 10, endOffset: 27 },
+        docId: 'doc1',
+        chunkIndex: 2,
+        startOffset: 10,
+        endOffset: 27,
       },
     ])
   })

--- a/ui/src/__tests__/lib/upload-service.test.ts
+++ b/ui/src/__tests__/lib/upload-service.test.ts
@@ -1,0 +1,49 @@
+/**
+ * parseUploadRequest — intake parsing. Focus: the `agentId` field (client hint
+ * that lets the auto-ingest gate resolve the harness before the session is
+ * persisted) is parsed from both the multipart and JSON paths.
+ */
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('../../lib/harness-patterns/assert.server', () => ({
+  assertServerOnImport: vi.fn(),
+  assertServer: vi.fn(),
+}))
+
+import { parseUploadRequest } from '../../lib/stash/upload-service.server'
+
+const jsonReq = (body: unknown) =>
+  new Request('http://x/api/stash/upload', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+
+describe('parseUploadRequest — agentId', () => {
+  it('JSON: parses agentId alongside the doc input', async () => {
+    const out = await parseUploadRequest(
+      jsonReq({ sessionId: 's1', filename: 'a.md', content: 'hi', agentId: 'retriever' }),
+    )
+    expect(out.sessionId).toBe('s1')
+    expect(out.content).toBe('hi')
+    expect(out.agentId).toBe('retriever')
+  })
+
+  it('JSON: omits agentId when absent or blank', async () => {
+    expect((await parseUploadRequest(jsonReq({ sessionId: 's1', content: 'hi' }))).agentId).toBeUndefined()
+    expect(
+      (await parseUploadRequest(jsonReq({ sessionId: 's1', content: 'hi', agentId: '  ' }))).agentId,
+    ).toBeUndefined()
+  })
+
+  it('multipart: parses agentId + file', async () => {
+    const form = new FormData()
+    form.set('sessionId', 's1')
+    form.set('agentId', 'retriever')
+    form.set('file', new Blob(['# Doc\n\nbody'], { type: 'text/markdown' }), 'a.md')
+    const out = await parseUploadRequest(new Request('http://x/api/stash/upload', { method: 'POST', body: form }))
+    expect(out.agentId).toBe('retriever')
+    expect(out.sessionId).toBe('s1')
+    expect(out.content).toContain('body')
+  })
+})

--- a/ui/src/__tests__/lib/vector-store.test.ts
+++ b/ui/src/__tests__/lib/vector-store.test.ts
@@ -148,6 +148,34 @@ describe('vector-store', () => {
       expect(await store.search([1, 2, 3])).toEqual([])
     })
 
+    it('parses a SINGLE match returned as a bare hit object (gateway 1-result shape)', async () => {
+      // Live regression: for exactly ONE match the gateway returns the hit as a
+      // bare object (not an array, not a {results:[…]} wrapper) — one text block,
+      // un-aggregated. The old parseHits treated any non-array object as a
+      // wrapper, found no .results/.documents/.matches, and yielded [] → search
+      // silently returned nothing. (N≥2 matches arrive as an array and worked.)
+      const meta = 'b64:' + Buffer.from(JSON.stringify({ content: 'hello', _vid: 'd1:0' })).toString('base64')
+      const callTool: CallTool = async (name) =>
+        name === 'vector_search_hash'
+          ? { success: true, data: { id: 'p:d1:0', payload: null, score: '0.2044', meta } }
+          : { success: true, data: 1 }
+      const store = createVectorStore({ indexName: 'idx1', prefix: 'p:', dim: 3, callTool })
+      const hits = await store.search([0, 0, 0], 3)
+      expect(hits).toHaveLength(1)
+      expect(hits[0].id).toBe('d1:0')
+      expect(hits[0].payload.content).toBe('hello')
+      expect(hits[0].score).toBe(0.2044) // string score coerced to number
+    })
+
+    it('ignores a non-hit bare object (e.g. an empty/no-results response)', async () => {
+      const callTool: CallTool = async (name) =>
+        name === 'vector_search_hash'
+          ? { success: true, data: { count: 0 } }
+          : { success: true, data: 1 }
+      const store = createVectorStore({ indexName: 'idx1', prefix: 'p:', dim: 3, callTool })
+      expect(await store.search([0, 0, 0], 3)).toEqual([])
+    })
+
     it('parses a JSON-string meta and a {result} wrapper shape', async () => {
       // Mimic a backend that returns rows under a key, with meta as raw JSON.
       const callTool: CallTool = async (name) =>

--- a/ui/src/components/ark-ui/ChatInterface.tsx
+++ b/ui/src/components/ark-ui/ChatInterface.tsx
@@ -74,6 +74,9 @@ export interface ChatInterfaceProps {
   onHighlightEntities?: (ids: string[]) => void
   /** Open the inline file viewer for a citation clicked in an assistant message. */
   onOpenReference?: (target: OpenReferenceTarget) => void
+  /** True while uploaded sources are still embedding — blocks the composer so the
+   *  user can't query the retriever before its documents are searchable. */
+  embeddingSources?: boolean
   // ---- Per-session progress + run state (lives in the route, see #47) ----
   getProgress: (sessionId: string) => ChainProgressController
   getRunState: (sessionId: string) => SessionRunState
@@ -526,8 +529,12 @@ export const ChatInterface = (props: ChatInterfaceProps) => {
       <div border="t dark-border-primary" p="4" bg="dark-bg-secondary/80" backdrop-blur="sm">
         <ChatInput
           onSend={handleSendMessage}
-          disabled={isProcessing()}
-          blockedMessage={blockedMessage()}
+          disabled={isProcessing() || !!props.embeddingSources}
+          blockedMessage={
+            props.embeddingSources
+              ? 'Embedding sources… you can ask once indexing finishes.'
+              : blockedMessage()
+          }
           focusToken={props.focusInputToken}
         />
       </div>

--- a/ui/src/components/ark-ui/ChatInterface.tsx
+++ b/ui/src/components/ark-ui/ChatInterface.tsx
@@ -29,6 +29,8 @@ import {
   loadConversation,
   extractGraphFromResult,
   extractGraphElements,
+  extractReferences,
+  type OpenReferenceTarget,
 } from '~/lib/harness-client'
 import { getSettings } from '~/lib/settings-store'
 import { parseChatStream, type DoneEventData } from '~/lib/sse-client'
@@ -70,6 +72,8 @@ export interface ChatInterfaceProps {
   graphEntityNames?: Map<string, string[]>
   /** Callback to highlight specific graph element IDs */
   onHighlightEntities?: (ids: string[]) => void
+  /** Open the inline file viewer for a citation clicked in an assistant message. */
+  onOpenReference?: (target: OpenReferenceTarget) => void
   // ---- Per-session progress + run state (lives in the route, see #47) ----
   getProgress: (sessionId: string) => ChainProgressController
   getRunState: (sessionId: string) => SessionRunState
@@ -155,6 +159,22 @@ export const ChatInterface = (props: ChatInterfaceProps) => {
           }
           if (props.onContextUpdate) {
             props.onContextUpdate(ctx)
+          }
+          // Re-attach retriever citations to the latest assistant message so the
+          // Sources footer + inline chips survive reload (best-effort — only the
+          // most recent turn's references are recoverable from the event stream).
+          const refs = extractReferences(events)
+          if (refs.length) {
+            setMessages((prev) => {
+              const next = [...prev]
+              for (let i = next.length - 1; i >= 0; i--) {
+                if (next[i].role === 'assistant') {
+                  next[i] = { ...next[i], references: refs }
+                  break
+                }
+              }
+              return next
+            })
           }
         } catch (err) {
           console.warn('[ChatInterface] failed to replay events:', err)
@@ -319,6 +339,8 @@ export const ChatInterface = (props: ChatInterfaceProps) => {
           role: 'assistant',
           content: finalResponse,
           timestamp: new Date(),
+          // Retriever citations for this turn (inline superscripts + footer).
+          references: extractReferences(finalResult?.context?.events ?? []),
           toolCall: finalResult?.status === 'paused' && (finalResult.data as Record<string, unknown>).pendingAction ? {
             type: 'neo4j',
             status: 'pending',
@@ -484,6 +506,7 @@ export const ChatInterface = (props: ChatInterfaceProps) => {
           onRejectWrite={handleRejectWrite}
           graphEntityNames={props.graphEntityNames}
           onHighlightEntities={props.onHighlightEntities}
+          onOpenReference={props.onOpenReference}
           trailing={() => (
             <LiveProgressBar
               status={currentSnapshot().status}

--- a/ui/src/components/ark-ui/ChatMessages.tsx
+++ b/ui/src/components/ark-ui/ChatMessages.tsx
@@ -6,6 +6,8 @@ import type { ElementDefinition } from 'cytoscape'
 import type { ToolCallInfo } from './types'
 import { ToolCallDisplay } from './ToolCallDisplay'
 import { marked } from 'marked'
+import type { RetrievalReference } from '~/lib/harness-patterns'
+import type { OpenReferenceTarget } from '~/lib/harness-client/reference-extractor'
 
 // Configure marked for safe HTML output
 marked.setOptions({
@@ -26,6 +28,8 @@ export interface Message {
   patternId?: string
   /** Turn/iteration context string, e.g. "(turn 3, attempt 2)" */
   turnInfo?: string
+  /** Retriever citations for this turn (inline superscripts + sources footer). */
+  references?: RetrievalReference[]
 }
 
 interface ChatMessagesProps {
@@ -36,6 +40,8 @@ interface ChatMessagesProps {
   graphEntityNames?: Map<string, string[]>
   /** Callback to highlight graph element IDs (hover/click) */
   onHighlightEntities?: (ids: string[]) => void
+  /** Open the inline file viewer for a cited reference (click on a citation). */
+  onOpenReference?: (target: OpenReferenceTarget) => void
   /** Optional slot rendered after the last message, inside the scroll area —
    *  used by ChatInterface to inline the live progress bar where the next
    *  assistant bubble would appear. */
@@ -99,6 +105,46 @@ function annotateEntities(
   return segments.join('')
 }
 
+/**
+ * Wrap retriever-cited filename mentions in the rendered markdown with a
+ * clickable `.doc-ref` span + a "↗" superscript (mirrors {@link annotateEntities}).
+ * Skips HTML tags and code blocks. The click opens the inline file viewer.
+ */
+function annotateReferences(html: string, references: RetrievalReference[]): string {
+  if (!references || references.length === 0) return html
+  // filename → docId (first reference for that file)
+  const byName = new Map<string, string>()
+  for (const r of references) if (r.source && !byName.has(r.source)) byName.set(r.source, r.docId)
+  const names = [...byName.keys()].filter(n => n.length >= 3).sort((a, b) => b.length - a.length)
+  if (names.length === 0) return html
+
+  const escaped = names.map(n => n.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+  const pattern = new RegExp(`\\b(${escaped.join('|')})\\b`, 'gi')
+
+  const segments = html.split(/(<[^>]+>)/g)
+  let inCode = false
+  for (let i = 0; i < segments.length; i++) {
+    const seg = segments[i]
+    if (seg.startsWith('<code') || seg.startsWith('<pre')) inCode = true
+    if (seg === '</code>' || seg === '</pre>') { inCode = false; continue }
+    if (seg.startsWith('<') || inCode) continue
+
+    segments[i] = seg.replace(pattern, (match) => {
+      const key = [...byName.keys()].find(k => k.toLowerCase() === match.toLowerCase())
+      if (!key) return match
+      const docId = byName.get(key)!
+      return `<span class="doc-ref" data-doc-id="${docId}" title="Open ${key} in viewer">${match}<sup class="doc-ref-mark">↗</sup></span>`
+    })
+  }
+
+  return segments.join('')
+}
+
+/** Unique references by document (one footer chip per cited file). */
+function dedupeReferencesByDoc(references: RetrievalReference[]): RetrievalReference[] {
+  return [...new Map(references.map(r => [r.docId, r])).values()]
+}
+
 // ============================================================================
 // Think Block Extraction
 // ============================================================================
@@ -151,6 +197,14 @@ export const ChatMessages = (props: ChatMessagesProps) => {
   }
 
   const handleClick = (e: MouseEvent) => {
+    // Reference citation (inline superscript) → open the inline file viewer.
+    const refTarget = (e.target as HTMLElement).closest('.doc-ref') as HTMLElement | null
+    if (refTarget) {
+      const docId = refTarget.dataset.docId
+      if (docId) props.onOpenReference?.({ docId })
+      return
+    }
+
     const target = (e.target as HTMLElement).closest('.graph-entity') as HTMLElement | null
     if (!target) return
     const name = target.dataset.entityName
@@ -183,10 +237,10 @@ export const ChatMessages = (props: ChatMessagesProps) => {
     return 'AI'
   }
 
-  /** Render assistant message with entity annotation */
-  const renderAssistantContent = (content: string) => {
+  /** Render assistant message with entity + reference annotation */
+  const renderAssistantContent = (content: string, references: RetrievalReference[]) => {
     const html = marked.parse(content ?? '') as string
-    return annotateEntities(html, props.graphEntityNames ?? new Map())
+    return annotateReferences(annotateEntities(html, props.graphEntityNames ?? new Map()), references)
   }
 
   return (
@@ -278,8 +332,30 @@ export const ChatMessages = (props: ChatMessagesProps) => {
                                 text="sm"
                                 class="prose-chat"
                                 // eslint-disable-next-line solid/no-innerhtml
-                                innerHTML={renderAssistantContent(body)}
+                                innerHTML={renderAssistantContent(body, message.references ?? [])}
                               />
+                              {/* Sources footer — one chip per cited file; opens
+                                  the inline file viewer (navigator pages chunks). */}
+                              <Show when={message.references && message.references.length > 0}>
+                                <div class="doc-ref-footer">
+                                  <span text="xs dark-text-tertiary">Sources:</span>
+                                  <For each={dedupeReferencesByDoc(message.references!)}>
+                                    {(r) => (
+                                      <button
+                                        class="doc-ref-chip"
+                                        title={`Open ${r.source} in viewer`}
+                                        onClick={(e) => {
+                                          e.stopPropagation()
+                                          props.onOpenReference?.({ docId: r.docId })
+                                        }}
+                                      >
+                                        <span class="i-mdi-file-document-outline" style={{ width: '11px', height: '11px' }} />
+                                        {r.source}
+                                      </button>
+                                    )}
+                                  </For>
+                                </div>
+                              </Show>
                             </>
                           )
                         })()}

--- a/ui/src/components/ark-ui/DataStashPanel.tsx
+++ b/ui/src/components/ark-ui/DataStashPanel.tsx
@@ -624,8 +624,11 @@ const FileViewer = (props: {
     setContent(null)
     fetch(`/api/stash/document/${encodeURIComponent(id)}?sessionId=${encodeURIComponent(sid)}`)
       .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
-      .then((d: { content?: string; encoding?: string }) => {
-        if (d.encoding === 'base64') setError('Binary file — no text preview')
+      // The route wraps the doc: `{ document: { content, encoding, … } }`.
+      .then((body: { document?: { content?: string; encoding?: string } }) => {
+        const d = body.document
+        if (!d) setError('Document not found')
+        else if (d.encoding === 'base64') setError('Binary file — no text preview')
         else setContent(d.content ?? '')
       })
       .catch((e) => setError(e instanceof Error ? e.message : 'Failed to load file'))

--- a/ui/src/components/ark-ui/DataStashPanel.tsx
+++ b/ui/src/components/ark-ui/DataStashPanel.tsx
@@ -387,6 +387,8 @@ const IconGallery = (props: { items: ToolResultItem[]; onAction: (id: string, ac
 const DocChip = (props: {
   doc: StashDocumentMeta
   onAction: (id: string, action: DocAction) => Promise<void>
+  onView: () => void
+  active?: boolean
 }) => {
   const d = () => props.doc
   const grayed = () => !!(d().hidden || d().archived)
@@ -425,6 +427,36 @@ const DocChip = (props: {
 
   return (
     <div style={{ position: 'relative', display: 'inline-block' }}>
+      {/* "Eye" — open the inline file viewer. Text docs only (binary has no
+          text view). Stops propagation so it doesn't also open the chip menu. */}
+      <Show when={d().encoding !== 'base64'}>
+        <button
+          onClick={(e) => {
+            e.stopPropagation()
+            props.onView()
+          }}
+          title="View file"
+          style={{
+            position: 'absolute',
+            top: '0px',
+            right: '0px',
+            'z-index': '6',
+            background: 'transparent',
+            border: 'none',
+            cursor: 'pointer',
+            padding: '2px',
+            'line-height': '0',
+            opacity: props.active ? '1' : '0.55',
+          }}
+          onMouseEnter={(e) => (e.currentTarget.style.opacity = '1')}
+          onMouseLeave={(e) => (e.currentTarget.style.opacity = props.active ? '1' : '0.55')}
+        >
+          <span
+            class={props.active ? 'i-mdi-eye' : 'i-mdi-eye-outline'}
+            style={{ width: '13px', height: '13px', color: '#22d3ee', display: 'block' }}
+          />
+        </button>
+      </Show>
       {/* Native title tooltip — keeps the chip simple; Ark's Tooltip is used by
           the tool-result chips above. */}
       <div
@@ -436,8 +468,8 @@ const DocChip = (props: {
         w="16"
         cursor="pointer"
         rounded="lg"
-        bg={menuOpen() ? 'dark-bg-tertiary' : 'transparent hover:dark-bg-secondary'}
-        border={menuOpen() ? '1 dark-border-secondary' : '1 transparent hover:dark-border-primary'}
+        bg={props.active ? 'dark-bg-tertiary' : menuOpen() ? 'dark-bg-tertiary' : 'transparent hover:dark-bg-secondary'}
+        border={props.active || menuOpen() ? '1 dark-border-secondary' : '1 transparent hover:dark-border-primary'}
         transition="all"
         opacity={grayed() ? '35' : loading() ? '50' : '100'}
         onClick={() => setMenuOpen(!menuOpen())}
@@ -563,6 +595,143 @@ const DocChip = (props: {
 }
 
 // ============================================================================
+// Inline File Viewer — raw text + line numbers, scrollable, reference-highlighted
+// ============================================================================
+
+/** A char range to highlight in the viewer (from a retrieval reference). Line
+ *  numbers are derived here, after the file content is fetched. */
+export interface ViewerHighlight {
+  startOffset: number
+  endOffset: number
+}
+
+const FileViewer = (props: {
+  sessionId: string
+  doc: StashDocumentMeta
+  highlight?: ViewerHighlight
+  onClose: () => void
+}) => {
+  const [content, setContent] = createSignal<string | null>(null)
+  const [error, setError] = createSignal<string | null>(null)
+  const [loading, setLoading] = createSignal(true)
+
+  // Fetch the full document text on open / when the target doc changes.
+  createEffect(() => {
+    const id = props.doc.id
+    const sid = props.sessionId
+    setLoading(true)
+    setError(null)
+    setContent(null)
+    fetch(`/api/stash/document/${encodeURIComponent(id)}?sessionId=${encodeURIComponent(sid)}`)
+      .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
+      .then((d: { content?: string; encoding?: string }) => {
+        if (d.encoding === 'base64') setError('Binary file — no text preview')
+        else setContent(d.content ?? '')
+      })
+      .catch((e) => setError(e instanceof Error ? e.message : 'Failed to load file'))
+      .finally(() => setLoading(false))
+  })
+
+  const lines = createMemo(() => (content() ?? '').split('\n'))
+
+  // Char offsets → 1-based inclusive line range (the chunker's offsets satisfy
+  // content === docText.slice(start, end)).
+  const hlRange = createMemo(() => {
+    const c = content()
+    const h = props.highlight
+    if (!c || !h) return null
+    const start = Math.max(0, Math.min(h.startOffset, c.length))
+    const end = Math.max(start, Math.min(h.endOffset, c.length))
+    return {
+      startLine: c.slice(0, start).split('\n').length,
+      endLine: c.slice(0, end).split('\n').length,
+    }
+  })
+
+  // Scroll the first highlighted line into view once content + ref are ready.
+  let firstHot: HTMLDivElement | undefined
+  createEffect(() => {
+    if (content() && hlRange() && firstHot) firstHot.scrollIntoView({ block: 'center' })
+  })
+
+  return (
+    <div border="t dark-border-primary" bg="dark-bg-secondary" flex="~ col" style={{ 'max-height': '340px' }}>
+      <div flex="~" items="center" gap="2" p="x-3 y-2" bg="dark-bg-tertiary" border="b dark-border-primary">
+        <span
+          class={getDocIcon(props.doc.mimeType, props.doc.filename)}
+          style={{ width: '14px', height: '14px', color: '#34d399', 'flex-shrink': '0' }}
+        />
+        <span text="xs dark-text-secondary" font="mono" style={{ flex: '1', 'word-break': 'break-all' }}>
+          {props.doc.filename}
+        </span>
+        <Show when={hlRange()}>
+          {(r) => (
+            <span text="xs" style={{ color: '#f59e0b', 'font-family': 'monospace' }}>
+              L{r().startLine}{r().endLine !== r().startLine ? `–${r().endLine}` : ''}
+            </span>
+          )}
+        </Show>
+        <button
+          onClick={() => props.onClose()}
+          title="Close viewer"
+          style={{ background: 'transparent', border: 'none', cursor: 'pointer', color: '#71717a', 'font-size': '13px', 'line-height': '1', padding: '2px 4px' }}
+        >
+          ✕
+        </button>
+      </div>
+      <div
+        style={{ overflow: 'auto', 'font-family': '"Fira Code", ui-monospace, monospace', 'font-size': '11px', 'line-height': '1.55' }}
+      >
+        <Show when={loading()}>
+          <div p="3" flex="~" items="center" gap="2" text="xs dark-text-tertiary">
+            <span class="i-mdi-loading" style={{ width: '14px', height: '14px', animation: 'spin 1s linear infinite' }} />
+            <span>Loading file…</span>
+          </div>
+        </Show>
+        <Show when={error()}>
+          <div p="3" text="xs red-400">{error()}</div>
+        </Show>
+        <Show when={content() !== null}>
+          <For each={lines()}>
+            {(line, i) => {
+              const n = i() + 1
+              const r = hlRange()
+              const hot = !!r && n >= r.startLine && n <= r.endLine
+              return (
+                <div
+                  ref={(el) => {
+                    if (r && n === r.startLine) firstHot = el
+                  }}
+                  flex="~"
+                  style={{ background: hot ? 'rgba(245,158,11,0.13)' : 'transparent' }}
+                >
+                  <span
+                    style={{
+                      width: '42px',
+                      'flex-shrink': '0',
+                      'text-align': 'right',
+                      padding: '0 8px',
+                      color: '#52525b',
+                      'user-select': 'none',
+                      'border-right': hot ? '2px solid #f59e0b' : '2px solid transparent',
+                    }}
+                  >
+                    {n}
+                  </span>
+                  <span style={{ 'white-space': 'pre-wrap', 'word-break': 'break-word', padding: '0 10px', color: '#d4d4d8', flex: '1' }}>
+                    {line || ' '}
+                  </span>
+                </div>
+              )
+            }}
+          </For>
+        </Show>
+      </div>
+    </div>
+  )
+}
+
+// ============================================================================
 // Upload Zone — file picker + drag-and-drop (Issue #6)
 // ============================================================================
 
@@ -671,11 +840,19 @@ export const DataStashPanel = (props: DataStashPanelProps) => {
   const [watching, setWatching] = createSignal(false)
   let watchTimer: ReturnType<typeof setTimeout> | undefined
   let inFlight = false
+  // Inline file viewer: which doc is open + an optional char range to highlight.
+  const [viewer, setViewer] = createSignal<{ doc: StashDocumentMeta; highlight?: ViewerHighlight } | null>(null)
 
   const applyDocs = (sid: string, list: StashDocumentMeta[]) => {
     docCache.set(sid, list)
     if (sid === props.sessionId) setDocs(list)
   }
+
+  // Close the viewer if its doc disappears (deleted) or the session changes.
+  createEffect(() => {
+    const v = viewer()
+    if (v && !docs().some((d) => d.id === v.doc.id)) setViewer(null)
+  })
 
   // Single-flight background refresh. Shows a spinner only on the cold load
   // (nothing cached yet); otherwise updates silently behind the cached view.
@@ -851,9 +1028,27 @@ export const DataStashPanel = (props: DataStashPanelProps) => {
         <Show when={docs().length > 0}>
           <div flex="~ wrap" gap="2" p="x-3 y-2">
             <For each={docs()}>
-              {(doc) => <DocChip doc={doc} onAction={handleDocAction} />}
+              {(doc) => (
+                <DocChip
+                  doc={doc}
+                  onAction={handleDocAction}
+                  onView={() => setViewer((v) => (v?.doc.id === doc.id ? null : { doc }))}
+                  active={viewer()?.doc.id === doc.id}
+                />
+              )}
             </For>
           </div>
+        </Show>
+        {/* Inline viewer for the open file — full width, below the gallery. */}
+        <Show when={viewer()}>
+          {(v) => (
+            <FileViewer
+              sessionId={props.sessionId}
+              doc={v().doc}
+              highlight={v().highlight}
+              onClose={() => setViewer(null)}
+            />
+          )}
         </Show>
         {/* Cold-load only — never blocks the drop zone (background refresh). */}
         <Show when={loading() && docs().length === 0}>

--- a/ui/src/components/ark-ui/DataStashPanel.tsx
+++ b/ui/src/components/ark-ui/DataStashPanel.tsx
@@ -11,12 +11,12 @@
  * Hovering shows the LLM summary (or a raw preview if no summary yet).
  */
 
-import { For, Show, createSignal, createMemo, createEffect, onCleanup } from 'solid-js'
+import { For, Show, createSignal, createMemo, createEffect, on, onCleanup } from 'solid-js'
 import { isServer } from 'solid-js/web'
 import { Tooltip } from '@ark-ui/solid/tooltip'
 import type { ContextEvent, ToolResultEventData, RetrievalReference } from '~/lib/harness-patterns'
 import type { StashDocumentMeta } from '~/lib/document-store.server'
-import { referencesForDoc } from '~/lib/harness-client/reference-extractor'
+import { referencesForDoc, type OpenReferenceTarget } from '~/lib/harness-client/reference-extractor'
 
 // ============================================================================
 // Types
@@ -31,6 +31,8 @@ export interface DataStashPanelProps {
   events: ContextEvent[]
   sessionId: string
   onStashAction: (eventId: string, action: StashAction) => Promise<void>
+  /** A citation clicked in the chat — open the inline viewer at this reference. */
+  pendingReference?: OpenReferenceTarget | null
 }
 
 interface ToolResultItem {
@@ -914,6 +916,28 @@ export const DataStashPanel = (props: DataStashPanelProps) => {
     const v = viewer()
     if (v && !docs().some((d) => d.id === v.doc.id)) setViewer(null)
   })
+
+  // A citation was clicked in the chat → open the viewer at that reference.
+  // Scoped to `pendingReference` only (via `on`), so a background doc-list
+  // refresh doesn't re-open/reset the viewer while the user navigates chunks.
+  createEffect(
+    on(
+      () => props.pendingReference,
+      (ref) => {
+        if (!ref) return
+        const doc = docs().find((d) => d.id === ref.docId)
+        if (!doc) return // not one of this session's uploads
+        const refs = referencesForDoc(props.events, ref.docId)
+        const idx =
+          ref.startOffset != null
+            ? refs.findIndex(
+                (r) => r.startOffset === ref.startOffset && r.endOffset === ref.endOffset,
+              )
+            : 0
+        openViewer(doc, Math.max(0, idx))
+      },
+    ),
+  )
 
   // Single-flight background refresh. Shows a spinner only on the cold load
   // (nothing cached yet); otherwise updates silently behind the cached view.

--- a/ui/src/components/ark-ui/DataStashPanel.tsx
+++ b/ui/src/components/ark-ui/DataStashPanel.tsx
@@ -14,8 +14,9 @@
 import { For, Show, createSignal, createMemo, createEffect, onCleanup } from 'solid-js'
 import { isServer } from 'solid-js/web'
 import { Tooltip } from '@ark-ui/solid/tooltip'
-import type { ContextEvent, ToolResultEventData } from '~/lib/harness-patterns'
+import type { ContextEvent, ToolResultEventData, RetrievalReference } from '~/lib/harness-patterns'
 import type { StashDocumentMeta } from '~/lib/document-store.server'
+import { referencesForDoc } from '~/lib/harness-client/reference-extractor'
 
 // ============================================================================
 // Types
@@ -605,15 +606,35 @@ export interface ViewerHighlight {
   endOffset: number
 }
 
+/** 1-based inclusive line range for a char offset span in `content`. */
+function offsetsToLines(content: string, h: ViewerHighlight): { startLine: number; endLine: number } {
+  const start = Math.max(0, Math.min(h.startOffset, content.length))
+  const end = Math.max(start, Math.min(h.endOffset, content.length))
+  return {
+    startLine: content.slice(0, start).split('\n').length,
+    endLine: content.slice(0, end).split('\n').length,
+  }
+}
+
 const FileViewer = (props: {
   sessionId: string
   doc: StashDocumentMeta
-  highlight?: ViewerHighlight
+  highlights: ViewerHighlight[]
+  initialIndex?: number
   onClose: () => void
 }) => {
   const [content, setContent] = createSignal<string | null>(null)
   const [error, setError] = createSignal<string | null>(null)
   const [loading, setLoading] = createSignal(true)
+  // Which highlight the navigator is focused on (scrolled to + emphasized).
+  const [current, setCurrent] = createSignal(props.initialIndex ?? 0)
+
+  // Reset the focused highlight when the target doc or the incoming index
+  // changes (the viewer instance is reused across re-opens).
+  createEffect(() => {
+    props.doc.id
+    setCurrent(props.initialIndex ?? 0)
+  })
 
   // Fetch the full document text on open / when the target doc changes.
   createEffect(() => {
@@ -637,24 +658,26 @@ const FileViewer = (props: {
 
   const lines = createMemo(() => (content() ?? '').split('\n'))
 
-  // Char offsets → 1-based inclusive line range (the chunker's offsets satisfy
-  // content === docText.slice(start, end)).
-  const hlRange = createMemo(() => {
+  // All highlight ranges (aligned with props.highlights), once content is in.
+  const ranges = createMemo(() => {
     const c = content()
-    const h = props.highlight
-    if (!c || !h) return null
-    const start = Math.max(0, Math.min(h.startOffset, c.length))
-    const end = Math.max(start, Math.min(h.endOffset, c.length))
-    return {
-      startLine: c.slice(0, start).split('\n').length,
-      endLine: c.slice(0, end).split('\n').length,
-    }
+    if (!c) return [] as { startLine: number; endLine: number }[]
+    return props.highlights.map((h) => offsetsToLines(c, h))
   })
+  const activeRange = createMemo(() => ranges()[current()] ?? null)
+  // Every line covered by any highlight (light tint).
+  const hotLines = createMemo(() => {
+    const s = new Set<number>()
+    for (const r of ranges()) for (let n = r.startLine; n <= r.endLine; n++) s.add(n)
+    return s
+  })
+  const total = () => props.highlights.length
 
-  // Scroll the first highlighted line into view once content + ref are ready.
-  let firstHot: HTMLDivElement | undefined
+  // Scroll the focused range's first line into view when content / current change.
+  const lineEls = new Map<number, HTMLDivElement>()
   createEffect(() => {
-    if (content() && hlRange() && firstHot) firstHot.scrollIntoView({ block: 'center' })
+    const r = activeRange()
+    if (content() && r) lineEls.get(r.startLine)?.scrollIntoView({ block: 'center' })
   })
 
   return (
@@ -667,12 +690,34 @@ const FileViewer = (props: {
         <span text="xs dark-text-secondary" font="mono" style={{ flex: '1', 'word-break': 'break-all' }}>
           {props.doc.filename}
         </span>
-        <Show when={hlRange()}>
+        <Show when={activeRange()}>
           {(r) => (
             <span text="xs" style={{ color: '#f59e0b', 'font-family': 'monospace' }}>
               L{r().startLine}{r().endLine !== r().startLine ? `–${r().endLine}` : ''}
             </span>
           )}
+        </Show>
+        {/* Prev/next navigator across this doc's referenced chunks. */}
+        <Show when={total() > 1}>
+          <div flex="~" items="center" gap="1">
+            <button
+              onClick={() => setCurrent((c) => Math.max(0, c - 1))}
+              disabled={current() === 0}
+              title="Previous reference"
+              style={{ background: 'transparent', border: 'none', cursor: current() === 0 ? 'default' : 'pointer', color: current() === 0 ? '#3f3f46' : '#a1a1aa', 'font-size': '13px', 'line-height': '1', padding: '0 2px' }}
+            >
+              ‹
+            </button>
+            <span text="xs dark-text-tertiary" font="mono">{current() + 1}/{total()}</span>
+            <button
+              onClick={() => setCurrent((c) => Math.min(total() - 1, c + 1))}
+              disabled={current() === total() - 1}
+              title="Next reference"
+              style={{ background: 'transparent', border: 'none', cursor: current() === total() - 1 ? 'default' : 'pointer', color: current() === total() - 1 ? '#3f3f46' : '#a1a1aa', 'font-size': '13px', 'line-height': '1', padding: '0 2px' }}
+            >
+              ›
+            </button>
+          </div>
         </Show>
         <button
           onClick={() => props.onClose()}
@@ -698,15 +743,14 @@ const FileViewer = (props: {
           <For each={lines()}>
             {(line, i) => {
               const n = i() + 1
-              const r = hlRange()
-              const hot = !!r && n >= r.startLine && n <= r.endLine
+              const hot = () => hotLines().has(n)
+              const r = () => activeRange()
+              const active = () => !!r() && n >= r()!.startLine && n <= r()!.endLine
               return (
                 <div
-                  ref={(el) => {
-                    if (r && n === r.startLine) firstHot = el
-                  }}
+                  ref={(el) => lineEls.set(n, el)}
                   flex="~"
-                  style={{ background: hot ? 'rgba(245,158,11,0.13)' : 'transparent' }}
+                  style={{ background: active() ? 'rgba(245,158,11,0.16)' : hot() ? 'rgba(245,158,11,0.07)' : 'transparent' }}
                 >
                   <span
                     style={{
@@ -716,7 +760,7 @@ const FileViewer = (props: {
                       padding: '0 8px',
                       color: '#52525b',
                       'user-select': 'none',
-                      'border-right': hot ? '2px solid #f59e0b' : '2px solid transparent',
+                      'border-right': active() ? '2px solid #f59e0b' : hot() ? '2px solid rgba(245,158,11,0.4)' : '2px solid transparent',
                     }}
                   >
                     {n}
@@ -844,7 +888,21 @@ export const DataStashPanel = (props: DataStashPanelProps) => {
   let watchTimer: ReturnType<typeof setTimeout> | undefined
   let inFlight = false
   // Inline file viewer: which doc is open + an optional char range to highlight.
-  const [viewer, setViewer] = createSignal<{ doc: StashDocumentMeta; highlight?: ViewerHighlight } | null>(null)
+  const [viewer, setViewer] = createSignal<{
+    doc: StashDocumentMeta
+    highlights: ViewerHighlight[]
+    index: number
+  } | null>(null)
+
+  /** Open the viewer for a doc, highlighting its retrieved chunks (from the
+   *  latest retriever result in props.events), focused on `index`. */
+  const openViewer = (doc: StashDocumentMeta, index = 0) => {
+    const highlights = referencesForDoc(props.events, doc.id).map((r) => ({
+      startOffset: r.startOffset,
+      endOffset: r.endOffset,
+    }))
+    setViewer({ doc, highlights, index: Math.max(0, Math.min(index, Math.max(0, highlights.length - 1))) })
+  }
 
   const applyDocs = (sid: string, list: StashDocumentMeta[]) => {
     docCache.set(sid, list)
@@ -1035,7 +1093,7 @@ export const DataStashPanel = (props: DataStashPanelProps) => {
                 <DocChip
                   doc={doc}
                   onAction={handleDocAction}
-                  onView={() => setViewer((v) => (v?.doc.id === doc.id ? null : { doc }))}
+                  onView={() => (viewer()?.doc.id === doc.id ? setViewer(null) : openViewer(doc))}
                   active={viewer()?.doc.id === doc.id}
                 />
               )}
@@ -1048,7 +1106,8 @@ export const DataStashPanel = (props: DataStashPanelProps) => {
             <FileViewer
               sessionId={props.sessionId}
               doc={v().doc}
-              highlight={v().highlight}
+              highlights={v().highlights}
+              initialIndex={v().index}
               onClose={() => setViewer(null)}
             />
           )}

--- a/ui/src/components/ark-ui/DataStashPanel.tsx
+++ b/ui/src/components/ark-ui/DataStashPanel.tsx
@@ -11,7 +11,7 @@
  * Hovering shows the LLM summary (or a raw preview if no summary yet).
  */
 
-import { For, Show, createSignal, createMemo, createResource } from 'solid-js'
+import { For, Show, createSignal, createMemo, createResource, createEffect, onCleanup } from 'solid-js'
 import { isServer } from 'solid-js/web'
 import { Tooltip } from '@ark-ui/solid/tooltip'
 import type { ContextEvent, ToolResultEventData } from '~/lib/harness-patterns'
@@ -390,6 +390,11 @@ const DocChip = (props: {
 }) => {
   const d = () => props.doc
   const grayed = () => !!(d().hidden || d().archived)
+  // Vector-ingestion status set by the harness-aware auto-ingest path. `pending`
+  // → the upload is being chunked/embedded into the local vector store; `failed`
+  // → ingest errored (e.g. embedder offline). Absent → not ingested (the agent
+  // has no redis retriever) — show nothing.
+  const status = () => d().ingestStatus
   const [loading, setLoading] = createSignal(false)
   const [menuOpen, setMenuOpen] = createSignal(false)
 
@@ -437,15 +442,48 @@ const DocChip = (props: {
         opacity={grayed() ? '35' : loading() ? '50' : '100'}
         onClick={() => setMenuOpen(!menuOpen())}
       >
-        <span
-          class={getDocIcon(d().mimeType, d().filename)}
-          style={{
-            width: '28px',
-            height: '28px',
-            color: grayed() ? '#52525b' : '#34d399',
-            transition: 'all 0.15s',
-          }}
-        />
+        {/* Icon + an ingestion indicator badge over its corner. */}
+        <div style={{ position: 'relative', display: 'inline-flex' }}>
+          <span
+            class={getDocIcon(d().mimeType, d().filename)}
+            style={{
+              width: '28px',
+              height: '28px',
+              color: grayed() ? '#52525b' : '#34d399',
+              opacity: status() === 'pending' ? '0.5' : '1',
+              transition: 'all 0.15s',
+            }}
+          />
+          <Show when={status() === 'pending'}>
+            <span
+              class="i-mdi-loading"
+              title="Embedding into the vector store…"
+              style={{
+                position: 'absolute',
+                top: '-5px',
+                right: '-7px',
+                width: '14px',
+                height: '14px',
+                color: '#f59e0b',
+                animation: 'spin 1s linear infinite',
+              }}
+            />
+          </Show>
+          <Show when={status() === 'failed'}>
+            <span
+              class="i-mdi-alert-circle"
+              title="Ingest failed — not searchable (is the embedder running?)"
+              style={{
+                position: 'absolute',
+                top: '-5px',
+                right: '-7px',
+                width: '13px',
+                height: '13px',
+                color: '#f87171',
+              }}
+            />
+          </Show>
+        </div>
         <span
           style={{
             'font-family': '"Fira Code", ui-monospace, monospace',
@@ -459,6 +497,17 @@ const DocChip = (props: {
         >
           {truncate(d().filename, 18)}
         </span>
+        {/* "embedding…" / "failed" line below the icon. */}
+        <Show when={status() === 'pending'}>
+          <span style={{ 'font-size': '8px', color: '#f59e0b', 'line-height': '1.1' }}>
+            embedding…
+          </span>
+        </Show>
+        <Show when={status() === 'failed'}>
+          <span style={{ 'font-size': '8px', color: '#f87171', 'line-height': '1.1' }}>
+            index failed
+          </span>
+        </Show>
       </div>
 
       <Show when={menuOpen()}>
@@ -608,6 +657,11 @@ export const DataStashPanel = (props: DataStashPanelProps) => {
   )
   const [uploading, setUploading] = createSignal(false)
   const [uploadError, setUploadError] = createSignal<string | null>(null)
+  // Post-upload watch window: ingest runs in the background server-side, so we
+  // poll briefly after an upload to catch the (absent → pending → indexed)
+  // status transitions even before the first `pending` lands.
+  const [watching, setWatching] = createSignal(false)
+  let watchTimer: ReturnType<typeof setTimeout> | undefined
 
   const uploadFiles = async (files: File[]) => {
     if (!props.sessionId) {
@@ -626,12 +680,20 @@ export const DataStashPanel = (props: DataStashPanelProps) => {
           const body = (await res.json().catch(() => ({}))) as { error?: string }
           throw new Error(body.error ?? `Upload failed (${res.status})`)
         }
+        // Show each upload as soon as it's stored (the POST returns before
+        // ingest finishes), rather than waiting for the whole batch.
+        await refetch()
       }
-      await refetch()
     } catch (err) {
       setUploadError(err instanceof Error ? err.message : 'Upload failed')
     } finally {
       setUploading(false)
+      // Open a ~15s watch window so the "embedding…" indicator appears + clears
+      // without a manual refresh, then stops (covers the no-retriever case where
+      // no status ever lands).
+      setWatching(true)
+      if (watchTimer) clearTimeout(watchTimer)
+      watchTimer = setTimeout(() => setWatching(false), 15000)
     }
   }
 
@@ -673,6 +735,21 @@ export const DataStashPanel = (props: DataStashPanelProps) => {
   }
 
   const docs = createMemo(() => documents() ?? [])
+
+  // Poll for ingest-status changes while any upload is `pending` or we're inside
+  // the post-upload watch window. The effect re-runs whenever `docs()` or
+  // `watching()` changes; each run that still needs updates arms a single
+  // interval and tears it down on the next run (or on unmount).
+  createEffect(() => {
+    if (isServer) return
+    const active = watching() || docs().some((d) => d.ingestStatus === 'pending')
+    if (!active) return
+    const timer = setInterval(() => void refetch(), 2500)
+    onCleanup(() => clearInterval(timer))
+  })
+  onCleanup(() => {
+    if (watchTimer) clearTimeout(watchTimer)
+  })
 
   const partitioned = createMemo(() => {
     const toolResults: ToolResultItem[] = props.events

--- a/ui/src/components/ark-ui/DataStashPanel.tsx
+++ b/ui/src/components/ark-ui/DataStashPanel.tsx
@@ -36,6 +36,8 @@ export interface DataStashPanelProps {
   onStashAction: (eventId: string, action: StashAction) => Promise<void>
   /** A citation clicked in the chat — open the inline viewer at this reference. */
   pendingReference?: OpenReferenceTarget | null
+  /** Fired after a successful upload (so the route can watch embedding status). */
+  onUploaded?: () => void
 }
 
 interface ToolResultItem {
@@ -995,13 +997,16 @@ export const DataStashPanel = (props: DataStashPanelProps) => {
       setUploadError(err instanceof Error ? err.message : 'Upload failed')
     } finally {
       setUploading(false)
-      // Open a ~20s watch window so the "embedding…" indicator appears + clears
-      // without a manual refresh, then stops (covers the no-retriever case where
-      // no status ever lands). One reconcile refresh picks up server-side fields.
+      // The upload response already carries `ingestStatus` (the optimistic add
+      // shows "embedding…" instantly), so we DON'T refresh immediately — an
+      // early fetch would race the background ingest and clobber the optimistic
+      // `pending` back to none. Open a ~25s watch window instead; the poll
+      // reconciles pending → indexed once redis catches up.
       setWatching(true)
       if (watchTimer) clearTimeout(watchTimer)
-      watchTimer = setTimeout(() => setWatching(false), 20000)
-      void refresh()
+      watchTimer = setTimeout(() => setWatching(false), 25000)
+      // Let the route track embedding status (to block the chat composer).
+      props.onUploaded?.()
     }
   }
 

--- a/ui/src/components/ark-ui/DataStashPanel.tsx
+++ b/ui/src/components/ark-ui/DataStashPanel.tsx
@@ -30,6 +30,9 @@ export type DocAction = StashAction | 'delete' | 'download'
 export interface DataStashPanelProps {
   events: ContextEvent[]
   sessionId: string
+  /** The conversation's selected agent — sent with uploads so the auto-ingest
+   *  gate can resolve the harness even before the session is persisted. */
+  agentId?: string
   onStashAction: (eventId: string, action: StashAction) => Promise<void>
   /** A citation clicked in the chat — open the inline viewer at this reference. */
   pendingReference?: OpenReferenceTarget | null
@@ -973,6 +976,7 @@ export const DataStashPanel = (props: DataStashPanelProps) => {
       for (const file of files) {
         const form = new FormData()
         form.set('sessionId', sid)
+        if (props.agentId) form.set('agentId', props.agentId)
         form.set('file', file)
         const res = await fetch('/api/stash/upload', { method: 'POST', body: form })
         const body = (await res.json().catch(() => ({}))) as {

--- a/ui/src/components/ark-ui/DataStashPanel.tsx
+++ b/ui/src/components/ark-ui/DataStashPanel.tsx
@@ -11,7 +11,7 @@
  * Hovering shows the LLM summary (or a raw preview if no summary yet).
  */
 
-import { For, Show, createSignal, createMemo, createResource, createEffect, onCleanup } from 'solid-js'
+import { For, Show, createSignal, createMemo, createEffect, onCleanup } from 'solid-js'
 import { isServer } from 'solid-js/web'
 import { Tooltip } from '@ark-ui/solid/tooltip'
 import type { ContextEvent, ToolResultEventData } from '~/lib/harness-patterns'
@@ -640,6 +640,14 @@ const UploadZone = (props: {
 // Main Component
 // ============================================================================
 
+// Client-side cache of a session's uploaded-doc list. Ark's Tabs unmounts the
+// inactive tab, so this panel re-mounts every time it's selected — without the
+// cache, each re-mount re-ran a ~12s `listDocuments` and the Suspense boundary
+// flashed "Loading data…". We seed the signal from the cache (instant) and
+// refresh in the background, so re-selecting the tab is immediate and never
+// blanks the panel. (No suspending resource → the Suspense fallback never fires.)
+const docCache = new Map<string, StashDocumentMeta[]>()
+
 async function fetchDocuments(sessionId: string): Promise<StashDocumentMeta[]> {
   const res = await fetch(`/api/stash/upload?sessionId=${encodeURIComponent(sessionId)}`)
   if (!res.ok) return []
@@ -649,12 +657,12 @@ async function fetchDocuments(sessionId: string): Promise<StashDocumentMeta[]> {
 
 export const DataStashPanel = (props: DataStashPanelProps) => {
   // Uploaded documents live in Redis (Issue #6), separate from the tool_result
-  // events in `props.events`. Fetched on mount and refetched after mutations.
-  // Guarded against SSR — relative-URL fetch has no origin on the server.
-  const [documents, { refetch }] = createResource(
-    () => (isServer ? undefined : props.sessionId || undefined),
-    fetchDocuments,
+  // events in `props.events`. Seeded from the module cache, refreshed in the
+  // background — see `docCache` above.
+  const [docs, setDocs] = createSignal<StashDocumentMeta[]>(
+    props.sessionId ? (docCache.get(props.sessionId) ?? []) : [],
   )
+  const [loading, setLoading] = createSignal(false)
   const [uploading, setUploading] = createSignal(false)
   const [uploadError, setUploadError] = createSignal<string | null>(null)
   // Post-upload watch window: ingest runs in the background server-side, so we
@@ -662,9 +670,38 @@ export const DataStashPanel = (props: DataStashPanelProps) => {
   // status transitions even before the first `pending` lands.
   const [watching, setWatching] = createSignal(false)
   let watchTimer: ReturnType<typeof setTimeout> | undefined
+  let inFlight = false
+
+  const applyDocs = (sid: string, list: StashDocumentMeta[]) => {
+    docCache.set(sid, list)
+    if (sid === props.sessionId) setDocs(list)
+  }
+
+  // Single-flight background refresh. Shows a spinner only on the cold load
+  // (nothing cached yet); otherwise updates silently behind the cached view.
+  const refresh = async () => {
+    const sid = props.sessionId
+    if (!sid || isServer || inFlight) return
+    inFlight = true
+    if (!docCache.has(sid)) setLoading(true)
+    try {
+      applyDocs(sid, await fetchDocuments(sid))
+    } finally {
+      inFlight = false
+      setLoading(false)
+    }
+  }
+
+  // (Re)seed from cache + refresh whenever the session changes.
+  createEffect(() => {
+    const sid = props.sessionId
+    setDocs(sid ? (docCache.get(sid) ?? []) : [])
+    if (sid) void refresh()
+  })
 
   const uploadFiles = async (files: File[]) => {
-    if (!props.sessionId) {
+    const sid = props.sessionId
+    if (!sid) {
       setUploadError('Start a conversation before uploading')
       return
     }
@@ -673,37 +710,43 @@ export const DataStashPanel = (props: DataStashPanelProps) => {
     try {
       for (const file of files) {
         const form = new FormData()
-        form.set('sessionId', props.sessionId)
+        form.set('sessionId', sid)
         form.set('file', file)
         const res = await fetch('/api/stash/upload', { method: 'POST', body: form })
-        if (!res.ok) {
-          const body = (await res.json().catch(() => ({}))) as { error?: string }
-          throw new Error(body.error ?? `Upload failed (${res.status})`)
+        const body = (await res.json().catch(() => ({}))) as {
+          error?: string
+          document?: StashDocumentMeta
         }
-        // Show each upload as soon as it's stored (the POST returns before
-        // ingest finishes), rather than waiting for the whole batch.
-        await refetch()
+        if (!res.ok) throw new Error(body.error ?? `Upload failed (${res.status})`)
+        // Show each upload the instant it's stored — the POST returns before
+        // ingest finishes, so there's no blocking refetch here.
+        if (body.document) {
+          const doc = body.document
+          applyDocs(sid, [doc, ...docs().filter((d) => d.id !== doc.id)])
+        }
       }
     } catch (err) {
       setUploadError(err instanceof Error ? err.message : 'Upload failed')
     } finally {
       setUploading(false)
-      // Open a ~15s watch window so the "embedding…" indicator appears + clears
+      // Open a ~20s watch window so the "embedding…" indicator appears + clears
       // without a manual refresh, then stops (covers the no-retriever case where
-      // no status ever lands).
+      // no status ever lands). One reconcile refresh picks up server-side fields.
       setWatching(true)
       if (watchTimer) clearTimeout(watchTimer)
-      watchTimer = setTimeout(() => setWatching(false), 15000)
+      watchTimer = setTimeout(() => setWatching(false), 20000)
+      void refresh()
     }
   }
 
   const handleDocAction = async (id: string, action: DocAction) => {
-    if (!props.sessionId) return
+    const sid = props.sessionId
+    if (!sid) return
     if (action === 'download') {
       // Stream the raw file via the ?download route (binary is base64-decoded
       // server-side). Anchor-click so the Content-Disposition filename is used.
       const a = document.createElement('a')
-      a.href = `/api/stash/document/${encodeURIComponent(id)}?sessionId=${encodeURIComponent(props.sessionId)}&download`
+      a.href = `/api/stash/document/${encodeURIComponent(id)}?sessionId=${encodeURIComponent(sid)}&download`
       a.download = ''
       a.rel = 'noopener'
       document.body.appendChild(a)
@@ -712,8 +755,9 @@ export const DataStashPanel = (props: DataStashPanelProps) => {
       return
     }
     if (action === 'delete') {
+      applyDocs(sid, docs().filter((d) => d.id !== id)) // optimistic remove
       await fetch(
-        `/api/stash/document/${encodeURIComponent(id)}?sessionId=${encodeURIComponent(props.sessionId)}`,
+        `/api/stash/document/${encodeURIComponent(id)}?sessionId=${encodeURIComponent(sid)}`,
         { method: 'DELETE' },
       )
     } else {
@@ -728,23 +772,20 @@ export const DataStashPanel = (props: DataStashPanelProps) => {
       await fetch(`/api/stash/document/${encodeURIComponent(id)}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ sessionId: props.sessionId, ...patch }),
+        body: JSON.stringify({ sessionId: sid, ...patch }),
       })
     }
-    await refetch()
+    void refresh()
   }
 
-  const docs = createMemo(() => documents() ?? [])
-
-  // Poll for ingest-status changes while any upload is `pending` or we're inside
-  // the post-upload watch window. The effect re-runs whenever `docs()` or
-  // `watching()` changes; each run that still needs updates arms a single
-  // interval and tears it down on the next run (or on unmount).
+  // Gentle, single-flight status poll while an upload is `pending` or within the
+  // post-upload watch window. The `inFlight` guard in `refresh` prevents overlap
+  // (no 12s list-storm), and the server-side list cache keeps each poll cheap.
   createEffect(() => {
     if (isServer) return
     const active = watching() || docs().some((d) => d.ingestStatus === 'pending')
     if (!active) return
-    const timer = setInterval(() => void refetch(), 2500)
+    const timer = setInterval(() => void refresh(), 4000)
     onCleanup(() => clearInterval(timer))
   })
   onCleanup(() => {
@@ -812,6 +853,13 @@ export const DataStashPanel = (props: DataStashPanelProps) => {
             <For each={docs()}>
               {(doc) => <DocChip doc={doc} onAction={handleDocAction} />}
             </For>
+          </div>
+        </Show>
+        {/* Cold-load only — never blocks the drop zone (background refresh). */}
+        <Show when={loading() && docs().length === 0}>
+          <div flex="~" items="center" gap="2" p="x-3 y-2" text="xs dark-text-tertiary">
+            <span class="i-mdi-loading" style={{ width: '14px', height: '14px', animation: 'spin 1s linear infinite' }} />
+            <span>Loading uploads…</span>
           </div>
         </Show>
       </CollapsibleSection>

--- a/ui/src/components/ark-ui/SupportPanel.tsx
+++ b/ui/src/components/ark-ui/SupportPanel.tsx
@@ -6,7 +6,8 @@
  */
 
 import { Tabs } from '@ark-ui/solid/tabs';
-import { Show, createSignal, createMemo, Suspense } from 'solid-js';
+import { Show, createSignal, createMemo, createEffect, Suspense } from 'solid-js';
+import type { OpenReferenceTarget } from '~/lib/harness-client';
 import { GraphVisualization } from './GraphVisualization';
 import { ObservabilityPanel } from './ObservabilityPanel';
 import { DataStashPanel, type StashAction } from './DataStashPanel';
@@ -66,6 +67,9 @@ export interface SupportPanelProps {
   agentId?: string;
   /** Callback for data stash actions (hide/unhide/archive/unarchive) */
   onStashAction?: (eventId: string, action: StashAction) => Promise<void>;
+  /** A citation clicked in the chat — switch to the Data Stash tab and open the
+   *  inline viewer at this reference. */
+  pendingReference?: OpenReferenceTarget | null;
 }
 
 // ============================================================================
@@ -74,6 +78,12 @@ export interface SupportPanelProps {
 
 export const SupportPanel = (props: SupportPanelProps) => {
   const [selectedTab, setSelectedTab] = createSignal('stats');
+
+  // A chat citation was clicked → surface the Data Stash tab so its inline
+  // viewer (opened by DataStashPanel from the same `pendingReference`) is visible.
+  createEffect(() => {
+    if (props.pendingReference) setSelectedTab('data');
+  });
 
   // Filter graph elements by source
   const neo4jElements = createMemo(() =>
@@ -302,6 +312,7 @@ export const SupportPanel = (props: SupportPanelProps) => {
                 events={props.contextEvents ?? []}
                 sessionId={props.sessionId ?? ''}
                 onStashAction={props.onStashAction ?? (async () => {})}
+                pendingReference={props.pendingReference}
               />
             </Suspense>
           </Tabs.Content>

--- a/ui/src/components/ark-ui/SupportPanel.tsx
+++ b/ui/src/components/ark-ui/SupportPanel.tsx
@@ -70,6 +70,8 @@ export interface SupportPanelProps {
   /** A citation clicked in the chat — switch to the Data Stash tab and open the
    *  inline viewer at this reference. */
   pendingReference?: OpenReferenceTarget | null;
+  /** Fired after a successful upload so the route can watch embedding status. */
+  onUploaded?: () => void;
 }
 
 // ============================================================================
@@ -314,6 +316,7 @@ export const SupportPanel = (props: SupportPanelProps) => {
                 agentId={props.agentId}
                 onStashAction={props.onStashAction ?? (async () => {})}
                 pendingReference={props.pendingReference}
+                onUploaded={props.onUploaded}
               />
             </Suspense>
           </Tabs.Content>

--- a/ui/src/components/ark-ui/SupportPanel.tsx
+++ b/ui/src/components/ark-ui/SupportPanel.tsx
@@ -311,6 +311,7 @@ export const SupportPanel = (props: SupportPanelProps) => {
               <DataStashPanel
                 events={props.contextEvents ?? []}
                 sessionId={props.sessionId ?? ''}
+                agentId={props.agentId}
                 onStashAction={props.onStashAction ?? (async () => {})}
                 pendingReference={props.pendingReference}
               />

--- a/ui/src/lib/chunking.server.ts
+++ b/ui/src/lib/chunking.server.ts
@@ -156,10 +156,16 @@ export function chunkBySentence(text: string, config?: Partial<ChunkConfig>): Ch
   return packUnits(text, splitUnits(text, SENTENCE_SEP), cfg.maxChars, cfg.overlap)
 }
 
-/** Split on blank lines, then greedily pack paragraphs into `maxChars` chunks. */
+/**
+ * Split on blank lines, then greedily pack paragraphs into `maxChars` chunks.
+ * A markdown heading binds forward to its section body (see {@link bindHeadings})
+ * so a bare "## Heading" is never emitted as its own (useless) chunk. On
+ * headingless prose this is a no-op, so no MIME-type dispatch is needed.
+ */
 export function chunkByParagraph(text: string, config?: Partial<ChunkConfig>): Chunk[] {
   const cfg = normalizeConfig(config)
-  return packUnits(text, splitUnits(text, PARAGRAPH_SEP), cfg.maxChars, cfg.overlap)
+  const units = bindHeadings(text, splitUnits(text, PARAGRAPH_SEP))
+  return packUnits(text, units, cfg.maxChars, cfg.overlap)
 }
 
 /**
@@ -180,6 +186,58 @@ function splitUnits(text: string, separatorRe: RegExp): Unit[] {
   }
   if (start < text.length) units.push({ start, end: text.length })
   return units.filter((u) => text.slice(u.start, u.end).trim().length > 0)
+}
+
+/** An ATX markdown heading line: 1–6 `#` then whitespace (`# `, `### `, …). */
+const HEADING_LINE = /^#{1,6}\s+/
+
+/**
+ * A unit whose every non-empty line is a heading — i.e. it carries no body of
+ * its own. `# Header` (a lone heading) is pure; `# Header\ntext` (heading + body
+ * with no blank line between, which `splitUnits` keeps as one unit) is not.
+ */
+function isPureHeadingUnit(text: string, u: Unit): boolean {
+  let sawContent = false
+  for (const line of text.slice(u.start, u.end).split('\n')) {
+    if (line.trim() === '') continue
+    sawContent = true
+    if (!HEADING_LINE.test(line)) return false
+  }
+  return sawContent
+}
+
+/**
+ * Fuse each run of consecutive pure-heading units with the body unit that
+ * follows, so a markdown heading is never emitted as its own chunk (a bare
+ * "## Architecture" retrieves nothing useful). Two stacked headings both attach
+ * to the next paragraph. Units are contiguous (or separated only by whitespace
+ * `splitUnits` dropped), so a fused unit is still a single span
+ * `[firstHeading.start, body.end]` — the offset invariant
+ * (`content === text.slice(start, end)`) is preserved, and a section longer than
+ * `maxChars` still sub-splits in `packUnits` with the heading on the first
+ * window. Trailing heading(s) with no following body (EOF) are left as-is.
+ */
+function bindHeadings(text: string, units: Unit[]): Unit[] {
+  const out: Unit[] = []
+  let i = 0
+  while (i < units.length) {
+    if (!isPureHeadingUnit(text, units[i])) {
+      out.push(units[i])
+      i++
+      continue
+    }
+    let j = i
+    while (j < units.length && isPureHeadingUnit(text, units[j])) j++
+    if (j < units.length) {
+      // Heading run [i, j) + the following body unit j → one contiguous span.
+      out.push({ start: units[i].start, end: units[j].end })
+      i = j + 1
+    } else {
+      // Nothing to bind forward to — keep the trailing heading(s) as-is.
+      for (; i < j; i++) out.push(units[i])
+    }
+  }
+  return out
 }
 
 /** Trim leading/trailing whitespace of a span, keeping offsets faithful. */

--- a/ui/src/lib/document-ingest.server.ts
+++ b/ui/src/lib/document-ingest.server.ts
@@ -27,7 +27,7 @@
  */
 
 import { assertServerOnImport } from './harness-patterns/assert.server'
-import { callTool as defaultCallTool } from './harness-patterns/mcp-client.server'
+import { stashCallTool } from './redis-direct.server'
 import {
   DEFAULT_TTL_SECONDS,
   getDocument,
@@ -118,7 +118,7 @@ function spaceKey(sessionId: string): string {
 /** Read the embedding space a session's corpus was built with, if any. */
 export async function getEmbeddingSpace(
   sessionId: string,
-  callTool: CallTool = defaultCallTool,
+  callTool: CallTool = stashCallTool(),
 ): Promise<EmbeddingSpace | null> {
   const res = await callTool('json_get', { name: spaceKey(sessionId), path: '$' })
   if (!res.success || res.data == null) return null
@@ -165,7 +165,7 @@ export async function ingestDocument(
   doc: StashDocument,
   opts: IngestOptions = {},
 ): Promise<IngestResult> {
-  const callTool = opts.callTool ?? defaultCallTool
+  const callTool = opts.callTool ?? stashCallTool()
   const embedFn = opts.embedFn ?? defaultEmbed
   const ttl = opts.ttlSeconds ?? DEFAULT_TTL_SECONDS
 
@@ -245,7 +245,7 @@ export async function ingestStashDocument(
   docId: string,
   opts: IngestOptions = {},
 ): Promise<IngestResult | null> {
-  const callTool = opts.callTool ?? defaultCallTool
+  const callTool = opts.callTool ?? stashCallTool()
   const doc = await getDocument(sessionId, docId, callTool)
   if (!doc) return null
   if (doc.encoding === 'base64') {
@@ -289,7 +289,7 @@ export async function ensureSessionIngested(
   sessionId: string,
   opts: IngestOptions = {},
 ): Promise<void> {
-  const callTool = opts.callTool ?? defaultCallTool
+  const callTool = opts.callTool ?? stashCallTool()
   const metas = await listDocuments(sessionId, callTool)
   for (const m of metas) {
     if (m.ingestStatus === 'indexed' || m.ingestStatus === 'pending') continue
@@ -313,7 +313,7 @@ export async function searchDocuments(
   query: string,
   opts: SearchOptions = {},
 ): Promise<SearchHit[]> {
-  const callTool = opts.callTool ?? defaultCallTool
+  const callTool = opts.callTool ?? stashCallTool()
   const embedOneFn = opts.embedOneFn ?? defaultEmbedOne
 
   const recorded = await getEmbeddingSpace(sessionId, callTool)

--- a/ui/src/lib/document-ingest.server.ts
+++ b/ui/src/lib/document-ingest.server.ts
@@ -252,6 +252,10 @@ export async function ingestStashDocument(
     await setDocumentFlags(sessionId, docId, { ingestStatus: 'failed' }, callTool)
     return null
   }
+  // Mark 'pending' up front so the panel shows "embedding…" for BOTH the
+  // upload-gate and the lazy-ensure paths (embedding a doc is slow on the serial
+  // gateway; without this the UI looks stuck at no-status).
+  await setDocumentFlags(sessionId, docId, { ingestStatus: 'pending' }, callTool)
   try {
     const result = await ingestDocument(doc, opts)
     await setDocumentFlags(sessionId, docId, { ingestStatus: 'indexed' }, callTool)

--- a/ui/src/lib/document-ingest.server.ts
+++ b/ui/src/lib/document-ingest.server.ts
@@ -252,10 +252,14 @@ export async function ingestStashDocument(
     await setDocumentFlags(sessionId, docId, { ingestStatus: 'failed' }, callTool)
     return null
   }
-  // Mark 'pending' up front so the panel shows "embedding…" for BOTH the
-  // upload-gate and the lazy-ensure paths (embedding a doc is slow on the serial
-  // gateway; without this the UI looks stuck at no-status).
-  await setDocumentFlags(sessionId, docId, { ingestStatus: 'pending' }, callTool)
+  // Mark 'pending' up front so the panel shows "embedding…" while we embed
+  // (slow on the serial gateway; without this the lazy-ensure path looks stuck
+  // at no-status). The upload-gate path already persisted 'pending' in the
+  // store write, so skip the redundant round-trip there — re-writing the same
+  // value only burns a serial gateway call and a list-cache invalidation.
+  if (doc.ingestStatus !== 'pending') {
+    await setDocumentFlags(sessionId, docId, { ingestStatus: 'pending' }, callTool)
+  }
   try {
     const result = await ingestDocument(doc, opts)
     await setDocumentFlags(sessionId, docId, { ingestStatus: 'indexed' }, callTool)

--- a/ui/src/lib/document-ingest.server.ts
+++ b/ui/src/lib/document-ingest.server.ts
@@ -268,10 +268,14 @@ export async function ingestStashDocument(
  * the upload-time gate couldn't fire), or one whose ingest failed transiently
  * (embedder offline at upload time), becomes searchable on first retrieval.
  *
- * Skips only `'indexed'` (already searchable) and `base64` binaries (never
- * text-ingestable — a permanent skip). `'failed'` IS retried: such failures are
- * usually transient (embedder down), so a re-attempt recovers them once the
- * embedder is back. A fully-indexed corpus costs just one `listDocuments`.
+ * Ingests only what the upload-time gate can't or didn't handle:
+ *  - `'failed'` — retried (usually a transient embedder-down at upload time);
+ *  - absent (no status) — the gate never fired (e.g. uploaded before the
+ *    session was persisted).
+ * Skips `'indexed'` (searchable), `'pending'` (the gate is actively ingesting
+ * it — re-ingesting would double the work and contend on the serial gateway),
+ * and `base64` binaries (never text-ingestable). A fully-indexed corpus costs
+ * just one `listDocuments`.
  */
 export async function ensureSessionIngested(
   sessionId: string,
@@ -280,7 +284,7 @@ export async function ensureSessionIngested(
   const callTool = opts.callTool ?? defaultCallTool
   const metas = await listDocuments(sessionId, callTool)
   for (const m of metas) {
-    if (m.ingestStatus === 'indexed') continue
+    if (m.ingestStatus === 'indexed' || m.ingestStatus === 'pending') continue
     if (m.encoding === 'base64') continue
     await ingestStashDocument(sessionId, m.id, opts)
   }

--- a/ui/src/lib/document-ingest.server.ts
+++ b/ui/src/lib/document-ingest.server.ts
@@ -264,10 +264,14 @@ export async function ingestStashDocument(
 
 /**
  * Idempotently ingest every not-yet-indexed document in a session. The
- * retriever's safety net: an upload that happened before the agent was known
- * (so the upload-time gate couldn't fire) still becomes searchable on first
- * retrieval. Skips docs already `'indexed'` or `'failed'` (terminal) and binary
- * uploads, so a fully-indexed corpus costs just one `listDocuments`.
+ * retriever's safety net: an upload that happened before the agent was known (so
+ * the upload-time gate couldn't fire), or one whose ingest failed transiently
+ * (embedder offline at upload time), becomes searchable on first retrieval.
+ *
+ * Skips only `'indexed'` (already searchable) and `base64` binaries (never
+ * text-ingestable — a permanent skip). `'failed'` IS retried: such failures are
+ * usually transient (embedder down), so a re-attempt recovers them once the
+ * embedder is back. A fully-indexed corpus costs just one `listDocuments`.
  */
 export async function ensureSessionIngested(
   sessionId: string,
@@ -276,7 +280,7 @@ export async function ensureSessionIngested(
   const callTool = opts.callTool ?? defaultCallTool
   const metas = await listDocuments(sessionId, callTool)
   for (const m of metas) {
-    if (m.ingestStatus === 'indexed' || m.ingestStatus === 'failed') continue
+    if (m.ingestStatus === 'indexed') continue
     if (m.encoding === 'base64') continue
     await ingestStashDocument(sessionId, m.id, opts)
   }

--- a/ui/src/lib/document-store.server.ts
+++ b/ui/src/lib/document-store.server.ts
@@ -28,7 +28,7 @@
  */
 
 import { assertServerOnImport } from './harness-patterns/assert.server'
-import { callTool as defaultCallTool } from './harness-patterns/mcp-client.server'
+import { stashCallTool, directCallTool, gatewayCallTool } from './redis-direct.server'
 import type { ToolCallResult } from './harness-patterns/types'
 import type { PriorResult } from '../../baml_client/types'
 
@@ -275,7 +275,7 @@ export function redisWriteError(result: ToolCallResult): string | null {
  */
 export async function storeDocument(
   input: StoreDocumentInput,
-  callTool: CallTool = defaultCallTool,
+  callTool: CallTool = stashCallTool(),
 ): Promise<StashDocument> {
   const encoding = input.encoding ?? 'utf8'
   // `size` is the ORIGINAL byte count: for base64 that's the decoded length
@@ -340,7 +340,7 @@ export async function storeDocument(
 export async function getDocument(
   sessionId: string,
   docId: string,
-  callTool: CallTool = defaultCallTool,
+  callTool: CallTool = stashCallTool(),
 ): Promise<StashDocument | null> {
   const res = await callTool('json_get', {
     name: docKey(sessionId, docId),
@@ -357,7 +357,7 @@ export async function getDocument(
 export async function getDocumentMeta(
   sessionId: string,
   docId: string,
-  callTool: CallTool = defaultCallTool,
+  callTool: CallTool = stashCallTool(),
 ): Promise<StashDocumentMeta | null> {
   const doc = await getDocument(sessionId, docId, callTool)
   if (!doc) return null
@@ -390,9 +390,9 @@ export function invalidateDocumentList(sessionId: string): void {
  */
 export async function listDocuments(
   sessionId: string,
-  callTool: CallTool = defaultCallTool,
+  callTool: CallTool = stashCallTool(),
 ): Promise<StashDocumentMeta[]> {
-  const cacheable = callTool === defaultCallTool
+  const cacheable = callTool === gatewayCallTool || callTool === directCallTool
   if (cacheable) {
     const hit = listCache.get(sessionId)
     if (hit && Date.now() - hit.at < LIST_CACHE_TTL_MS) return hit.docs
@@ -433,7 +433,7 @@ export async function setDocumentFlags(
   sessionId: string,
   docId: string,
   patch: { hidden?: boolean; archived?: boolean; ingestStatus?: IngestStatus },
-  callTool: CallTool = defaultCallTool,
+  callTool: CallTool = stashCallTool(),
 ): Promise<StashDocument | null> {
   const doc = await getDocument(sessionId, docId, callTool)
   if (!doc) return null
@@ -469,7 +469,7 @@ export async function setDocumentFlags(
 export async function deleteDocument(
   sessionId: string,
   docId: string,
-  callTool: CallTool = defaultCallTool,
+  callTool: CallTool = stashCallTool(),
 ): Promise<void> {
   // `delete` uses `key` (not `name`) — see CLAUDE.md Redis quirks.
   await callTool('delete', { key: docKey(sessionId, docId) })

--- a/ui/src/lib/document-store.server.ts
+++ b/ui/src/lib/document-store.server.ts
@@ -100,6 +100,14 @@ export interface StoreDocumentInput {
    * base64-encoded binary (the size limit then applies to the decoded bytes).
    */
   encoding?: 'utf8' | 'base64'
+  /**
+   * Initial vector-ingestion status, persisted in the SAME first write. The
+   * upload route sets `'pending'` here when it will auto-ingest, so Redis
+   * reflects "embedding…" from t=0 — otherwise a status poll landing before the
+   * background ingest's own `setDocumentFlags('pending')` reads no status and
+   * the UI flickers (chip blanks, composer un-blocks). Absent → not ingested.
+   */
+  ingestStatus?: IngestStatus
 }
 
 // ============================================================================
@@ -290,6 +298,9 @@ export async function storeDocument(
     content: input.content,
     // Omit when utf8 so existing docs/tests stay byte-identical.
     ...(encoding === 'base64' ? { encoding } : {}),
+    // Persist the initial ingest status in this first write (no separate
+    // setDocumentFlags round-trip), so a poll can never read a status gap.
+    ...(input.ingestStatus ? { ingestStatus: input.ingestStatus } : {}),
   }
 
   const ttl = input.ttlSeconds ?? DEFAULT_TTL_SECONDS

--- a/ui/src/lib/document-store.server.ts
+++ b/ui/src/lib/document-store.server.ts
@@ -317,6 +317,7 @@ export async function storeDocument(
     throw new Error(`Failed to index document: ${idxErr}`)
   }
 
+  invalidateDocumentList(doc.sessionId)
   return doc
 }
 
@@ -352,15 +353,39 @@ export async function getDocumentMeta(
   return stripContent(doc)
 }
 
+// ── listDocuments cache ──────────────────────────────────────────────────
+// listDocuments is `smembers` + one `json_get` per doc, all serial on the MCP
+// gateway (~1.6s/call) → 12-21s for a handful of docs. The panel refetches it
+// (mount, status polls), so without a cache every refresh re-pays that. Cache
+// the result per session in-process; invalidate on any write. Only cache reads
+// that use the real gateway client — tests inject a fake `callTool` and must not
+// share state across cases.
+interface ListCacheEntry {
+  docs: StashDocumentMeta[]
+  at: number
+}
+const listCache = new Map<string, ListCacheEntry>()
+const LIST_CACHE_TTL_MS = 30_000
+
+/** Drop a session's cached document list (call after any write). */
+export function invalidateDocumentList(sessionId: string): void {
+  listCache.delete(sessionId)
+}
+
 /**
  * List metadata for every (non-expired) document in a session. Documents whose
  * keys have expired but linger in the index are pruned from the index as a
- * side-effect, so the index self-heals.
+ * side-effect, so the index self-heals. Cached per session (see above).
  */
 export async function listDocuments(
   sessionId: string,
   callTool: CallTool = defaultCallTool,
 ): Promise<StashDocumentMeta[]> {
+  const cacheable = callTool === defaultCallTool
+  if (cacheable) {
+    const hit = listCache.get(sessionId)
+    if (hit && Date.now() - hit.at < LIST_CACHE_TTL_MS) return hit.docs
+  }
   const members = await callTool('smembers', { name: indexKey(sessionId) })
   if (!members.success) return []
 
@@ -379,6 +404,7 @@ export async function listDocuments(
 
   // Newest first, matching the conversations list ordering.
   out.sort((a, b) => b.uploadedAt - a.uploadedAt)
+  if (cacheable) listCache.set(sessionId, { docs: out, at: Date.now() })
   return out
 }
 
@@ -420,6 +446,7 @@ export async function setDocumentFlags(
   if (setErr) {
     throw new Error(`Failed to update document: ${setErr}`)
   }
+  invalidateDocumentList(sessionId)
   return doc
 }
 
@@ -436,6 +463,7 @@ export async function deleteDocument(
   // `delete` uses `key` (not `name`) — see CLAUDE.md Redis quirks.
   await callTool('delete', { key: docKey(sessionId, docId) })
   await callTool('srem', { name: indexKey(sessionId), value: docId })
+  invalidateDocumentList(sessionId)
 }
 
 // ============================================================================

--- a/ui/src/lib/harness-client/examples/retriever-agent.server.ts
+++ b/ui/src/lib/harness-client/examples/retriever-agent.server.ts
@@ -16,15 +16,16 @@
  * Composition:
  *   router({ retriever | neo4j | web_search })
  *     → routes({
- *         retriever:  chain(compactIntent(), retriever({ backends:[redis] })),
+ *         retriever:  retriever({ backends:[redis], generateQuery: true }),
  *         neo4j:      simpleLoop(neo4j),
  *         web_search: simpleLoop(web),
  *       })
  *     → synthesizer('thread')
  *
- * `chain(compactIntent(), retriever())` rephrases the conversation into a clean
- * search query (one cheap Haiku/Sonnet call) before the vector search — reusing
- * the existing `compactIntent` pattern rather than a bespoke query step.
+ * The retriever searches with the user's **raw message** by default — the user's
+ * own words embed better than a paraphrase. `generateQuery: true` rewrites the
+ * query with a cheap `RetrieveQuery` call ONLY when the turn has history (to
+ * resolve "more on that" / "those sections"); turn-1 messages search verbatim.
  *
  * The Supabase backend (company pgvector via the Supabase MCP) is a deferred
  * stub; add `createSupabaseBackend()` to `backends` once IT provides access.
@@ -34,9 +35,7 @@
 import {
   router,
   routes,
-  chain,
   simpleLoop,
-  compactIntent,
   retriever,
   synthesizer,
   withReferences,
@@ -61,17 +60,17 @@ async function createPatterns(sessionId: string): Promise<ConfiguredPattern<Sess
   const tools = await Tools();
   const schema = await getSchema();
 
-  // ── retriever route: rephrase → vector search over this session's uploads ──
+  // ── retriever route: vector search over this session's uploaded docs ──
+  // Raw user message by default; rewritten to a search query only when the turn
+  // has history (generateQuery).
   const redisBackend = createRedisBackend(sessionId);
-  const retrieverPattern = chain<SessionData>(
-    compactIntent<SessionData>({ patternId: "retriever-intent", liveEvents: true }),
-    retriever<SessionData>({
-      patternId: "retriever",
-      backends: [redisBackend],
-      k: 5,
-      liveEvents: true,
-    }),
-  );
+  const retrieverPattern = retriever<SessionData>({
+    patternId: "retriever",
+    backends: [redisBackend],
+    k: 5,
+    generateQuery: true,
+    liveEvents: true,
+  });
 
   // ── neo4j + web routes: identical to the default agent ──
   const neo4jController = createNeo4jController(tools.neo4j ?? []);

--- a/ui/src/lib/harness-client/index.ts
+++ b/ui/src/lib/harness-client/index.ts
@@ -31,5 +31,12 @@ export {
   extractGraphFromResult
 } from './graph-extractor'
 
+// Reference Extraction (client-safe) — retriever citations
+export {
+  extractReferences,
+  referencesForDoc,
+  type OpenReferenceTarget
+} from './reference-extractor'
+
 // Types
 export type { GraphElement } from './types'

--- a/ui/src/lib/harness-client/reference-extractor.ts
+++ b/ui/src/lib/harness-client/reference-extractor.ts
@@ -17,6 +17,17 @@ import type {
 } from '~/lib/harness-patterns'
 
 /**
+ * The payload a chat citation passes across panes to open the inline viewer.
+ * `docId` is required; the optional offsets focus a specific chunk (footer chips
+ * pass them; an inline filename superscript omits them → opens at chunk 0).
+ */
+export interface OpenReferenceTarget {
+  docId: string
+  startOffset?: number
+  endOffset?: number
+}
+
+/**
  * References from the **most recent** retriever `tool_result` in the stream
  * (one retriever call per turn). Returns `[]` when there's no retriever result.
  */

--- a/ui/src/lib/harness-client/reference-extractor.ts
+++ b/ui/src/lib/harness-client/reference-extractor.ts
@@ -1,0 +1,43 @@
+/**
+ * Reference Extractor (client-safe)
+ *
+ * Pulls the retriever's typed `references` out of the event stream, mirroring
+ * `graph-extractor.ts` (which pulls graph nodes from tool_results). The retriever
+ * emits a {@link RetrieverResult} as its `tool_result.result`, carrying
+ * `references: RetrievalReference[]` (source + docId + char offsets) — the
+ * locatable subset the chat citations + inline file viewer consume.
+ *
+ * Types are imported type-only, so this stays client-safe (no server import).
+ */
+import type {
+  ContextEvent,
+  ToolResultEventData,
+  RetrievalReference,
+  RetrieverResult,
+} from '~/lib/harness-patterns'
+
+/**
+ * References from the **most recent** retriever `tool_result` in the stream
+ * (one retriever call per turn). Returns `[]` when there's no retriever result.
+ */
+export function extractReferences(events: ContextEvent[]): RetrievalReference[] {
+  for (let i = events.length - 1; i >= 0; i--) {
+    const e = events[i]
+    if (e.type !== 'tool_result') continue
+    const data = e.data as ToolResultEventData
+    if (data?.tool !== 'retriever') continue
+    const result = data.result as Partial<RetrieverResult> | undefined
+    return Array.isArray(result?.references) ? result.references : []
+  }
+  return []
+}
+
+/** References for a single document, sorted by position in the source text. */
+export function referencesForDoc(
+  events: ContextEvent[],
+  docId: string,
+): RetrievalReference[] {
+  return extractReferences(events)
+    .filter((r) => r.docId === docId)
+    .sort((a, b) => a.startOffset - b.startOffset)
+}

--- a/ui/src/lib/harness-client/registry.server.ts
+++ b/ui/src/lib/harness-client/registry.server.ts
@@ -10,7 +10,7 @@
 "use server";
 
 import type { ConfiguredPattern } from "../harness-patterns";
-import { usesCodeMode } from "../harness-patterns";
+import { usesCodeMode, harnessHasRedisRetriever } from "../harness-patterns";
 import type { SessionData } from "./session.server";
 
 // ============================================================================
@@ -117,6 +117,38 @@ export async function agentUsesCodeMode(
     return result;
   } catch {
     return agentId === "code-mode";
+  }
+}
+
+/** Memoized by agentId (harness structure is session-independent). */
+const redisRetrieverCapabilityCache = new Map<string, boolean>();
+
+/**
+ * Whether an agent composes a `retriever` wired to the redis/local-vector
+ * backend — i.e. whether uploads to its sessions should be auto-ingested. The
+ * upload route uses this as a **fast** gate decision so it can return
+ * `ingestStatus: 'pending'` immediately (the panel shows "embedding…" without
+ * waiting on a poll), while the actual embedding runs in the background. Builds
+ * the patterns once per agentId and caches the boolean; on a `createPatterns`
+ * failure returns `false` without caching (retry next time).
+ */
+export async function agentUsesRedisRetriever(
+  agentId: string,
+  sessionId: string,
+): Promise<boolean> {
+  const cached = redisRetrieverCapabilityCache.get(agentId);
+  if (cached !== undefined) return cached;
+
+  const agent = getAgent(agentId);
+  if (!agent) return false;
+
+  try {
+    const patterns = await agent.createPatterns(sessionId);
+    const result = harnessHasRedisRetriever(patterns);
+    redisRetrieverCapabilityCache.set(agentId, result);
+    return result;
+  } catch {
+    return false;
   }
 }
 

--- a/ui/src/lib/harness-patterns/README.md
+++ b/ui/src/lib/harness-patterns/README.md
@@ -547,15 +547,14 @@ ONE query from context and fans it out to one or more injected **backends**,
 returning normalized matches-with-references for a downstream `synthesizer`.
 
 ```typescript
-chain(
-  compactIntent(),                                   // rephrase → scope.data.intent
-  retriever({ backends: [redisBackend], k: 5 }),     // embed + KNN, no LLM loop
-)
+// Raw user message is the query; rewritten only when the turn has history.
+retriever({ backends: [redisBackend], k: 5, generateQuery: true })
 
 interface RetrieverConfig extends PatternConfig {
   backends: RetrieverBackend[]   // injected DB sources (app-side)
   k?: number                     // max hits, default 5
-  turnWindow?: number            // widen the query to the last N user turns
+  generateQuery?: boolean        // RetrieveQuery rewrite, ONLY when history exists
+  turnWindow?: number            // no-LLM: widen the query to the last N user turns
 }
 interface RetrieverBackend {
   name: string
@@ -565,11 +564,14 @@ interface RetrieverBackend {
 ```
 
 **How it works:**
-1. **Query**: prefers the upstream compacted `scope.data.intent`; falls back to
-   the last `user_message`, or the last `turnWindow` user turns joined.
+1. **Query**: the user's **raw last message** by default (their own words embed
+   best). `generateQuery: true` rewrites it via a cheap `RetrieveQuery` (Haiku)
+   call **only when the turn has history** — resolving "more on that" / "those
+   sections" into a self-contained query; turn 1 is searched verbatim.
+   `turnWindow: N` is a no-LLM alternative (concatenate the last N user turns).
 2. **Fan-out**: `Promise.all` over the backends. A failing backend yields `[]`
    plus an `error` event (per-backend isolation) — one bad source never sinks
-   the retrieval.
+   the retrieval. A failed `RetrieveQuery` falls back to the raw message.
 3. **Merge**: flatten, sort closest-first (`score` ascending; un-scored last),
    cap at `k`. Writes `scope.data.matches` and emits a `tool_result`
    (`tool: 'retriever'`) — the same channel `synthesizer` reads via

--- a/ui/src/lib/harness-patterns/index.ts
+++ b/ui/src/lib/harness-patterns/index.ts
@@ -159,6 +159,8 @@ export {
   type RetrieverConfig,
   type RetrieverData,
   type RetrievalHit,
+  type RetrievalReference,
+  type RetrieverResult,
   type ApprovalPredicate,
   type WithApprovalData,
   type JudgeConfig,

--- a/ui/src/lib/harness-patterns/patterns/index.ts
+++ b/ui/src/lib/harness-patterns/patterns/index.ts
@@ -16,6 +16,8 @@ export {
   type RetrieverConfig,
   type RetrieverData,
   type RetrievalHit,
+  type RetrievalReference,
+  type RetrieverResult,
 } from './retriever.server'
 export { parallel } from './parallel.server'
 export { judge, type JudgeConfig, type JudgeData, type EvaluatorFn } from './judge.server'

--- a/ui/src/lib/harness-patterns/patterns/retriever.server.ts
+++ b/ui/src/lib/harness-patterns/patterns/retriever.server.ts
@@ -31,17 +31,23 @@
  */
 
 import { assertServerOnImport } from '../assert.server'
+import { Collector } from '@boundaryml/baml'
 import type {
   PatternScope,
   EventView,
   ConfiguredPattern,
   PatternConfig,
   UserMessageEventData,
+  AssistantMessageEventData,
   ToolResultEventData,
   ErrorEventData,
+  LLMCallData,
 } from '../types'
 import { trackEvent, resolveConfig } from '../context.server'
 import { getErrorHint } from '../error-hints'
+import { trimToFit, getContextWindow } from '../token-budget.server'
+import { extractLLMCallData, extractFailureLLMCallData } from '../baml-adapters.server'
+import { clientOverrideFor, resolveClientForRole } from '../clients.server'
 
 assertServerOnImport()
 
@@ -84,13 +90,23 @@ export interface RetrieverConfig extends PatternConfig {
   backends: RetrieverBackend[]
   /** Max hits to return (per backend cap + final cap). Default 5. */
   k?: number
-  /** When there's no compacted intent, build the query from the last N user
-   *  turns instead of just the last message. Default: last message only. */
+  /**
+   * Rewrite the query with a cheap `RetrieveQuery` LLM call **only when the
+   * conversation has history** — to resolve back-references ("more on that",
+   * "those sections") into a self-contained search query. Turn-1 messages are
+   * already standalone, so they're searched verbatim (no call). Off by default:
+   * the raw last user message is the query. Mutually exclusive with `turnWindow`
+   * (this wins when both are set and history exists).
+   */
+  generateQuery?: boolean
+  /** No-LLM alternative to `generateQuery`: build the query from the last N user
+   *  turns joined, instead of just the last message. Default: last message. */
   turnWindow?: number
 }
 
 export interface RetrieverData {
-  /** Set by an upstream `compactIntent`/`router`; preferred query source. */
+  /** Optional context hint (e.g. the router's classified intent) passed through
+   *  to backends alongside the query — NOT the query itself. */
   intent?: string
   /** Output: the normalized matches (also emitted as a tool_result). */
   matches?: RetrievalHit[]
@@ -110,7 +126,7 @@ export interface RetrieverConfigMarker extends PatternConfig {
 export function retriever<T extends RetrieverData>(
   config: RetrieverConfig,
 ): ConfiguredPattern<T> {
-  const { backends = [], k = 5, turnWindow, ...patternConfig } = config
+  const { backends = [], k = 5, turnWindow, generateQuery = false, ...patternConfig } = config
   const backendKinds = backends.map((b) => b.name)
 
   const resolved = resolveConfig('retriever', { patternId: 'retriever', ...patternConfig })
@@ -119,43 +135,65 @@ export function retriever<T extends RetrieverData>(
 
   const fn = async (scope: PatternScope<T>, view: EventView): Promise<PatternScope<T>> => {
     try {
-      const intent = (scope.data as RetrieverData).intent
-      const lastUser = view.fromAll().ofType('user_message').last(1).get()[0]
-      const lastText = lastUser ? (lastUser.data as UserMessageEventData).content : ''
+      // The query is the raw last user message by default — we want the user's
+      // own words against the embedding index, not a verbose paraphrase. Two
+      // opt-in overrides: `generateQuery` (LLM rewrite, only with history) and
+      // `turnWindow` (no-LLM concat of recent turns).
+      const msgs = view.fromAll().messages().get()
+      const lastUser = [...msgs].reverse().find((e) => e.type === 'user_message')
+      const latest = lastUser ? (lastUser.data as UserMessageEventData).content : ''
 
-      let text = intent ?? ''
-      if (!text) {
-        if (turnWindow && turnWindow > 0) {
-          const recent = view
-            .fromLastNTurns(turnWindow)
-            .ofType('user_message')
-            .get()
-            .map((e) => (e.data as UserMessageEventData).content)
-            .filter(Boolean)
-          text = (recent.length ? recent.join('\n') : lastText).trim()
-        } else {
-          text = lastText
+      let text = latest
+      let llmCall: LLMCallData | undefined
+
+      if (latest && generateQuery) {
+        const rawHistory = msgs
+          .filter((e) => e !== lastUser)
+          .map((e) => ({
+            role: e.type === 'user_message' ? 'user' : 'assistant',
+            content: (
+              (e.data as UserMessageEventData | AssistantMessageEventData).content ?? ''
+            ).replace(/<think>[\s\S]*?<\/think>\s*/g, ''),
+          }))
+          .filter((m) => m.content.trim().length > 0)
+        // Only rewrite when there's history to resolve against — turn 1 is
+        // already a standalone query, so it's searched verbatim (no LLM call).
+        if (rawHistory.length > 0) {
+          const rewritten = await rewriteQuery(scope, rawHistory, latest, resolved)
+          text = rewritten.text
+          llmCall = rewritten.llmCall
         }
+      } else if (latest && turnWindow && turnWindow > 0) {
+        const recent = view
+          .fromLastNTurns(turnWindow)
+          .ofType('user_message')
+          .get()
+          .map((e) => (e.data as UserMessageEventData).content)
+          .filter(Boolean)
+        text = (recent.length ? recent.join('\n') : latest).trim()
       }
 
       if (!text || backends.length === 0) {
         scope.data = { ...scope.data, matches: [] }
-        emitMatches(scope, [], backendKinds, text, resolved.trackHistory)
+        emitMatches(scope, [], backendKinds, text, resolved.trackHistory, llmCall)
         return scope
       }
+
+      // Optional context hint passed to backends alongside the query.
+      const intent = (scope.data as RetrieverData).intent
 
       // Fan out to all backends concurrently; a failing backend yields [] and an
       // error event rather than sinking the whole retrieval.
       const perBackend = await Promise.all(
-        backends.map(async (b) => {
+        backends.map(async (backend) => {
           try {
-            return await b.search({ text, intent }, { k })
+            return await backend.search({ text, intent }, { k })
           } catch (err) {
             trackEvent(
               scope,
               'error',
               {
-                error: `retriever backend "${b.name}": ${err instanceof Error ? err.message : String(err)}`,
+                error: `retriever backend "${backend.name}": ${err instanceof Error ? err.message : String(err)}`,
                 severity: resolved.errorSeverity,
               } as ErrorEventData,
               true,
@@ -172,7 +210,7 @@ export function retriever<T extends RetrieverData>(
         .slice(0, k)
 
       scope.data = { ...scope.data, matches }
-      emitMatches(scope, matches, backendKinds, text, resolved.trackHistory)
+      emitMatches(scope, matches, backendKinds, text, resolved.trackHistory, llmCall)
       return scope
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error)
@@ -190,13 +228,16 @@ export function retriever<T extends RetrieverData>(
 }
 
 /** Emit the retrieval as a `tool_result` so the synthesizer reads it via
- *  `view.fromLastPattern()` (same channel a simpleLoop tool call uses). */
+ *  `view.fromLastPattern()` (same channel a simpleLoop tool call uses). The
+ *  optional `llmCall` carries `RetrieveQuery` observability when the query was
+ *  rewritten. */
 function emitMatches<T>(
   scope: PatternScope<T>,
   matches: RetrievalHit[],
   backendKinds: string[],
   query: string,
   trackHistory: Parameters<typeof trackEvent>[3],
+  llmCall?: LLMCallData,
 ): void {
   trackEvent(
     scope,
@@ -210,5 +251,46 @@ function emitMatches<T>(
         : 'no matches',
     } as ToolResultEventData,
     trackHistory,
+    llmCall,
   )
+}
+
+/**
+ * Rewrite the latest message into a concise search query via the `RetrieveQuery`
+ * BAML call (cheap describe-tier client). Best-effort: on failure it returns the
+ * raw latest text and tracks a recoverable error, so retrieval still runs.
+ */
+async function rewriteQuery<T>(
+  scope: PatternScope<T>,
+  history: Array<{ role: string; content: string }>,
+  latest: string,
+  resolved: ReturnType<typeof resolveConfig>,
+): Promise<{ text: string; llmCall?: LLMCallData }> {
+  const collector = new Collector('retriever')
+  const startTime = Date.now()
+  const contextWindow = getContextWindow(resolveClientForRole('describe'))
+  const trimmed = trimToFit(history, (h) => JSON.stringify(h), 300, contextWindow)
+  const variables = { history: trimmed, latest }
+  try {
+    const { b } = await import('../../../../baml_client')
+    const opts = { collector, ...clientOverrideFor('describe') }
+    const raw = await b.RetrieveQuery(trimmed, latest, opts)
+    const text = raw.trim() || latest
+    return { text, llmCall: extractLLMCallData(collector, 'RetrieveQuery', variables, startTime, text) }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    trackEvent(
+      scope,
+      'error',
+      {
+        error: `retriever query rewrite: ${msg}`,
+        severity: resolved.errorSeverity,
+        hint: getErrorHint(msg),
+        kind: 'llm_call' as const,
+      } as ErrorEventData,
+      true,
+      extractFailureLLMCallData(collector, 'RetrieveQuery', variables, startTime),
+    )
+    return { text: latest }
+  }
 }

--- a/ui/src/lib/harness-patterns/patterns/retriever.server.ts
+++ b/ui/src/lib/harness-patterns/patterns/retriever.server.ts
@@ -68,7 +68,50 @@ export interface RetrievalHit {
   source?: string
   /** Distance (lower = closer) when available. */
   score?: number
+  /**
+   * Locator into the source document, when the backend can provide one — char
+   * offsets into the doc's stored text (`content === docText.slice(start,end)`).
+   * Promotes what was backend-specific `metadata` to a typed, first-class shape
+   * so the retriever can build {@link RetrievalReference}s generically and the UI
+   * can open an inline file viewer at the right place. Absent for backends with
+   * no locatable source (e.g. web).
+   */
+  docId?: string
+  chunkIndex?: number
+  startOffset?: number
+  endOffset?: number
+  /** Anything else a backend wants to attach (non-standard, untyped). */
   metadata?: Record<string, unknown>
+}
+
+/**
+ * A locatable pointer into a source document — the UI-facing projection of a
+ * {@link RetrievalHit} that carries a locator. Char offsets are into the doc's
+ * stored text; line numbers are derived on open (the viewer fetches the doc).
+ */
+export interface RetrievalReference {
+  /** Human-facing source label (filename). */
+  source: string
+  /** Stash document id — fetch its text to render the viewer. */
+  docId: string
+  chunkIndex: number
+  startOffset: number
+  endOffset: number
+  /** Distance (lower = closer) when available. */
+  score?: number
+}
+
+/**
+ * The `result` payload of the retriever's `tool_result` event — the typed
+ * envelope consumers narrow to (synthesizer prompt, reference chips, viewer).
+ * `matches` carry the full text (for the synthesizer); `references` are the
+ * locatable subset for the UI.
+ */
+export interface RetrieverResult {
+  query: string
+  backends: string[]
+  matches: RetrievalHit[]
+  references: RetrievalReference[]
 }
 
 /**
@@ -227,10 +270,31 @@ export function retriever<T extends RetrieverData>(
   return { name: 'retriever', fn, config: resolved, estimateTurns: () => 0 }
 }
 
+/** Project a hit to a locatable reference, or null when it has no source
+ *  locator (e.g. a web hit) — those can't drive the inline file viewer. */
+function toReference(h: RetrievalHit): RetrievalReference | null {
+  if (
+    !h.source ||
+    h.docId === undefined ||
+    h.startOffset === undefined ||
+    h.endOffset === undefined
+  ) {
+    return null
+  }
+  return {
+    source: h.source,
+    docId: h.docId,
+    chunkIndex: h.chunkIndex ?? 0,
+    startOffset: h.startOffset,
+    endOffset: h.endOffset,
+    score: h.score,
+  }
+}
+
 /** Emit the retrieval as a `tool_result` so the synthesizer reads it via
  *  `view.fromLastPattern()` (same channel a simpleLoop tool call uses). The
- *  optional `llmCall` carries `RetrieveQuery` observability when the query was
- *  rewritten. */
+ *  result is a typed {@link RetrieverResult}. The optional `llmCall` carries
+ *  `RetrieveQuery` observability when the query was rewritten. */
 function emitMatches<T>(
   scope: PatternScope<T>,
   matches: RetrievalHit[],
@@ -239,12 +303,16 @@ function emitMatches<T>(
   trackHistory: Parameters<typeof trackEvent>[3],
   llmCall?: LLMCallData,
 ): void {
+  const references = matches
+    .map(toReference)
+    .filter((r): r is RetrievalReference => r !== null)
+  const result: RetrieverResult = { query, backends: backendKinds, matches, references }
   trackEvent(
     scope,
     'tool_result',
     {
       tool: 'retriever',
-      result: { matches, backends: backendKinds, query },
+      result,
       success: true,
       summary: matches.length
         ? `${matches.length} match(es) from ${backendKinds.join(', ') || 'no backends'}`

--- a/ui/src/lib/harness-patterns/patterns/synthesizer.server.ts
+++ b/ui/src/lib/harness-patterns/patterns/synthesizer.server.ts
@@ -15,6 +15,7 @@ import type {
   EventView,
   ConfiguredPattern,
   AssistantMessageEventData,
+  ToolResultEventData,
   LLMCallData
 } from '../types'
 import { DIRECT_RESPONSE_ROUTE } from '../types'
@@ -234,9 +235,31 @@ function buildSynthesisInputFromView(
               result: null,
               timestamp: event.ts
             })
-          } else if (event.type === 'tool_result' && iterations.length > 0) {
-            const resultData = event.data as { result: unknown }
-            iterations[iterations.length - 1].result = resultData.result
+          } else if (event.type === 'tool_result') {
+            const resultData = event.data as ToolResultEventData
+            const open = iterations.length > 0 ? iterations[iterations.length - 1] : undefined
+            if (open && open.result === null) {
+              // Pair with the controller_action that just preceded it (loop case).
+              open.result = resultData.result
+            } else {
+              // A tool_result with no preceding action — e.g. the `retriever`
+              // pattern, which does one search and emits a result without an LLM
+              // tool-call loop. Synthesize a minimal iteration so the result
+              // still reaches Synthesize (otherwise thread mode drops it and the
+              // synthesizer answers from nothing).
+              iterations.push({
+                turn: turn++,
+                action: {
+                  reasoning: '',
+                  tool_name: resultData.tool ?? 'tool',
+                  tool_args: '',
+                  status: resultData.success ? 'success' : 'error',
+                  is_final: true,
+                },
+                result: resultData.result,
+                timestamp: event.ts,
+              })
+            }
           }
         }
 

--- a/ui/src/lib/redis-direct.server.ts
+++ b/ui/src/lib/redis-direct.server.ts
@@ -1,0 +1,292 @@
+/**
+ * Direct Redis Client — Server Only
+ *
+ * A `CallTool`-shaped adapter over a direct `ioredis` connection, for the Data
+ * Stash APP path only. The MCP gateway runs the redis MCP over a single serial
+ * stdio pipe (~1.6s per call), so ingesting a doc costs O(chunks)×2 serial
+ * round-trips (~200s for a large doc). The exact same commands issued directly
+ * to `localhost:6379` are sub-millisecond — the bottleneck is gateway latency,
+ * not command count. This adapter runs them directly.
+ *
+ * It is a **drop-in** for `callTool`: the whole Data Stash layer
+ * (`document-store` / `document-ingest` / `vector-store`) is already
+ * parameterised on an injectable `CallTool`, so swapping the implementation
+ * needs no change to the tested ingest/search logic. `stashCallTool()` picks
+ * this adapter vs the gateway from `STASH_DIRECT_REDIS` — mirroring the
+ * `USE_MIXED_CHAINS` toggle. The GLOBAL `defaultCallTool` is untouched, so
+ * agentic MCP tool use still goes through the gateway.
+ *
+ * Same instance, same schema: the gateway's redis-mcp and this client both hit
+ * the one redis-stack (`localhost:6379`, published by docker-compose), and the
+ * vector field (`vector`, FLOAT32) + key schema match what `set_vector_in_hash`
+ * already wrote — so a direct `FT.SEARCH` reads gateway-written vectors and
+ * vice-versa. Requires redis-stack (RediSearch/RedisJSON); on arm64 colima the
+ * redis service must run `platform: linux/amd64` (same as the gateway path).
+ */
+
+import { Redis } from 'ioredis'
+import { assertServerOnImport } from './harness-patterns/assert.server'
+import { callTool as gatewayCallTool } from './harness-patterns/mcp-client.server'
+import type { CallTool } from './document-store.server'
+import type { ToolCallResult } from './harness-patterns/types'
+
+assertServerOnImport()
+
+// ============================================================================
+// Schema constants (must match what the redis-mcp tools use — see module doc)
+// ============================================================================
+
+/** Hash field holding the FLOAT32 vector blob. The redis-mcp default; the Data
+ *  Stash never overrides it. Kept as a const so dedup can reuse it later. */
+const VEC_FIELD = 'vector'
+/** Hash field holding the base64 JSON payload (`encodeMeta` output). */
+const META_FIELD = 'meta'
+
+// ============================================================================
+// Connection (lazy singleton — import never blocks; connects on first command)
+// ============================================================================
+
+let client: Redis | null = null
+
+/** The shared direct client. Lazy (`lazyConnect`) so importing this module —
+ *  which happens even when the flag is off — never opens a socket. */
+export function getRedis(): Redis {
+  if (client) return client
+  const host = process.env.REDIS_HOST_DIRECT || process.env.REDIS_HOST || 'localhost'
+  const port = Number(process.env.REDIS_PORT || 6379)
+  const password = process.env.REDIS_PWD || process.env.REDIS_PASSWORD || undefined
+  const useTls = process.env.REDIS_SSL === 'true'
+  const c = new Redis({
+    host,
+    port,
+    password,
+    lazyConnect: true,
+    maxRetriesPerRequest: 2,
+    family: 0, // let ioredis choose IPv4/IPv6 (avoids macOS localhost mismatch)
+    ...(useTls ? { tls: {} } : {}),
+  })
+  // ioredis auto-reconnects; surface the blip but never let it crash the server.
+  c.on('error', (err: Error) =>
+    console.error('[redis-direct] connection error:', err?.message ?? err),
+  )
+  client = c
+  return c
+}
+
+/** Drop the singleton without awaiting (HMR / tests). */
+export function resetRedisDirect(): void {
+  client?.disconnect()
+  client = null
+}
+
+/** Gracefully close the singleton (await-able). */
+export async function closeRedisDirect(): Promise<void> {
+  if (!client) return
+  try {
+    await client.quit()
+  } catch {
+    client.disconnect()
+  }
+  client = null
+}
+
+// ============================================================================
+// Vector encoding
+// ============================================================================
+
+/** Pack a vector as a little-endian FLOAT32 blob — byte-identical to what the
+ *  redis-mcp server wrote (numpy `float32.tobytes()`), so KNN over a mixed
+ *  corpus (some chunks gateway-written, some direct) still matches. */
+export function toFloat32LE(vec: number[]): Buffer {
+  const buf = Buffer.allocUnsafe(vec.length * 4)
+  for (let i = 0; i < vec.length; i++) buf.writeFloatLE(vec[i], i * 4)
+  return buf
+}
+
+// ============================================================================
+// The adapter
+// ============================================================================
+
+const ok = (data: unknown): ToolCallResult => ({ success: true, data })
+const fail = (err: unknown): ToolCallResult => ({
+  success: false,
+  data: null,
+  error: err instanceof Error ? err.message : String(err),
+})
+
+function s(v: unknown): string {
+  return typeof v === 'string' ? v : String(v)
+}
+
+/**
+ * Build a `CallTool` backed by `redis` (defaults to the shared singleton,
+ * resolved per-invocation so it survives `resetRedisDirect`). Tests pass a fake
+ * ioredis. Each case returns the SAME `ToolCallResult` shape the existing
+ * parsers expect (`redisWriteError`, `unwrapJsonGet`, `parseSetMembers`,
+ * `parseHits`) — see the per-tool notes.
+ */
+export function makeDirectCallTool(injected?: Redis): CallTool {
+  return async (name: string, args: Record<string, unknown>): Promise<ToolCallResult> => {
+    const redis = injected ?? getRedis()
+    try {
+      switch (name) {
+        // ── RedisJSON (documents + embedding-space record) ──────────────────
+        case 'json_set': {
+          // {name, path:'$', value:<json str>, expire_seconds}
+          await redis.call('JSON.SET', s(args.name), s(args.path ?? '$'), s(args.value))
+          if (args.expire_seconds != null) {
+            await redis.expire(s(args.name), Number(args.expire_seconds))
+          }
+          return ok('OK') // redisWriteError passes "OK"
+        }
+        case 'json_get': {
+          // {name, path:'$'} → raw JSON string (or null); unwrapJsonGet parses it.
+          const v = await redis.call('JSON.GET', s(args.name), s(args.path ?? '$'))
+          return ok(v ?? null)
+        }
+
+        // ── Session index SET ───────────────────────────────────────────────
+        case 'sadd': {
+          const n = await redis.sadd(s(args.name), s(args.value))
+          if (args.expire_seconds != null) {
+            await redis.expire(s(args.name), Number(args.expire_seconds))
+          }
+          return ok(n)
+        }
+        case 'smembers':
+          return ok(await redis.smembers(s(args.name))) // string[] → parseSetMembers
+        case 'srem':
+          return ok(await redis.srem(s(args.name), s(args.value)))
+        case 'delete': // note: `key`, not `name`
+          return ok(await redis.del(s(args.key)))
+        case 'expire':
+          return ok(await redis.expire(s(args.name), Number(args.expire_seconds)))
+
+        // ── Vector store (RediSearch HNSW) ──────────────────────────────────
+        case 'create_vector_index_hash': {
+          // {index_name, prefix, dim, distance_metric}. Tolerate "already exists"
+          // via the outer catch — the message contains "exist", which
+          // ensureIndex's /exist/i guard swallows.
+          await redis.call(
+            'FT.CREATE',
+            s(args.index_name),
+            'ON',
+            'HASH',
+            'PREFIX',
+            '1',
+            s(args.prefix),
+            'SCHEMA',
+            VEC_FIELD,
+            'VECTOR',
+            'HNSW',
+            '6',
+            'TYPE',
+            'FLOAT32',
+            'DIM',
+            s(args.dim),
+            'DISTANCE_METRIC',
+            s(args.distance_metric ?? 'COSINE'),
+            META_FIELD,
+            'TEXT',
+            // Dedup (later): append `'session_ids','TAG','SEPARATOR',','` here and
+            // hset a session_ids field, to enable a per-session FT.SEARCH filter.
+          )
+          return ok('OK')
+        }
+        case 'set_vector_in_hash': {
+          // {name, vector} → one hash field holding the FLOAT32 blob.
+          await redis.hset(s(args.name), VEC_FIELD, toFloat32LE(args.vector as number[]))
+          return ok(true)
+        }
+        case 'hset': {
+          // {name, key:'meta', value:<b64 str>, expire_seconds?}
+          const n = await redis.hset(s(args.name), s(args.key), s(args.value))
+          if (args.expire_seconds != null) {
+            await redis.expire(s(args.name), Number(args.expire_seconds))
+          }
+          return ok(n)
+        }
+        case 'vector_search_hash':
+          return ok(await knnSearch(redis, args))
+
+        default:
+          return fail(`redis-direct: unhandled tool "${name}"`)
+      }
+    } catch (err) {
+      return fail(err)
+    }
+  }
+}
+
+/**
+ * KNN search via native `FT.SEARCH`, shaped into the array-of-hit-objects that
+ * `parseHits` (vector-store.server.ts) consumes: each row `{ id, meta, score }`
+ * where `meta` is the stored base64 payload and `id` is the redis key (parseHits
+ * prefers the `_vid` inside meta). The optional `filter` is a dedup-readiness
+ * hook: today every caller omits it (`*` = unfiltered KNN); later a session-
+ * membership TAG filter can be passed with no signature change.
+ */
+async function knnSearch(
+  redis: Redis,
+  args: Record<string, unknown>,
+): Promise<Array<Record<string, unknown>>> {
+  const k = Number(args.k) || 5
+  const blob = toFloat32LE(args.query_vector as number[])
+  const pre = typeof args.filter === 'string' && args.filter ? args.filter : '*'
+  const query = `${pre}=>[KNN ${k} @${VEC_FIELD} $BLOB AS score]`
+  const reply = (await redis.call(
+    'FT.SEARCH',
+    s(args.index_name),
+    query,
+    'PARAMS',
+    '2',
+    'BLOB',
+    blob,
+    'RETURN',
+    '2',
+    META_FIELD,
+    'score',
+    'SORTBY',
+    'score',
+    'DIALECT',
+    '2',
+  )) as unknown
+
+  // RESP2 shape: [ total, key1, [field,val,...], key2, [...], ... ].
+  if (!Array.isArray(reply) || reply.length < 2) return []
+  const rows: Array<Record<string, unknown>> = []
+  for (let i = 1; i + 1 < reply.length; i += 2) {
+    const key = reply[i]
+    const fields = reply[i + 1]
+    const rec: Record<string, unknown> = { id: typeof key === 'string' ? key : s(key) }
+    if (Array.isArray(fields)) {
+      for (let j = 0; j + 1 < fields.length; j += 2) {
+        const val = fields[j + 1]
+        rec[s(fields[j])] = Buffer.isBuffer(val) ? val.toString('utf8') : val
+      }
+    }
+    rows.push(rec)
+  }
+  return rows
+}
+
+// ============================================================================
+// Flag-gated resolver (Data-Stash-scoped)
+// ============================================================================
+
+/** The shared direct adapter (lazy client, resolved per call). */
+export const directCallTool: CallTool = makeDirectCallTool()
+
+/**
+ * The `CallTool` the Data Stash layer should default to: the direct client when
+ * `STASH_DIRECT_REDIS=1`, else the MCP gateway. Read per-call (like
+ * `clientOverrideFor`) so a test/env change needs no re-import. Only the Data
+ * Stash modules call this — agentic MCP tools keep using `defaultCallTool`.
+ */
+export function stashCallTool(): CallTool {
+  return process.env.STASH_DIRECT_REDIS === '1' ? directCallTool : gatewayCallTool
+}
+
+/** Re-exported so the document-store list cache can recognise a "real" backend
+ *  (either default) and still bypass caching for injected test fakes. */
+export { gatewayCallTool }

--- a/ui/src/lib/retriever/redis-backend.server.ts
+++ b/ui/src/lib/retriever/redis-backend.server.ts
@@ -55,12 +55,11 @@ export function createRedisBackend(
         content: h.content,
         source: h.source,
         score: h.score,
-        metadata: {
-          docId: h.docId,
-          chunkIndex: h.chunkIndex,
-          startOffset: h.startOffset,
-          endOffset: h.endOffset,
-        },
+        // First-class locator → enables typed RetrievalReference + the viewer.
+        docId: h.docId,
+        chunkIndex: h.chunkIndex,
+        startOffset: h.startOffset,
+        endOffset: h.endOffset,
       }))
     },
   }

--- a/ui/src/lib/retriever/redis-backend.server.ts
+++ b/ui/src/lib/retriever/redis-backend.server.ts
@@ -38,15 +38,16 @@ export function createRedisBackend(
     type: 'vector',
     async search({ text }, { k }): Promise<RetrievalHit[]> {
       if (ensureIngested && !ensured) {
-        // Mark before awaiting so racing searches don't double-ensure; a
-        // transient failure won't be retried this session (the upload gate is
-        // the primary path — this is only a net).
+        // Fire the ingest safety net in the BACKGROUND — never block the query.
+        // Ingesting a session's docs is O(chunks) serial gateway writes (minutes
+        // for several docs); awaiting it here made the first retrieval take
+        // ~200s. The query searches whatever's already indexed; results fill in
+        // as ingest completes (the panel shows per-doc "embedding…" → "indexed").
+        // Mark first so racing searches don't re-trigger it.
         ensured = true
-        try {
-          await ensureFn(sessionId)
-        } catch {
-          /* best-effort */
-        }
+        void ensureFn(sessionId).catch(() => {
+          /* best-effort net; the upload-time gate is the primary path */
+        })
       }
       const hits = await searchFn(sessionId, text, { k })
       return hits.map((h) => ({

--- a/ui/src/lib/stash/upload-service.server.ts
+++ b/ui/src/lib/stash/upload-service.server.ts
@@ -76,7 +76,7 @@ export function isTextMime(mimeType: string): boolean {
  */
 export async function parseUploadRequest(
   request: Request,
-): Promise<StoreDocumentInput> {
+): Promise<StoreDocumentInput & { agentId?: string }> {
   const contentType = request.headers.get('content-type') ?? ''
 
   if (contentType.includes('multipart/form-data')) {
@@ -90,6 +90,10 @@ export async function parseUploadRequest(
     }
     const blob = file as File
     const sessionId = String(form.get('sessionId') ?? '').trim()
+    // Optional: the conversation's selected agent, so the auto-ingest gate can
+    // resolve the harness even before the session is persisted (uploads made
+    // before the first chat message).
+    const agentId = String(form.get('agentId') ?? '').trim() || undefined
     const filename = blob.name || 'upload'
     const ttlRaw = form.get('ttlSeconds')
     const ttlSeconds =
@@ -106,13 +110,14 @@ export async function parseUploadRequest(
       content,
       ...(isText ? {} : { encoding: 'base64' as const }),
       ...(Number.isFinite(ttlSeconds) ? { ttlSeconds } : {}),
+      ...(agentId ? { agentId } : {}),
     }
   }
 
   // Default: JSON body.
-  let body: Partial<StoreDocumentInput>
+  let body: Partial<StoreDocumentInput> & { agentId?: string }
   try {
-    body = (await request.json()) as Partial<StoreDocumentInput>
+    body = (await request.json()) as Partial<StoreDocumentInput> & { agentId?: string }
   } catch {
     throw new Error('Request body must be JSON or multipart/form-data')
   }
@@ -120,6 +125,7 @@ export async function parseUploadRequest(
     throw new Error('content (string) is required')
   }
   const filename = body.filename?.trim() || 'upload.txt'
+  const agentId = typeof body.agentId === 'string' ? body.agentId.trim() || undefined : undefined
   return {
     sessionId: String(body.sessionId ?? '').trim(),
     filename,
@@ -127,5 +133,6 @@ export async function parseUploadRequest(
     content: body.content,
     ...(body.encoding === 'base64' ? { encoding: 'base64' as const } : {}),
     ...(typeof body.ttlSeconds === 'number' ? { ttlSeconds: body.ttlSeconds } : {}),
+    ...(agentId ? { agentId } : {}),
   }
 }

--- a/ui/src/lib/vector-store.server.ts
+++ b/ui/src/lib/vector-store.server.ts
@@ -23,7 +23,7 @@
  */
 
 import { assertServerOnImport } from './harness-patterns/assert.server'
-import { callTool as defaultCallTool } from './harness-patterns/mcp-client.server'
+import { stashCallTool } from './redis-direct.server'
 import { redisWriteError, type CallTool } from './document-store.server'
 import type { EmbeddingSpace } from './embeddings.server'
 
@@ -75,7 +75,7 @@ const VID_KEY = '_vid'
 // ============================================================================
 
 export function createVectorStore(opts: VectorStoreOptions): VectorStore {
-  const callTool = opts.callTool ?? defaultCallTool
+  const callTool = opts.callTool ?? stashCallTool()
   const metric = opts.distanceMetric ?? 'COSINE'
 
   async function ensureIndex(): Promise<void> {

--- a/ui/src/lib/vector-store.server.ts
+++ b/ui/src/lib/vector-store.server.ts
@@ -189,7 +189,18 @@ function parseHits(data: unknown): VectorHit[] {
   }
   if (rows && typeof rows === 'object' && !Array.isArray(rows)) {
     const obj = rows as Record<string, unknown>
-    rows = obj.results ?? obj.documents ?? obj.matches ?? []
+    const wrapped = obj.results ?? obj.documents ?? obj.matches
+    if (Array.isArray(wrapped)) {
+      rows = wrapped
+    } else if ('meta' in obj || '_vid' in obj || 'id' in obj || 'score' in obj) {
+      // The gateway aggregates N≥2 matches into an array, but returns a SINGLE
+      // match as one bare hit object (one text block, not wrapped). Treat a
+      // lone hit-shaped object as a one-element result set — otherwise a
+      // single-match KNN search silently yields zero hits.
+      rows = [obj]
+    } else {
+      rows = []
+    }
   }
   if (!Array.isArray(rows)) return []
 

--- a/ui/src/routes/api/stash/upload.ts
+++ b/ui/src/routes/api/stash/upload.ts
@@ -15,11 +15,8 @@ import {
   listDocuments,
 } from '../../../lib/document-store.server'
 import { ingestStashDocument } from '../../../lib/document-ingest.server'
-import {
-  getOrBuildPatterns,
-  loadSession,
-} from '../../../lib/harness-client/session.server'
-import { harnessHasRedisRetriever } from '../../../lib/harness-patterns'
+import { loadSession } from '../../../lib/harness-client/session.server'
+import { agentUsesRedisRetriever } from '../../../lib/harness-client/registry.server'
 import { parseUploadRequest } from '../../../lib/stash/upload-service.server'
 import { json, withUser } from '../../../lib/stash/http.server'
 
@@ -39,17 +36,22 @@ export async function POST(event: APIEvent) {
     try {
       const { agentId, ...storeInput } = input
       const doc = await storeDocument(storeInput)
-      // Harness-aware Data Stash: if this session's agent composes a retriever
-      // wired to the local redis vector store, make the upload searchable.
-      // Fired-and-forgotten OFF the upload's critical path — resolving the agent
-      // + embedding can take seconds, and the upload should feel instant. The
-      // doc is marked `ingestStatus: 'pending'` as soon as the gate fires; the
-      // client polls `GET ?sessionId` to surface "embedding…" → indexed/failed.
-      void maybeAutoIngest(input.sessionId, userId, doc.id, doc.encoding, agentId)
-      // Return metadata only — the client already has the content it uploaded,
-      // and full inlining bloats the response.
       const { content: _content, ...meta } = doc
       void _content
+
+      // Harness-aware Data Stash: if this session's agent composes a retriever
+      // wired to the local redis vector store, auto-ingest the upload. The GATE
+      // DECISION is fast (memoized per agentId) so we can report
+      // `ingestStatus: 'pending'` in THIS response — the panel shows "embedding…"
+      // instantly, without waiting on a status poll. The actual embed (slow on
+      // the serial gateway) runs in the background; the client reconciles to
+      // indexed/failed via `GET ?sessionId`. The agentId hint lets this work even
+      // before the session is persisted (drop-files-then-chat).
+      if (await willAutoIngest(input.sessionId, userId, doc.encoding, agentId)) {
+        meta.ingestStatus = 'pending'
+        void ingestStashDocument(input.sessionId, doc.id).catch(() => {})
+      }
+
       return json({ ok: true, document: meta }, 201)
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'Upload failed'
@@ -60,33 +62,25 @@ export async function POST(event: APIEvent) {
 }
 
 /**
- * Auto-ingest gate (runs in the background — see the POST handler). No-ops when
- * the upload should not be ingested: binary, unresolvable agent, or no
- * redis-retriever in the harness. Otherwise chunks → embeds → indexes
- * (ingestStashDocument marks `'pending'` → `'indexed'`/`'failed'`).
- *
- * The agent is resolved from the client-supplied `agentId` when present — so the
- * gate fires even for uploads made BEFORE the session is persisted (the common
- * "drop files, then start chatting" flow) — falling back to the persisted
- * session's agent. Best-effort: never throws; the retriever's lazy
+ * Fast gate decision: should this upload be auto-ingested? True only for a
+ * text doc whose (client-hinted or persisted) agent composes a redis retriever.
+ * `agentUsesRedisRetriever` is memoized per agentId, so this is cheap after the
+ * first call. Best-effort: never throws (returns false); the retriever's lazy
  * `ensureSessionIngested` net still covers anything missed on first search.
  */
-async function maybeAutoIngest(
+async function willAutoIngest(
   sessionId: string,
   userId: string,
-  docId: string,
   encoding: 'utf8' | 'base64' | undefined,
   agentId: string | undefined,
-): Promise<void> {
-  if (encoding === 'base64') return // binary: not text-ingestable
+): Promise<boolean> {
+  if (encoding === 'base64') return false // binary: not text-ingestable
   try {
     const resolvedAgentId = agentId ?? (await loadSession(sessionId, userId))?.agentId
-    if (!resolvedAgentId) return // session not persisted + no agent hint
-    const patterns = await getOrBuildPatterns(sessionId, resolvedAgentId)
-    if (!harnessHasRedisRetriever(patterns)) return
-    await ingestStashDocument(sessionId, docId)
+    if (!resolvedAgentId) return false // session not persisted + no agent hint
+    return await agentUsesRedisRetriever(resolvedAgentId, sessionId)
   } catch {
-    /* best-effort: status stays unset; the retriever's net retries on search */
+    return false
   }
 }
 

--- a/ui/src/routes/api/stash/upload.ts
+++ b/ui/src/routes/api/stash/upload.ts
@@ -13,7 +13,6 @@ import type { APIEvent } from '@solidjs/start/server'
 import {
   storeDocument,
   listDocuments,
-  setDocumentFlags,
 } from '../../../lib/document-store.server'
 import { ingestStashDocument } from '../../../lib/document-ingest.server'
 import {
@@ -38,14 +37,15 @@ export async function POST(event: APIEvent) {
     if (!input.sessionId) return json({ error: 'sessionId is required' }, 400)
 
     try {
-      const doc = await storeDocument(input)
+      const { agentId, ...storeInput } = input
+      const doc = await storeDocument(storeInput)
       // Harness-aware Data Stash: if this session's agent composes a retriever
       // wired to the local redis vector store, make the upload searchable.
       // Fired-and-forgotten OFF the upload's critical path — resolving the agent
       // + embedding can take seconds, and the upload should feel instant. The
       // doc is marked `ingestStatus: 'pending'` as soon as the gate fires; the
       // client polls `GET ?sessionId` to surface "embedding…" → indexed/failed.
-      void maybeAutoIngest(input.sessionId, userId, doc.id, doc.encoding)
+      void maybeAutoIngest(input.sessionId, userId, doc.id, doc.encoding, agentId)
       // Return metadata only — the client already has the content it uploaded,
       // and full inlining bloats the response.
       const { content: _content, ...meta } = doc
@@ -61,29 +61,32 @@ export async function POST(event: APIEvent) {
 
 /**
  * Auto-ingest gate (runs in the background — see the POST handler). No-ops when
- * the upload should not be ingested: binary, no persisted session yet, or no
- * redis-retriever in the harness. Marks the doc `'pending'` the moment it
- * decides to ingest (so the panel can show "embedding…"), then chunks → embeds →
- * indexes, landing `'indexed'`/`'failed'`. Best-effort: never throws. Docs
- * uploaded before the session is persisted are covered by the retriever's lazy
- * `ensureSessionIngested` net on first search.
+ * the upload should not be ingested: binary, unresolvable agent, or no
+ * redis-retriever in the harness. Otherwise chunks → embeds → indexes
+ * (ingestStashDocument marks `'pending'` → `'indexed'`/`'failed'`).
+ *
+ * The agent is resolved from the client-supplied `agentId` when present — so the
+ * gate fires even for uploads made BEFORE the session is persisted (the common
+ * "drop files, then start chatting" flow) — falling back to the persisted
+ * session's agent. Best-effort: never throws; the retriever's lazy
+ * `ensureSessionIngested` net still covers anything missed on first search.
  */
 async function maybeAutoIngest(
   sessionId: string,
   userId: string,
   docId: string,
   encoding: 'utf8' | 'base64' | undefined,
+  agentId: string | undefined,
 ): Promise<void> {
   if (encoding === 'base64') return // binary: not text-ingestable
   try {
-    const loaded = await loadSession(sessionId, userId)
-    if (!loaded) return
-    const patterns = await getOrBuildPatterns(sessionId, loaded.agentId)
+    const resolvedAgentId = agentId ?? (await loadSession(sessionId, userId))?.agentId
+    if (!resolvedAgentId) return // session not persisted + no agent hint
+    const patterns = await getOrBuildPatterns(sessionId, resolvedAgentId)
     if (!harnessHasRedisRetriever(patterns)) return
-    await setDocumentFlags(sessionId, docId, { ingestStatus: 'pending' })
     await ingestStashDocument(sessionId, docId)
   } catch {
-    /* best-effort: status stays pending/unset; the retriever's net retries */
+    /* best-effort: status stays unset; the retriever's net retries on search */
   }
 }
 

--- a/ui/src/routes/api/stash/upload.ts
+++ b/ui/src/routes/api/stash/upload.ts
@@ -35,20 +35,30 @@ export async function POST(event: APIEvent) {
 
     try {
       const { agentId, ...storeInput } = input
-      const doc = await storeDocument(storeInput)
-      const { content: _content, ...meta } = doc
-      void _content
 
       // Harness-aware Data Stash: if this session's agent composes a retriever
       // wired to the local redis vector store, auto-ingest the upload. The GATE
-      // DECISION is fast (memoized per agentId) so we can report
-      // `ingestStatus: 'pending'` in THIS response — the panel shows "embedding…"
-      // instantly, without waiting on a status poll. The actual embed (slow on
-      // the serial gateway) runs in the background; the client reconciles to
-      // indexed/failed via `GET ?sessionId`. The agentId hint lets this work even
-      // before the session is persisted (drop-files-then-chat).
-      if (await willAutoIngest(input.sessionId, userId, doc.encoding, agentId)) {
-        meta.ingestStatus = 'pending'
+      // DECISION is fast (memoized per agentId), and we decide it BEFORE storing
+      // so the very first write persists `ingestStatus: 'pending'`. That closes
+      // the status gap: Redis reflects "embedding…" from t=0, so a status poll
+      // (chip / composer-block) can never read a no-status doc and flicker. The
+      // actual embed (slow on the serial gateway) runs in the background; the
+      // client reconciles to indexed/failed via `GET ?sessionId`. The agentId
+      // hint lets this work even before the session is persisted (drop-then-chat).
+      const ingest = await willAutoIngest(
+        input.sessionId,
+        userId,
+        storeInput.encoding,
+        agentId,
+      )
+      const doc = await storeDocument({
+        ...storeInput,
+        ...(ingest ? { ingestStatus: 'pending' as const } : {}),
+      })
+      const { content: _content, ...meta } = doc
+      void _content
+
+      if (ingest) {
         void ingestStashDocument(input.sessionId, doc.id).catch(() => {})
       }
 

--- a/ui/src/routes/api/stash/upload.ts
+++ b/ui/src/routes/api/stash/upload.ts
@@ -14,7 +14,6 @@ import {
   storeDocument,
   listDocuments,
   setDocumentFlags,
-  type IngestStatus,
 } from '../../../lib/document-store.server'
 import { ingestStashDocument } from '../../../lib/document-ingest.server'
 import {
@@ -42,19 +41,15 @@ export async function POST(event: APIEvent) {
       const doc = await storeDocument(input)
       // Harness-aware Data Stash: if this session's agent composes a retriever
       // wired to the local redis vector store, make the upload searchable.
-      // Best-effort and decoupled from upload success — a failure here never
-      // changes the 201.
-      const ingestStatus = await maybeAutoIngest(
-        input.sessionId,
-        userId,
-        doc.id,
-        doc.encoding,
-      )
+      // Fired-and-forgotten OFF the upload's critical path — resolving the agent
+      // + embedding can take seconds, and the upload should feel instant. The
+      // doc is marked `ingestStatus: 'pending'` as soon as the gate fires; the
+      // client polls `GET ?sessionId` to surface "embedding…" → indexed/failed.
+      void maybeAutoIngest(input.sessionId, userId, doc.id, doc.encoding)
       // Return metadata only — the client already has the content it uploaded,
       // and full inlining bloats the response.
       const { content: _content, ...meta } = doc
       void _content
-      if (ingestStatus) meta.ingestStatus = ingestStatus
       return json({ ok: true, document: meta }, 201)
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'Upload failed'
@@ -65,31 +60,30 @@ export async function POST(event: APIEvent) {
 }
 
 /**
- * Auto-ingest gate. Returns the ingest status to stamp on the response, or
- * `undefined` when the upload should not be ingested (binary, no persisted
- * session, no redis-retriever in the harness, or a resolution failure). Marks
- * the doc `'pending'` synchronously, then ingests in the background so the
- * upload returns immediately — embedding a large doc takes seconds. Docs
- * uploaded before the session is persisted are covered by the retriever's
- * lazy `ensureSessionIngested` net on first search.
+ * Auto-ingest gate (runs in the background — see the POST handler). No-ops when
+ * the upload should not be ingested: binary, no persisted session yet, or no
+ * redis-retriever in the harness. Marks the doc `'pending'` the moment it
+ * decides to ingest (so the panel can show "embedding…"), then chunks → embeds →
+ * indexes, landing `'indexed'`/`'failed'`. Best-effort: never throws. Docs
+ * uploaded before the session is persisted are covered by the retriever's lazy
+ * `ensureSessionIngested` net on first search.
  */
 async function maybeAutoIngest(
   sessionId: string,
   userId: string,
   docId: string,
   encoding: 'utf8' | 'base64' | undefined,
-): Promise<IngestStatus | undefined> {
-  if (encoding === 'base64') return undefined // binary: not text-ingestable
+): Promise<void> {
+  if (encoding === 'base64') return // binary: not text-ingestable
   try {
     const loaded = await loadSession(sessionId, userId)
-    if (!loaded) return undefined
+    if (!loaded) return
     const patterns = await getOrBuildPatterns(sessionId, loaded.agentId)
-    if (!harnessHasRedisRetriever(patterns)) return undefined
+    if (!harnessHasRedisRetriever(patterns)) return
     await setDocumentFlags(sessionId, docId, { ingestStatus: 'pending' })
-    void ingestStashDocument(sessionId, docId).catch(() => {})
-    return 'pending'
+    await ingestStashDocument(sessionId, docId)
   } catch {
-    return undefined
+    /* best-effort: status stays pending/unset; the retriever's net retries */
   }
 }
 

--- a/ui/src/routes/index.tsx
+++ b/ui/src/routes/index.tsx
@@ -36,6 +36,43 @@ export default function Home() {
   const [pendingReference, setPendingReference] = createSignal<OpenReferenceTarget | null>(null)
   const [contextEvents, setContextEvents] = createSignal<ContextEvent[]>([])
   const [unifiedContext, setUnifiedContext] = createSignal<UnifiedContext | undefined>(undefined)
+
+  // Block the chat composer while uploaded sources are still embedding, so the
+  // user can't query the retriever before its documents are searchable. Tracked
+  // here (always mounted) via a light status poll — works even when the Data
+  // Stash tab (which also polls) is closed; the list cache keeps polls cheap.
+  const [embeddingSources, setEmbeddingSources] = createSignal(false)
+  let embedPollTimer: ReturnType<typeof setTimeout> | undefined
+  let embedPolls = 0
+  const pollEmbedding = async (sid: string) => {
+    if (!sid) return
+    try {
+      const res = await fetch(`/api/stash/upload?sessionId=${encodeURIComponent(sid)}`)
+      const body = res.ok ? ((await res.json()) as { documents?: Array<{ ingestStatus?: string }> }) : {}
+      if (sid !== selectedSessionId()) return // session switched mid-poll
+      const pending = (body.documents ?? []).some((d) => d.ingestStatus === 'pending')
+      setEmbeddingSources(pending)
+      embedPolls += 1
+      // Keep watching while pending (cap ~6 min so a stuck ingest can't block forever).
+      if (pending && embedPolls < 120) embedPollTimer = setTimeout(() => void pollEmbedding(sid), 3000)
+    } catch {
+      setEmbeddingSources(false)
+    }
+  }
+  const watchEmbedding = (sid: string) => {
+    if (embedPollTimer) clearTimeout(embedPollTimer)
+    embedPolls = 0
+    if (sid) void pollEmbedding(sid)
+  }
+  // Poll on session open (catches a session reopened mid-embed) and after uploads.
+  createEffect(() => {
+    const sid = selectedSessionId()
+    setEmbeddingSources(false)
+    watchEmbedding(sid)
+  })
+  onCleanup(() => {
+    if (embedPollTimer) clearTimeout(embedPollTimer)
+  })
   // The conversation's selected agent, reported up from ChatInterface, so the
   // Tools panel's code-mode gate tracks the live selection (default until set).
   const [currentAgentId, setCurrentAgentId] = createSignal<string>('default')
@@ -274,6 +311,7 @@ export default function Home() {
                 graphEntityNames={graphEntityNames()}
                 onHighlightEntities={setHighlightedIds}
                 onOpenReference={setPendingReference}
+                embeddingSources={embeddingSources()}
                 getProgress={getProgress}
                 getRunState={getRunState}
                 updateRunState={updateRunState}
@@ -310,6 +348,7 @@ export default function Home() {
             agentId={currentAgentId()}
             onStashAction={handleStashAction}
             pendingReference={pendingReference()}
+            onUploaded={() => watchEmbedding(selectedSessionId())}
           />
         </Splitter.Panel>
       </Splitter.Root>

--- a/ui/src/routes/index.tsx
+++ b/ui/src/routes/index.tsx
@@ -6,7 +6,7 @@ import { SupportPanel, type GraphElement } from '~/components/ark-ui/SupportPane
 import type { ContextEvent, UnifiedContext, ToolResultEventData } from '~/lib/harness-patterns'
 import { executeCypherWrite } from '~/lib/neo4j/write-action'
 import { mergeGraphElements } from '~/lib/graph-merge'
-import { listConversations } from '~/lib/harness-client'
+import { listConversations, type OpenReferenceTarget } from '~/lib/harness-client'
 import { newSessionId } from '~/lib/session-id'
 import type { StashAction } from '~/components/ark-ui/DataStashPanel'
 import { createChainProgress, type ChainProgressController } from '~/components/ark-ui/useChainProgress'
@@ -31,6 +31,9 @@ export default function Home() {
 
   const [graphElements, setGraphElements] = createSignal<GraphElement[]>([])
   const [highlightedIds, setHighlightedIds] = createSignal<string[]>([])
+  // A citation clicked in an assistant message → SupportPanel switches to the
+  // Data Stash tab and opens the inline viewer at that reference.
+  const [pendingReference, setPendingReference] = createSignal<OpenReferenceTarget | null>(null)
   const [contextEvents, setContextEvents] = createSignal<ContextEvent[]>([])
   const [unifiedContext, setUnifiedContext] = createSignal<UnifiedContext | undefined>(undefined)
   // The conversation's selected agent, reported up from ChatInterface, so the
@@ -270,6 +273,7 @@ export default function Home() {
                 onSelectedAgentChange={setCurrentAgentId}
                 graphEntityNames={graphEntityNames()}
                 onHighlightEntities={setHighlightedIds}
+                onOpenReference={setPendingReference}
                 getProgress={getProgress}
                 getRunState={getRunState}
                 updateRunState={updateRunState}
@@ -305,6 +309,7 @@ export default function Home() {
             sessionId={selectedSessionId()}
             agentId={currentAgentId()}
             onStashAction={handleStashAction}
+            pendingReference={pendingReference()}
           />
         </Splitter.Panel>
       </Splitter.Root>

--- a/ui/uno.config.ts
+++ b/ui/uno.config.ts
@@ -231,6 +231,52 @@ export default defineConfig({
           border-bottom: 1px solid #00ffff;
           color: #00ffff;
         }
+        /* Retriever citations: inline filename superscript + sources footer */
+        .doc-ref {
+          cursor: pointer;
+          border-bottom: 1px dashed rgba(34,211,238,0.5);
+          border-radius: 2px;
+          transition: all 0.15s ease;
+        }
+        .doc-ref:hover {
+          background: rgba(34,211,238,0.15);
+          border-bottom-color: #22d3ee;
+        }
+        .doc-ref-mark {
+          font-size: 0.7em;
+          color: #22d3ee;
+          margin-left: 1px;
+          vertical-align: super;
+          line-height: 0;
+        }
+        .doc-ref-footer {
+          display: flex;
+          flex-wrap: wrap;
+          align-items: center;
+          gap: 6px;
+          margin-top: 8px;
+          padding-top: 6px;
+          border-top: 1px solid rgba(255,255,255,0.06);
+        }
+        .doc-ref-chip {
+          display: inline-flex;
+          align-items: center;
+          gap: 4px;
+          font-family: "Fira Code", ui-monospace, monospace;
+          font-size: 10px;
+          color: #7dd3fc;
+          background: rgba(34,211,238,0.08);
+          border: 1px solid rgba(34,211,238,0.25);
+          border-radius: 5px;
+          padding: 1px 7px;
+          cursor: pointer;
+          transition: all 0.15s ease;
+        }
+        .doc-ref-chip:hover {
+          background: rgba(34,211,238,0.18);
+          border-color: #22d3ee;
+          color: #e0f2fe;
+        }
       `,
     },
   ],


### PR DESCRIPTION
Follow-up work on top of the merged **#102** (harness-aware Data Stash + retriever pattern). 13 commits; `main` was merged in to resolve the `DataStashPanel`/`registry` overlaps with #104/#106, so this is mergeable.

## What's here

**Chat citations → inline viewer** (Stages i–iii)
- Typed `RetrieverResult`/`RetrievalReference` with first-class locators (docId + char offsets) in the retriever's `tool_result`.
- Inline `FileViewer` in the Data Stash panel: raw text + line numbers, multi-highlight, prev/next chunk navigator; opened by the file-chip **eye** or by a chat citation.
- Assistant messages get clickable citations — inline filename superscripts **and** a "Sources" footer — that open the viewer at the referenced chunk (`pendingReference` signal → SupportPanel → panel). Light `Synthesize` nudge to name source files.

**Panel perf**
- In-process `listDocuments` cache + client module cache + optimistic uploads → kills the ~12 s "Loading data…" on tab switch (was N+1 serial gateway calls).

**Upload path + embedding UX**
- Auto-ingest gate fires from a client `agentId` hint (upload-before-chat).
- Persist ingest `'pending'` in the **first** store write → instant "embedding…", no status-poll flicker; the chat composer is blocked while sources embed.

**Markdown chunking**
- `bindHeadings`: a heading binds forward to its section body, so a bare `## X` is never its own chunk (fixes "info on architecture" retrieving an empty heading); consecutive headings both prepend; offset-invariant preserved.

**Direct-Redis ingest/search** — behind `STASH_DIRECT_REDIS=1`
- A `CallTool`-shaped `ioredis` adapter bypassing the serial MCP gateway for the Data Stash **app path** → ingest **~200 s → <1 s**. Global `defaultCallTool` (agentic tools) untouched; mirrors the existing Neo4j direct-driver + MCP split. Content-hash-dedup hooks left inert (unused `filter` arg on the direct KNN).

## Verification
- `pnpm exec tsc --noEmit`: baseline (22 pre-existing, no new).
- `pnpm test:run`: **890 passed / 1 skipped** (skip = env-gated live-redis integration).
- Live: direct-Redis round-trip against redis-stack passes (`FT.CREATE` → upserts → KNN in ~150 ms).

## Deferred follow-up
- **Content-hash dedup** (the direct `FT.SEARCH` filter hook + named index/field helpers are already in place) → also unblocks the "Global data" check-in UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVhNfn9AB3S8PV1CNURCzQ
