### PR TITLE
feat(data-stash): convert docx/odt/pptx/pdf uploads to markdown for search

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -97,6 +97,25 @@ services:
       timeout: 5s
       retries: 10
 
+  doc-convert:
+    # Document → markdown extraction sidecar for the Data Stash pipeline: turns
+    # binary uploads (docx/odt/pptx/pdf) into markdown so they can be chunked,
+    # embedded and searched. Serves `POST /extract` (multipart `files` +
+    # `config`) and `GET /health` on :8000. Used only when STASH_CONVERT_DOCS=1
+    # (the app reads DOC_CONVERT_URL, default http://localhost:8000).
+    #
+    # Stable kreuzberg 4.x (Rust core, native parsers — no LibreOffice/pandoc).
+    # Alternative: the xberg successor line, e.g.
+    #   image: ghcr.io/xberg-io/xberg:1.0.0-rc.29-core
+    # exposes the same /extract contract (currently release-candidate only).
+    image: ghcr.io/kreuzberg-dev/kreuzberg-full:latest
+    container_name: doc-convert-seederis
+    restart: unless-stopped
+    ports:
+      - "8000:8000"
+    networks:
+      - app-network
+
 networks:
   app-network:
     driver: bridge

--- a/ui/.env.example
+++ b/ui/.env.example
@@ -65,3 +65,19 @@ VITE_DEV_BYPASS_AUTH='true'
 # REDIS_PORT='6379'
 # REDIS_PWD=''                    # falls back to REDIS_PASSWORD
 # REDIS_SSL='false'               # 'true' to connect over TLS
+
+# ----- Data Stash: document → markdown conversion -----
+#
+# By default only text-like uploads (md, txt, csv, json, html, …) are ingested
+# for search; binary office/PDF files are stored but not searchable. Set to '1'
+# to convert binary uploads (docx, odt, pptx, pdf) to markdown via the
+# `doc-convert` sidecar (see docker-compose.yaml) so they get chunked/embedded
+# and become searchable + viewable. The original bytes are kept for download.
+# Requires the sidecar running; if it's unreachable the upload still succeeds
+# and the doc is marked ingest-failed (search just won't include it).
+# STASH_CONVERT_DOCS='1'
+#
+# Base URL of the conversion sidecar (default shown). Override when the app runs
+# inside the compose network (then use http://doc-convert:8000).
+# DOC_CONVERT_URL='http://localhost:8000'
+# DOC_CONVERT_TIMEOUT_MS='120000'  # per-file conversion timeout

--- a/ui/src/__tests__/lib/doc-convert.server.test.ts
+++ b/ui/src/__tests__/lib/doc-convert.server.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Document → Markdown conversion client tests.
+ *
+ * Pure-function coverage for the response parser + MIME allowlist, and the
+ * `convertToMarkdown` HTTP call driven by an injected fake `fetch` (no socket).
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest'
+
+vi.mock('../../lib/harness-patterns/assert.server', () => ({
+  assertServerOnImport: vi.fn(),
+  assertServer: vi.fn(),
+}))
+
+import {
+  convertToMarkdown,
+  extractMarkdown,
+  isConvertible,
+  conversionEnabled,
+  docConvertUrl,
+} from '../../lib/doc-convert.server'
+
+/** Minimal Response-shaped stub so we don't depend on a global Response ctor. */
+function fakeResponse(body: unknown, ok = true, status = 200): Response {
+  return { ok, status, json: async () => body } as unknown as Response
+}
+
+describe('isConvertible', () => {
+  it('accepts docx/odt/pptx/pdf (and legacy variants), case-insensitively', () => {
+    for (const m of [
+      'application/pdf',
+      'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      'application/msword',
+      'application/vnd.oasis.opendocument.text',
+      'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+      'application/vnd.ms-powerpoint',
+    ]) {
+      expect(isConvertible(m)).toBe(true)
+      expect(isConvertible(`  ${m.toUpperCase()}  `)).toBe(true)
+    }
+  })
+
+  it('rejects text and non-office binaries (stored, not converted)', () => {
+    for (const m of ['text/plain', 'text/markdown', 'application/json', 'image/png', 'application/zip']) {
+      expect(isConvertible(m)).toBe(false)
+    }
+  })
+})
+
+describe('conversionEnabled', () => {
+  afterEach(() => {
+    delete process.env.STASH_CONVERT_DOCS
+  })
+  it('is true only when STASH_CONVERT_DOCS === "1"', () => {
+    delete process.env.STASH_CONVERT_DOCS
+    expect(conversionEnabled()).toBe(false)
+    process.env.STASH_CONVERT_DOCS = '0'
+    expect(conversionEnabled()).toBe(false)
+    process.env.STASH_CONVERT_DOCS = '1'
+    expect(conversionEnabled()).toBe(true)
+  })
+})
+
+describe('extractMarkdown', () => {
+  it('reads a bare array [{content}] (kreuzberg 4.x shape)', () => {
+    expect(extractMarkdown([{ content: '# A\n\nbody' }])).toBe('# A\n\nbody')
+  })
+  it('reads a wrapped {results:[{content}]} (xberg shape)', () => {
+    expect(extractMarkdown({ results: [{ content: '# B' }] })).toBe('# B')
+  })
+  it('falls back to text / markdown field names', () => {
+    expect(extractMarkdown([{ text: 'plain body' }])).toBe('plain body')
+    expect(extractMarkdown([{ markdown: '# C' }])).toBe('# C')
+  })
+  it('returns null for empty / malformed shapes', () => {
+    expect(extractMarkdown([])).toBeNull()
+    expect(extractMarkdown({})).toBeNull()
+    expect(extractMarkdown(null)).toBeNull()
+    expect(extractMarkdown([{ content: 123 }])).toBeNull() // non-string
+  })
+})
+
+describe('convertToMarkdown', () => {
+  const b64 = Buffer.from('raw pdf bytes').toString('base64')
+  afterEach(() => {
+    delete process.env.DOC_CONVERT_URL
+  })
+
+  it('POSTs multipart files+config to /extract and returns the markdown', async () => {
+    const fetchFn = vi.fn(async () => fakeResponse([{ content: '# Title\n\nBody.' }]))
+    const md = await convertToMarkdown(b64, 'report.pdf', 'application/pdf', fetchFn)
+
+    expect(md).toBe('# Title\n\nBody.')
+    expect(fetchFn).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchFn.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('http://localhost:8000/extract')
+    expect(init.method).toBe('POST')
+    const form = init.body as FormData
+    expect(form).toBeInstanceOf(FormData)
+    expect(String(form.get('config'))).toContain('markdown') // requests markdown output
+    expect(form.get('files')).toBeTruthy()
+  })
+
+  it('honours DOC_CONVERT_URL', async () => {
+    process.env.DOC_CONVERT_URL = 'http://doc-convert:8000'
+    const fetchFn = vi.fn(async () => fakeResponse([{ content: '# x' }]))
+    await convertToMarkdown(b64, 'a.pdf', 'application/pdf', fetchFn)
+    expect((fetchFn.mock.calls[0] as [string])[0]).toBe('http://doc-convert:8000/extract')
+  })
+
+  it('throws on a non-2xx response', async () => {
+    const fetchFn = vi.fn(async () => fakeResponse(null, false, 500))
+    await expect(convertToMarkdown(b64, 'a.pdf', 'application/pdf', fetchFn)).rejects.toThrow(/HTTP 500/)
+  })
+
+  it('throws when the sidecar returns no content', async () => {
+    const fetchFn = vi.fn(async () => fakeResponse([{ content: '' }]))
+    await expect(convertToMarkdown(b64, 'a.pdf', 'application/pdf', fetchFn)).rejects.toThrow(/no content/)
+  })
+})
+
+describe('docConvertUrl', () => {
+  afterEach(() => {
+    delete process.env.DOC_CONVERT_URL
+  })
+  it('defaults to localhost:8000, overridable via env', () => {
+    delete process.env.DOC_CONVERT_URL
+    expect(docConvertUrl()).toBe('http://localhost:8000')
+    process.env.DOC_CONVERT_URL = 'http://doc-convert:8000'
+    expect(docConvertUrl()).toBe('http://doc-convert:8000')
+  })
+})

--- a/ui/src/__tests__/lib/document-ingest-status.test.ts
+++ b/ui/src/__tests__/lib/document-ingest-status.test.ts
@@ -7,7 +7,7 @@
  * success, failed on error/binary, and idempotent skip-when-terminal.
  */
 
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 
 vi.mock('../../lib/harness-patterns/assert.server', () => ({
   assertServerOnImport: vi.fn(),
@@ -87,19 +87,31 @@ async function seed(
   fake: ReturnType<typeof makeFakeRedis>,
   id: string,
   content: string,
-  opts: { encoding?: 'base64' } = {},
+  opts: { encoding?: 'base64'; mimeType?: string } = {},
 ) {
   return storeDocument(
     {
       sessionId: 's1',
       id,
       filename: `${id}.txt`,
-      mimeType: 'text/plain',
+      mimeType: opts.mimeType ?? 'text/plain',
       content,
       ...(opts.encoding ? { encoding: opts.encoding } : {}),
     },
     fake.callTool,
   )
+}
+
+/** A base64 "binary" doc of a convertible type (e.g. a PDF). */
+async function seedBinary(
+  fake: ReturnType<typeof makeFakeRedis>,
+  id: string,
+  mimeType = 'application/pdf',
+) {
+  return seed(fake, id, Buffer.from(`raw ${id} bytes`).toString('base64'), {
+    encoding: 'base64',
+    mimeType,
+  })
 }
 
 describe('ingestStashDocument', () => {
@@ -139,6 +151,79 @@ describe('ingestStashDocument', () => {
     const res = await ingestStashDocument('s1', 'd2', { callTool: fake.callTool, embedFn: boom })
     expect(res).toBeNull()
     expect((await getDocument('s1', 'd2', fake.callTool))?.ingestStatus).toBe('failed')
+  })
+})
+
+describe('ingestStashDocument — binary conversion', () => {
+  let fake: ReturnType<typeof makeFakeRedis>
+  beforeEach(() => {
+    fake = makeFakeRedis()
+  })
+  afterEach(() => {
+    delete process.env.STASH_CONVERT_DOCS
+  })
+
+  it('converts a convertible binary → persists derivedText, chunks the markdown, indexes', async () => {
+    process.env.STASH_CONVERT_DOCS = '1'
+    const { embedFn } = makeEmbedder('m', 3)
+    const embedSpy = vi.fn(embedFn)
+    const markdown =
+      '# Architecture\n\nThe system uses a Rust core.\n\n## Storage\n\nRedis holds the vectors.'
+    const convertFn = vi.fn(async () => markdown)
+    await seedBinary(fake, 'pdf1')
+
+    const res = await ingestStashDocument('s1', 'pdf1', {
+      callTool: fake.callTool,
+      embedFn: embedSpy,
+      convertFn,
+    })
+
+    expect(res?.docId).toBe('pdf1')
+    expect(convertFn).toHaveBeenCalledTimes(1)
+    const stored = await getDocument('s1', 'pdf1', fake.callTool)
+    expect(stored?.ingestStatus).toBe('indexed')
+    expect(stored?.derivedText).toBe(markdown) // persisted for viewer/citations
+    expect(stored?.encoding).toBe('base64') // original bytes kept for download
+    expect(fake.hashes.size).toBeGreaterThan(0)
+    // Chunks were derived from the MARKDOWN, not the base64 original.
+    const embedded = embedSpy.mock.calls[0][0].join('\n')
+    expect(embedded).toContain('Architecture')
+    expect(embedded).toContain('Storage')
+  })
+
+  it('marks a convertible binary "failed" when conversion is disabled', async () => {
+    const { embedFn } = makeEmbedder('m', 3)
+    const convertFn = vi.fn(async () => '# md')
+    await seedBinary(fake, 'pdf2')
+    const res = await ingestStashDocument('s1', 'pdf2', {
+      callTool: fake.callTool,
+      embedFn,
+      convertFn,
+    })
+    expect(res).toBeNull()
+    expect(convertFn).not.toHaveBeenCalled()
+    const stored = await getDocument('s1', 'pdf2', fake.callTool)
+    expect(stored?.ingestStatus).toBe('failed')
+    expect(stored?.derivedText).toBeUndefined()
+  })
+
+  it('marks "failed" (never throws) when conversion errors, stores no derivedText', async () => {
+    process.env.STASH_CONVERT_DOCS = '1'
+    const { embedFn } = makeEmbedder('m', 3)
+    const convertFn = vi.fn(async () => {
+      throw new Error('doc-convert sidecar down')
+    })
+    await seedBinary(fake, 'pdf3')
+    const res = await ingestStashDocument('s1', 'pdf3', {
+      callTool: fake.callTool,
+      embedFn,
+      convertFn,
+    })
+    expect(res).toBeNull()
+    const stored = await getDocument('s1', 'pdf3', fake.callTool)
+    expect(stored?.ingestStatus).toBe('failed')
+    expect(stored?.derivedText).toBeUndefined()
+    expect(fake.hashes.size).toBe(0)
   })
 })
 
@@ -184,5 +269,20 @@ describe('ensureSessionIngested', () => {
     expect((await getDocument('s1', 'in-flight', fake.callTool))?.ingestStatus).toBe('pending') // skipped (gate owns it)
     expect((await getDocument('s1', 'bin', fake.callTool))?.ingestStatus).toBeUndefined() // skipped (binary)
     expect(embedSpy).toHaveBeenCalledTimes(2) // old-failed + fresh only
+  })
+
+  it('with conversion enabled, ingests a convertible binary (no longer skipped)', async () => {
+    process.env.STASH_CONVERT_DOCS = '1'
+    try {
+      const { embedFn } = makeEmbedder('m', 3)
+      const convertFn = vi.fn(async () => '# Title\n\nBody text here.')
+      await seedBinary(fake, 'pdfx')
+      await ensureSessionIngested('s1', { callTool: fake.callTool, embedFn, convertFn })
+      const stored = await getDocument('s1', 'pdfx', fake.callTool)
+      expect(stored?.ingestStatus).toBe('indexed')
+      expect(convertFn).toHaveBeenCalledTimes(1)
+    } finally {
+      delete process.env.STASH_CONVERT_DOCS
+    }
   })
 })

--- a/ui/src/__tests__/lib/document-store.test.ts
+++ b/ui/src/__tests__/lib/document-store.test.ts
@@ -240,6 +240,28 @@ describe('document-store (Issue #6)', () => {
       expect((meta as unknown as Record<string, unknown>).content).toBeUndefined()
       expect(meta!.filename).toBe('a.txt')
     })
+
+    it('surfaces derivedText as a `converted` flag in meta, never the markdown itself', async () => {
+      const stored = await storeDocument(
+        { sessionId: 's1', filename: 'report.pdf', mimeType: 'application/pdf', content: 'Ym9keQ==', encoding: 'base64' },
+        fake.callTool,
+      )
+      // No derivation yet → not converted.
+      let meta = await getDocumentMeta('s1', stored.id, fake.callTool)
+      expect(meta!.converted).toBeUndefined()
+
+      // After the ingest converter persists derived markdown…
+      await setDocumentFlags('s1', stored.id, { derivedText: '# Report\n\nBody.' }, fake.callTool)
+      meta = await getDocumentMeta('s1', stored.id, fake.callTool)
+      expect(meta!.converted).toBe(true)
+      // The (potentially large) markdown must not ride along in the meta.
+      expect((meta as unknown as Record<string, unknown>).derivedText).toBeUndefined()
+      // …but the original base64 bytes are still on the full doc for download.
+      const full = await getDocument('s1', stored.id, fake.callTool)
+      expect(full!.encoding).toBe('base64')
+      expect(full!.content).toBe('Ym9keQ==')
+      expect(full!.derivedText).toBe('# Report\n\nBody.')
+    })
   })
 
   describe('listDocuments', () => {

--- a/ui/src/components/ark-ui/DataStashPanel.tsx
+++ b/ui/src/components/ark-ui/DataStashPanel.tsx
@@ -456,9 +456,10 @@ const DocChip = (props: {
 
   return (
     <div style={{ position: 'relative', display: 'inline-block' }}>
-      {/* "Eye" — open the inline file viewer. Text docs only (binary has no
-          text view). Stops propagation so it doesn't also open the chip menu. */}
-      <Show when={d().encoding !== 'base64'}>
+      {/* "Eye" — open the inline file viewer. Text docs, plus converted
+          binaries (docx/pdf/… whose derived markdown is viewable); a raw binary
+          has no text view. Stops propagation so it doesn't also open the menu. */}
+      <Show when={d().encoding !== 'base64' || d().converted}>
         <button
           onClick={(e) => {
             e.stopPropagation()

--- a/ui/src/lib/doc-convert.server.ts
+++ b/ui/src/lib/doc-convert.server.ts
@@ -1,0 +1,136 @@
+/**
+ * Document → Markdown conversion — Server Only
+ *
+ * Converts binary office/PDF uploads (docx, odt, pptx, pdf) to markdown so they
+ * can flow through the existing text pipeline (chunk → embed → index → KNN).
+ * Without this, binary uploads are stored but never searchable (the chunker
+ * treats `content` as UTF-8 text and `ingestStashDocument` marks base64 docs
+ * `failed`).
+ *
+ * Conversion is a *host pipeline step*, not an agentic tool, so — like the
+ * direct-Redis app path — it talks to a plain HTTP sidecar rather than the MCP
+ * gateway. The sidecar is a document-extraction service exposing a `/extract`
+ * endpoint (default: the stable `kreuzberg-full` image; the `xberg` RC line is a
+ * drop-in alternative — same `/extract` contract, just a different compose tag).
+ *
+ * Gated by `STASH_CONVERT_DOCS=1`. Off (default) → binaries behave exactly as
+ * before (stored, not ingested). If the sidecar is unreachable the conversion
+ * throws and the caller records `ingestStatus: 'failed'` — the upload itself
+ * never fails.
+ */
+
+import { assertServerOnImport } from './harness-patterns/assert.server'
+
+assertServerOnImport()
+
+/** MIME type we tag derived text with once converted. */
+export const MARKDOWN_MIME = 'text/markdown'
+
+/** Whether document→markdown conversion is enabled for the Data Stash path. */
+export function conversionEnabled(): boolean {
+  return process.env.STASH_CONVERT_DOCS === '1'
+}
+
+/**
+ * Base URL of the conversion sidecar. Dev default matches the compose service
+ * publishing `8000:8000` on the host. Override with `DOC_CONVERT_URL` when the
+ * app runs inside the compose network (e.g. `http://doc-convert:8000`).
+ */
+export function docConvertUrl(): string {
+  return process.env.DOC_CONVERT_URL || 'http://localhost:8000'
+}
+
+/**
+ * Binary MIME types we route through the converter. Deliberately a small,
+ * explicit allowlist (the requested docx/odt/pptx/pdf + their legacy variants)
+ * rather than "any non-text" — an unknown binary (zip, image, parquet) should
+ * still be stored-but-not-ingested, not sent to the converter. Extend here to
+ * add formats (e.g. xlsx) the sidecar also supports.
+ */
+const CONVERTIBLE_MIMES = new Set<string>([
+  'application/pdf',
+  // Word
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document', // .docx
+  'application/msword', // .doc
+  // OpenDocument text
+  'application/vnd.oasis.opendocument.text', // .odt
+  // PowerPoint
+  'application/vnd.openxmlformats-officedocument.presentationml.presentation', // .pptx
+  'application/vnd.ms-powerpoint', // .ppt
+  'application/vnd.oasis.opendocument.presentation', // .odp
+])
+
+/** Whether a stored binary doc of this MIME type should be converted. */
+export function isConvertible(mimeType: string): boolean {
+  return CONVERTIBLE_MIMES.has(mimeType.trim().toLowerCase())
+}
+
+/** Conversion request timeout (ms). Large/scanned PDFs with OCR can be slow;
+ *  ingest runs in the background, so a generous default is fine. */
+const CONVERT_TIMEOUT_MS = Number(process.env.DOC_CONVERT_TIMEOUT_MS) || 120_000
+
+/**
+ * Pull the extracted markdown out of the sidecar's `/extract` reply. The stable
+ * kreuzberg 4.x server returns a BARE ARRAY (`[{ content, mime_type, … }]`); the
+ * xberg RC wraps it as `{ results: [...] }`. Accept either, and tolerate a
+ * `text`/`markdown` field name, so swapping the sidecar image needs no code
+ * change. Returns the string, or null if the shape carries no usable content.
+ */
+export function extractMarkdown(body: unknown): string | null {
+  const arr: unknown[] = Array.isArray(body)
+    ? body
+    : Array.isArray((body as { results?: unknown[] })?.results)
+      ? (body as { results: unknown[] }).results
+      : []
+  const first = arr[0]
+  if (!first || typeof first !== 'object') return null
+  const rec = first as Record<string, unknown>
+  const md = rec.content ?? rec.markdown ?? rec.text
+  return typeof md === 'string' ? md : null
+}
+
+/**
+ * Convert base64-encoded binary document bytes to markdown via the sidecar.
+ * `fetchFn` is injectable so tests never open a socket.
+ *
+ * @throws on disabled/unreachable sidecar, non-2xx, timeout, or empty output —
+ *         callers (ingest) turn a throw into `ingestStatus: 'failed'`.
+ */
+export async function convertToMarkdown(
+  base64Content: string,
+  filename: string,
+  mimeType: string,
+  fetchFn: typeof fetch = fetch,
+): Promise<string> {
+  const bytes = Buffer.from(base64Content, 'base64')
+  const form = new FormData()
+  const blob = new Blob([new Uint8Array(bytes)], {
+    type: mimeType || 'application/octet-stream',
+  })
+  form.append('files', blob, filename || 'upload')
+  // Request markdown explicitly — the sidecar defaults to `plain`, which drops
+  // heading markers and would defeat the markdown-aware chunker (bindHeadings).
+  form.append('config', JSON.stringify({ output_format: 'markdown' }))
+
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), CONVERT_TIMEOUT_MS)
+  let res: Response
+  try {
+    res = await fetchFn(`${docConvertUrl()}/extract`, {
+      method: 'POST',
+      body: form,
+      signal: controller.signal,
+    })
+  } finally {
+    clearTimeout(timer)
+  }
+
+  if (!res.ok) {
+    throw new Error(`doc-convert /extract failed: HTTP ${res.status}`)
+  }
+  const md = extractMarkdown(await res.json())
+  if (md == null || md.trim() === '') {
+    throw new Error('doc-convert returned no content')
+  }
+  return md
+}

--- a/ui/src/lib/document-ingest.server.ts
+++ b/ui/src/lib/document-ingest.server.ts
@@ -38,6 +38,12 @@ import {
 } from './document-store.server'
 import { chunkDocument, type Chunk, type ChunkConfig } from './chunking.server'
 import {
+  conversionEnabled,
+  convertToMarkdown,
+  isConvertible,
+  MARKDOWN_MIME,
+} from './doc-convert.server'
+import {
   embed as defaultEmbed,
   embedOne as defaultEmbedOne,
   assertSameSpace,
@@ -63,6 +69,10 @@ export interface IngestOptions {
   allowSpaceChange?: boolean
   callTool?: CallTool
   embedFn?: (texts: string[], config?: EmbeddingConfig) => Promise<EmbeddingResult>
+  /** Binary→markdown converter (injectable for tests, mirroring embedFn).
+   *  Defaults to the doc-convert sidecar client. Called only for convertible
+   *  base64 docs before chunking. */
+  convertFn?: (base64Content: string, filename: string, mimeType: string) => Promise<string>
 }
 
 export interface IngestResult {
@@ -232,9 +242,11 @@ export async function ingestDocument(
  * retriever's lazy safety net:
  *
  *  - missing doc            → `null` (nothing to do)
- *  - `base64` binary        → status `'failed'` (the text pipeline can't chunk
- *                             binary; mark it so we don't retry forever)
- *  - ingest throws          → status `'failed'`, returns `null`
+ *  - `base64` binary        → converted to markdown first when it's a
+ *                             convertible type (docx/pdf/pptx/odt) and
+ *                             conversion is enabled; otherwise status `'failed'`
+ *                             (the text pipeline can't chunk it — don't retry)
+ *  - convert/ingest throws  → status `'failed'`, returns `null`
  *  - ingest ok              → status `'indexed'`, returns the {@link IngestResult}
  *
  * Best-effort by contract: it never throws (failures live in the status field),
@@ -248,20 +260,36 @@ export async function ingestStashDocument(
   const callTool = opts.callTool ?? stashCallTool()
   const doc = await getDocument(sessionId, docId, callTool)
   if (!doc) return null
-  if (doc.encoding === 'base64') {
+
+  // Binary docs are only ingestable if we can convert them to text. A
+  // convertible type (docx/pdf/pptx/odt) with conversion enabled is handled in
+  // the try below; any other base64 is marked failed so we don't retry forever.
+  const needsConversion = doc.encoding === 'base64'
+  if (needsConversion && !(conversionEnabled() && isConvertible(doc.mimeType))) {
     await setDocumentFlags(sessionId, docId, { ingestStatus: 'failed' }, callTool)
     return null
   }
-  // Mark 'pending' up front so the panel shows "embedding…" while we embed
-  // (slow on the serial gateway; without this the lazy-ensure path looks stuck
-  // at no-status). The upload-gate path already persisted 'pending' in the
-  // store write, so skip the redundant round-trip there — re-writing the same
-  // value only burns a serial gateway call and a list-cache invalidation.
+
+  // Mark 'pending' up front so the panel shows "embedding…" while we
+  // convert/embed (both slow). The upload-gate path already persisted 'pending'
+  // in the store write, so skip the redundant round-trip there — re-writing the
+  // same value only burns a gateway call and a list-cache invalidation.
   if (doc.ingestStatus !== 'pending') {
     await setDocumentFlags(sessionId, docId, { ingestStatus: 'pending' }, callTool)
   }
   try {
-    const result = await ingestDocument(doc, opts)
+    let ingestDoc = doc
+    if (needsConversion) {
+      // docx/pdf/… → markdown. Persist the derived text so the file viewer and
+      // chat citations can render it (chunk offsets index into this markdown,
+      // not the base64 original — which stays in `content` for downloads). Then
+      // feed an in-memory text doc to the unchanged `ingestDocument`.
+      const convertFn = opts.convertFn ?? convertToMarkdown
+      const markdown = await convertFn(doc.content, doc.filename, doc.mimeType)
+      await setDocumentFlags(sessionId, docId, { derivedText: markdown }, callTool)
+      ingestDoc = { ...doc, content: markdown, mimeType: MARKDOWN_MIME, encoding: undefined }
+    }
+    const result = await ingestDocument(ingestDoc, opts)
     await setDocumentFlags(sessionId, docId, { ingestStatus: 'indexed' }, callTool)
     return result
   } catch {
@@ -282,7 +310,7 @@ export async function ingestStashDocument(
  *    session was persisted).
  * Skips `'indexed'` (searchable), `'pending'` (the gate is actively ingesting
  * it — re-ingesting would double the work and contend on the serial gateway),
- * and `base64` binaries (never text-ingestable). A fully-indexed corpus costs
+ * and non-convertible `base64` binaries. A fully-indexed corpus costs
  * just one `listDocuments`.
  */
 export async function ensureSessionIngested(
@@ -293,7 +321,9 @@ export async function ensureSessionIngested(
   const metas = await listDocuments(sessionId, callTool)
   for (const m of metas) {
     if (m.ingestStatus === 'indexed' || m.ingestStatus === 'pending') continue
-    if (m.encoding === 'base64') continue
+    // Skip binaries we can't turn into text; convertible ones (with conversion
+    // enabled) fall through to ingestStashDocument, which converts them.
+    if (m.encoding === 'base64' && !(conversionEnabled() && isConvertible(m.mimeType))) continue
     await ingestStashDocument(sessionId, m.id, opts)
   }
 }

--- a/ui/src/lib/document-store.server.ts
+++ b/ui/src/lib/document-store.server.ts
@@ -71,6 +71,14 @@ export interface StashDocumentMeta {
    * offline). Absent → never ingested (no redis-retriever in the harness).
    */
   ingestStatus?: IngestStatus
+  /**
+   * True when a text derivation exists (see {@link StashDocument.derivedText}) —
+   * a binary upload (docx/pdf/pptx/odt) converted to markdown for ingest.
+   * Meta-only convenience flag, computed from `derivedText` presence in
+   * {@link stripContent} (never stored separately). The panel uses it to offer
+   * the file viewer on converted binaries whose `encoding` is still `'base64'`.
+   */
+  converted?: boolean
 }
 
 export type IngestStatus = 'pending' | 'indexed' | 'failed'
@@ -83,6 +91,14 @@ export interface StashDocument extends StashDocumentMeta {
    * storing — this layer treats `content` as opaque UTF-8 text.
    */
   content: string
+  /**
+   * Markdown derived from a binary `content` (docx/pdf/pptx/odt) by the ingest
+   * converter (xberg sidecar). Present only on converted binaries; `content`
+   * still holds the original base64 bytes (so `?download` and the `/work` sync
+   * serve the real file). This is the text that gets chunked/embedded and shown
+   * in the file viewer — chunk char-offsets index into THIS, not `content`.
+   */
+  derivedText?: string
 }
 
 /** Input for {@link storeDocument}. `id` and `uploadedAt` are minted here. */
@@ -432,7 +448,13 @@ export async function listDocuments(
 export async function setDocumentFlags(
   sessionId: string,
   docId: string,
-  patch: { hidden?: boolean; archived?: boolean; ingestStatus?: IngestStatus },
+  patch: {
+    hidden?: boolean
+    archived?: boolean
+    ingestStatus?: IngestStatus
+    /** Derived markdown for a converted binary (see {@link StashDocument.derivedText}). */
+    derivedText?: string
+  },
   callTool: CallTool = stashCallTool(),
 ): Promise<StashDocument | null> {
   const doc = await getDocument(sessionId, docId, callTool)
@@ -441,6 +463,7 @@ export async function setDocumentFlags(
   if (patch.hidden !== undefined) doc.hidden = patch.hidden
   if (patch.archived !== undefined) doc.archived = patch.archived
   if (patch.ingestStatus !== undefined) doc.ingestStatus = patch.ingestStatus
+  if (patch.derivedText !== undefined) doc.derivedText = patch.derivedText
 
   // Rewriting via json_set at `$` would clear any existing expiry, so we
   // re-apply a TTL. There is no `ttl` tool on the Redis MCP surface to read the
@@ -512,8 +535,11 @@ export function toPriorResult(
 // Internal helpers
 // ============================================================================
 
-function stripContent(doc: StashDocument): StashDocumentMeta {
-  const { content: _content, ...meta } = doc
+export function stripContent(doc: StashDocument): StashDocumentMeta {
+  const { content: _content, derivedText, ...meta } = doc
   void _content
-  return meta
+  // Surface a boolean instead of the (potentially large) derived markdown, so
+  // the meta list stays light but the panel still knows a converted binary is
+  // viewable/ingested. Kept out of the stored JSON — computed on every read.
+  return { ...meta, ...(derivedText != null ? { converted: true } : {}) }
 }

--- a/ui/src/routes/api/stash/document/[id].ts
+++ b/ui/src/routes/api/stash/document/[id].ts
@@ -17,6 +17,7 @@ import {
   getDocument,
   deleteDocument,
   setDocumentFlags,
+  stripContent,
 } from '../../../../lib/document-store.server'
 import { json, withUser } from '../../../../lib/stash/http.server'
 
@@ -51,6 +52,16 @@ export async function GET(event: APIEvent) {
       })
     }
 
+    // Non-download: the viewer wants readable text. A converted binary
+    // (docx/pdf/pptx/odt) keeps its base64 original in `content` for downloads,
+    // so serve its derived markdown as the viewable `content` (utf8) instead —
+    // chunk offsets from citations index into THIS text. Drop the heavy base64
+    // blob and the duplicate `derivedText` field from the payload.
+    if (doc.derivedText != null) {
+      const { derivedText, ...rest } = doc
+      return json({ document: { ...rest, content: derivedText, encoding: 'utf8' as const } })
+    }
+
     return json({ document: doc })
   })
 }
@@ -79,8 +90,6 @@ export async function PATCH(event: APIEvent) {
       archived: body.archived,
     })
     if (!updated) return json({ error: 'Document not found' }, 404)
-    const { content: _content, ...meta } = updated
-    void _content
-    return json({ ok: true, document: meta })
+    return json({ ok: true, document: stripContent(updated) })
   })
 }

--- a/ui/src/routes/api/stash/upload.ts
+++ b/ui/src/routes/api/stash/upload.ts
@@ -18,6 +18,7 @@ import { ingestStashDocument } from '../../../lib/document-ingest.server'
 import { loadSession } from '../../../lib/harness-client/session.server'
 import { agentUsesRedisRetriever } from '../../../lib/harness-client/registry.server'
 import { parseUploadRequest } from '../../../lib/stash/upload-service.server'
+import { conversionEnabled, isConvertible } from '../../../lib/doc-convert.server'
 import { json, withUser } from '../../../lib/stash/http.server'
 
 export async function POST(event: APIEvent) {
@@ -49,6 +50,7 @@ export async function POST(event: APIEvent) {
         input.sessionId,
         userId,
         storeInput.encoding,
+        storeInput.mimeType,
         agentId,
       )
       const doc = await storeDocument({
@@ -82,9 +84,15 @@ async function willAutoIngest(
   sessionId: string,
   userId: string,
   encoding: 'utf8' | 'base64' | undefined,
+  mimeType: string,
   agentId: string | undefined,
 ): Promise<boolean> {
-  if (encoding === 'base64') return false // binary: not text-ingestable
+  // Binary is ingestable only if we can convert it to text — a convertible type
+  // (docx/pdf/pptx/odt) with conversion enabled. Other binaries (zip, images,
+  // parquet) are stored but not searchable, so don't fire the gate for them.
+  if (encoding === 'base64' && !(conversionEnabled() && isConvertible(mimeType))) {
+    return false
+  }
   try {
     const resolvedAgentId = agentId ?? (await loadSession(sessionId, userId))?.agentId
     if (!resolvedAgentId) return false // session not persisted + no agent hint


### PR DESCRIPTION
Adds **document → markdown conversion** to the Data Stash pipeline so binary uploads (**docx, odt, pptx, pdf**) become searchable + viewable + citable, not just stored. Previously the chunker treated `content` as UTF-8 text and `ingestStashDocument` marked every `base64` doc `failed`, so office/PDF files were dead weight.

## How it works

```
upload (base64 kept)  →  [convertible + flag on?]  →  POST /extract → markdown
                      →  persist derivedText  →  chunk(markdown) → embed → index
```

- **Sidecar, not MCP.** Conversion is a host pipeline step (like the direct-Redis app path), so it talks to a plain HTTP extraction service over `POST /extract`, bypassing the serial MCP gateway. New `doc-convert` compose service on `:8000`.
- **Engine choice.** Stable **kreuzberg 4.10.2** (`ghcr.io/kreuzberg-dev/kreuzberg-full`) — Rust core, native parsers (no LibreOffice/pandoc), markdown output that preserves heading structure (feeds the existing `bindHeadings` chunker). The xberg successor line exposes the same `/extract` contract and is a one-line compose swap (currently RC-only, hence the stable pick). The response parser accepts both kreuzberg's bare-array and xberg's `{results}` shape.
- **Storage keeps both.** The original bytes stay in `content` (so `?download` and the `/work` sync serve the real `.docx`/`.pdf`); the derived markdown lands in a new `derivedText` field. Chunk char-offsets and the file viewer index into `derivedText`, so chat citations line up with what's shown. A `converted` meta flag (computed, not stored) drives the panel's view-eye on converted binaries.
- **Same UX as text.** Convertible uploads flow through the existing auto-ingest gate → `pending` → `indexed`, so the "embedding…" indicator + composer-block work unchanged. `ensureSessionIngested` also admits them (lazy safety net).

## Config / rollout

- Off by default. Enable with **`STASH_CONVERT_DOCS=1`** (+ optional `DOC_CONVERT_URL`, default `http://localhost:8000`). Start the sidecar with `docker compose up -d doc-convert`.
- **Graceful fallback:** sidecar down/unreachable → the doc is marked ingest-`failed`; the upload itself never fails and non-convertible binaries behave exactly as before.

## Verification

- `pnpm exec tsc --noEmit`: 22 pre-existing errors, **0 new**.
- `pnpm test:run`: **907 passed / 1 skipped** (+25 new: converter parser/HTTP with injected fetch, ingest conversion/gate paths, the `converted` flag).
- **Live end-to-end:** real `.docx` and `.pdf` uploaded to the Retriever Agent → converted → embedded → retrieved correctly, with headings preserved and the original still downloadable. The `/extract` contract was validated empirically against the running container (it returns a bare array, which the doc's summary got wrong — the parser handles both shapes).

## Deferred

- `docs/DATA_STASH.md` conversion section (happy to add as a follow-up commit).
- Extending the `CONVERTIBLE_MIMES` allowlist (xlsx → markdown tables, etc.) — one-line additions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVhNfn9AB3S8PV1CNURCzQ
