### PR TITLE
feat(sandbox): image-processing, data & office rootfs flavours + router demonstrator (#78)

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -59,6 +59,7 @@ Source-level index: see [ui/README.md](../ui/README.md#documentation-index).
 | [DOCKER_COMPOSE.md](DOCKER_COMPOSE.md) | Neo4j, MCP Gateway, Redis service configuration |
 | [MCP_GATEWAY.md](MCP_GATEWAY.md) | MCP Gateway reference, CLI, troubleshooting |
 | [sandbox-plan.md](sandbox-plan.md) | Sandbox compute plan — `withSandbox` wrapper, attachment model, MCP-in-VM architecture, durable workspaces (`syncWorkspace`, #89), backend interface (Docker + Firecracker), substrate options, failure modes |
+| [sandbox-flavours.md](sandbox-flavours.md) | Sandbox rootfs flavours (#78) — the `image-processing` + `data` images, the router-over-flavoured-sandboxes recipe, ephemeral vs persistent, and deferred hardening (#116) |
 | [sandbox/README.md](sandbox/README.md) | Sandbox debugging — identify/inspect/reap containers, `/work` durable-workspace layout, `.harness-logs` jq recipes |
 
 **Key config files:**

--- a/docs/sandbox-flavours.md
+++ b/docs/sandbox-flavours.md
@@ -24,7 +24,12 @@ Two purpose-split flavours, each `FROM kg-sandbox:base`, built by
 | Flavour | Adds | For |
 |---|---|---|
 | **`image-processing`** | numpy, Pillow, OpenCV (Debian `python3-opencv`) + **imagemagick** | image manipulation |
-| **`data`** | pandas, numpy, polars, pyarrow, matplotlib, seaborn + openpyxl, python-docx, python-pptx, reportlab, pypdf (via **`uv`**) | data analysis, plots, office/pdf generation |
+| **`data`** | pandas, numpy, polars, pyarrow, matplotlib, seaborn + excel backends (openpyxl, fastexcel, xlsxwriter) + python-docx, python-pptx, reportlab, pypdf (via **`uv`**) | data analysis, plots, office/pdf generation |
+| **`office`** | python-docx (Word), openpyxl + xlsxwriter (Excel), PyMuPDF (PDF read/edit/create) (via **`uv`**) | editing MS-Office documents & PDFs as deliverables |
+
+Excel backends in `data`: pandas reads/writes xlsx via **openpyxl**; polars'
+`read_excel` needs **fastexcel** (the calamine engine); **xlsxwriter** is the
+write engine for `pd.ExcelWriter` / `pl.DataFrame.write_excel`.
 
 - **`base` stays the default rootfs;** flavours are opt-in via `withSandbox({ rootfs })`.
 - Both keep `sandbox_bash` and `mcp-only` egress (no network) for now.
@@ -127,5 +132,7 @@ works today (the demonstrator does exactly this).
 **Avoid overlap:** ingest-side many→markdown *conversion* (pdf/docx/odt → md, for
 search) is handled by the `doc-convert` sidecar (see [`DATA_STASH.md`](DATA_STASH.md)
 → Document conversion). These flavours are about *executing code* and *producing*
-image/office deliverables — a different axis. An `office` flavour (LibreOffice/uno)
-for true format conversion is deferred; prefer a service over baking it.
+image/office deliverables — a different axis. The `office` flavour EDITS
+docx/xlsx/pdf in-place (python-docx/openpyxl/PyMuPDF); true format *conversion*
+(docx↔odt, →pdf via an office engine) still isn't covered — that's a deferred
+LibreOffice service, not a flavour (prefer a service over baking it).

--- a/docs/sandbox-flavours.md
+++ b/docs/sandbox-flavours.md
@@ -1,0 +1,131 @@
+# Sandbox flavours & runtime selection — design note
+
+> **Status:** the `image-processing` + `data` flavours and a router demonstrator
+> ship in this PR; the hardening/ergonomics items are tracked in
+> [#116](https://github.com/mknw/harness-playground/issues/116). Tracks
+> [#78](https://github.com/mknw/harness-playground/issues/78). Companion to
+> [`sandbox-plan.md`](sandbox-plan.md) and [`data-flow.md`](data-flow.md)
+> (attachment lifecycle + `/work` ⇄ Data Stash).
+
+## Problem
+
+Sandbox v0 shipped one rootfs, `base` ([`rootfs/Dockerfile`](../rootfs/Dockerfile)):
+`node:22-bookworm-slim` + `python3`/`pip`/`venv` + `curl` + the two in-VM MCP
+servers. No image/data/office tooling, and the default `egress: 'mcp-only'` sets
+`--network none` ([`docker-backend.server.ts`](../ui/src/lib/sandbox/docker-backend.server.ts)),
+so the actor can't install packages at runtime either. Image processing, data
+analysis, and office-document generation were effectively blocked.
+
+## Flavours (this PR)
+
+Two purpose-split flavours, each `FROM kg-sandbox:base`, built by
+[`rootfs/build.sh`](../rootfs/build.sh):
+
+| Flavour | Adds | For |
+|---|---|---|
+| **`image-processing`** | numpy, Pillow, OpenCV (Debian `python3-opencv`) + **imagemagick** | image manipulation |
+| **`data`** | pandas, numpy, polars, pyarrow, matplotlib, seaborn + openpyxl, python-docx, python-pptx, reportlab, pypdf (via **`uv`**) | data analysis, plots, office/pdf generation |
+
+- **`base` stays the default rootfs;** flavours are opt-in via `withSandbox({ rootfs })`.
+- Both keep `sandbox_bash` and `mcp-only` egress (no network) for now.
+- **On the `data`/`image-processing` split:** `data` deliberately omits the heavy CV
+  libraries (`opencv`/`scikit-image`). Note that **Pillow still arrives in `data`
+  transitively** — matplotlib (required by seaborn) hard-depends on it — so the
+  split is really "no OpenCV in `data`", not "no Pillow". Truly Pillow-free `data`
+  would mean dropping matplotlib/seaborn.
+- **Why `image-processing` uses apt, not `uv`:** the `opencv-python` wheel SIGILLs
+  on import on arm64/colima (illegal instruction — the same class as the RediSearch
+  arm64 crash). Debian's `python3-opencv` (+ matched `python3-numpy`/`python3-pil`)
+  is compiled for a baseline ISA and imports cleanly. `data`'s uv wheels don't
+  SIGILL, so it stays on `uv`.
+
+## What already existed (the plumbing)
+
+- `RootfsId` is an open string; widened here to `'base' | 'image-processing' | 'data' | (string & {})` ([`types.ts`](../ui/src/lib/sandbox/types.ts)).
+- `imageForRootfs` maps `base` → `SANDBOX_IMAGE` and falls through to `kg-sandbox:${rootfs}` — no backend change to add a flavour ([`docker-backend.server.ts`](../ui/src/lib/sandbox/docker-backend.server.ts)).
+- `WarmPool` is keyed by rootfs flavour ([`warm-pool.server.ts`](../ui/src/lib/sandbox/warm-pool.server.ts)); caps added for the new flavours in `DEFAULT_SETTINGS.sandbox.warmPool`.
+
+## The composable recipe — router over flavoured sandboxes
+
+`withSandbox(config)(pattern)` returns a `ConfiguredPattern`; `router(name→description)`
++ `routes(name→pattern)` compose them. A route can be a flavoured, sandboxed
+controller — so flavour selection lives entirely in the harness. The demonstrator
+([`examples/flavoured-sandbox.server.ts`](../ui/src/lib/harness-client/examples/flavoured-sandbox.server.ts)):
+
+```ts
+// one ephemeral (base) + two persistent (data, image-processing) routes
+const basic = withSandbox({ rootfs: 'base', egress: 'mcp-only', sessionId })(loop)          // ephemeral (anon pool)
+const image = withSandbox({ id: `${sessionId}:image-processing`, sessionId,
+                            rootfs: 'image-processing', egress: 'mcp-only', syncWorkspace: true })(loop)
+const data  = withSandbox({ id: `${sessionId}:data`, sessionId,
+                            rootfs: 'data', egress: 'mcp-only', syncWorkspace: true })(loop)
+
+return [
+  router({ basic: '…', image_processing: '…', data: '…' }),
+  routes({ basic, image_processing: image, data }),
+  synthesizer({ mode: 'thread' }),
+]
+```
+
+```mermaid
+flowchart TD
+    U["User turn"] --> R{"router · classify intent"}
+    R -->|"quick shell / general"| BR["basic route<br/>withSandbox(rootfs 'base') · ephemeral (anon pool)"]
+    R -->|"image manipulation"| IR["image route<br/>withSandbox(id 'SID:image-processing', rootfs 'image-processing') · persistent"]
+    R -->|"data / plots / office"| DR["data route<br/>withSandbox(id 'SID:data', rootfs 'data') · persistent"]
+
+    BR --> BC[("base container<br/>reset each turn")]
+    IR --> IC[("image-processing container")]
+    DR --> DC[("data container")]
+
+    IC -. "hydrate /work/in · promote /work/out" .-> DS[("Data Stash · Redis<br/>shared /work across flavours")]
+    DC -. "hydrate / promote" .-> DS
+```
+
+Why it fits the current primitives (verified in source):
+
+- **Only the matched route boots.** `routes()` dispatches a single
+  `patternMap[routeName]` (`router.server.ts:238`), so only the selected flavour's
+  `withSandbox` fn runs → one container per turn, no fan-out.
+- **Capabilities flow through composition.** `routes()` exposes
+  `children: Object.values(patternMap)` (`router.server.ts:277`) and `withSandbox`
+  exposes `children:[pattern]` + stamps its `syncWorkspace` marker — so
+  `agentUsesSyncWorkspace` / `agentUsesRedisRetriever` work on a hand-composed agent.
+
+## Ephemerality is orthogonal to flavour
+
+Whether a sandbox is **ephemeral** (`fresh` or the anonymous-pool path — reset per
+turn) or **persistent** (`id` + `syncWorkspace` — parked across turns) is a
+*per-call* argument, not a property of the flavour. Any flavour can be used either
+way, and **multiple persistent flavours can coexist in one session**: use a
+flavour-scoped attachment id `id = ${sessionId}:${rootfs}` (distinct container per
+flavour) while keeping `sessionId` (the Data Stash key) the conversation id — so
+`/work` hydrate/promote is shared across the flavoured containers, only in-VM
+scratch differs. `id` and `sessionId` are *separate* `withSandbox` params, so this
+works today (the demonstrator does exactly this).
+
+## Deferred (→ [#116](https://github.com/mknw/harness-playground/issues/116))
+
+- **Flavour-in-identity.** Fold the `${id}:${rootfs}` convention *into* `withSandbox`
+  so callers can't forget it and silently reuse one container across flavours
+  (today `AttachmentTable.acquire` reuses by `id`, ignoring `rootfs`). Ergonomic/safety,
+  not a correctness blocker given the convention works now.
+- **Flavour-aware Shell.** `PtyManager.start` acquires `(sessionId, 'base')`
+  ([`pty-manager.server.ts`](../ui/src/lib/sandbox/pty-manager.server.ts)) — with
+  flavour-scoped agent containers the terminal opens a *separate* base box (it still
+  hydrates `/work/in` from the shared Data Stash, so it shows promoted deliverables
+  but not the flavoured containers' live scratch). Make the tab pick a flavour and
+  acquire `${sessionId}:${flavour}` (thread a `flavour` param through the PTY stream
+  route, like `agentId`).
+- **Guardrails** — per-flavour in-VM tool surface (curate/drop `sandbox_bash`;
+  whitelist capabilities, not command substrings), advisory command allow/denylist,
+  kernel hardening (`--cap-drop=ALL`, `--read-only` + writable `/work`, non-root
+  `USER`, seccomp), and **egress enforcement** (the `pypi`/`github-trusted`/`open`
+  profiles are named but not enforced yet) + `uv` live-install with a mounted cache.
+  Revisit with the `open` (networked) flavour.
+
+**Avoid overlap:** ingest-side many→markdown *conversion* (pdf/docx/odt → md, for
+search) is handled by the `doc-convert` sidecar (see [`DATA_STASH.md`](DATA_STASH.md)
+→ Document conversion). These flavours are about *executing code* and *producing*
+image/office deliverables — a different axis. An `office` flavour (LibreOffice/uno)
+for true format conversion is deferred; prefer a service over baking it.

--- a/docs/sandbox-plan.md
+++ b/docs/sandbox-plan.md
@@ -6,7 +6,7 @@ Reference design for `withSandbox` — a harness wrapper that attaches a statefu
 
 This document is the infrastructure design — wrapper API, attachment model, MCP-in-VM architecture, backend interface, substrate options, lifecycle, failure modes. It does **not** cover:
 - Why we want this (see #78)
-- Rootfs flavor catalog beyond the v0 minimum (see #78 → "Rootfs flavors")
+- Rootfs flavor catalog beyond the v0 minimum (see #78 → "Rootfs flavors"; the first `image-processing` + `data` flavours are specced in [`sandbox-flavours.md`](sandbox-flavours.md))
 - `backgroundSession` (a v2 primitive, orthogonal to `withSandbox`; outlined under "Deferred / v1+")
 
 > **Design-conversation note.** An earlier draft of this doc was scaffolded too early, before the load-bearing architectural choices were probed. The current shape was reached by sampling the option space first and converging with the user before writing. Keep that ordering. See CLAUDE.md → "Design Decisions" → "Probe before scaffolding."

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -56,6 +56,13 @@ COPY init.sh /opt/mcp/init.sh
 RUN chmod +x /opt/mcp/init.sh
 
 ENV WORK_DIR=/work
+# Don't prepend the script dir / cwd to sys.path (Python 3.11+). Agents write
+# scripts into /work (the cwd) with names they choose — a script named after a
+# stdlib module (inspect.py, types.py, email.py, …) would otherwise shadow that
+# module and break unrelated imports (`import pandas` died on an agent-written
+# /work/inspect.py via numpy's `import inspect`). Agents importing their own
+# sibling modules must set PYTHONPATH=/work explicitly (covered in guidance).
+ENV PYTHONSAFEPATH=1
 WORKDIR /work
 
 # Idle host: prepare /work, then block forever. MCP servers are spawned

--- a/rootfs/Dockerfile.data
+++ b/rootfs/Dockerfile.data
@@ -10,6 +10,9 @@ FROM kg-sandbox:base AS data
 # uv (static binary) — installs into the system python so `python3` sees it in
 # any shell.
 COPY --from=ghcr.io/astral-sh/uv:0.11.29 /uv /uvx /bin/
+# Excel backends: openpyxl = pandas' xlsx read/write engine; fastexcel = polars'
+# read_excel engine (calamine); xlsxwriter = the write engine both use for
+# pd.ExcelWriter / pl.DataFrame.write_excel.
 RUN uv pip install --system --break-system-packages --no-cache \
         pandas numpy polars pyarrow matplotlib seaborn \
-        openpyxl python-docx python-pptx reportlab pypdf
+        openpyxl fastexcel xlsxwriter python-docx python-pptx reportlab pypdf

--- a/rootfs/Dockerfile.data
+++ b/rootfs/Dockerfile.data
@@ -1,0 +1,15 @@
+# Sandbox rootfs — flavor: data
+#
+# base + the data-analysis + office/pdf stack (via uv). Deliberately NO opencv /
+# scikit-image (the heavy CV libs). Pillow still arrives transitively via
+# matplotlib (seaborn's plotting engine) — so the split is "no OpenCV", not
+# "no Pillow". See docs/sandbox-flavours.md. Guardrails/hardening deferred (#116).
+
+FROM kg-sandbox:base AS data
+
+# uv (static binary) — installs into the system python so `python3` sees it in
+# any shell.
+COPY --from=ghcr.io/astral-sh/uv:0.11.29 /uv /uvx /bin/
+RUN uv pip install --system --break-system-packages --no-cache \
+        pandas numpy polars pyarrow matplotlib seaborn \
+        openpyxl python-docx python-pptx reportlab pypdf

--- a/rootfs/Dockerfile.image-processing
+++ b/rootfs/Dockerfile.image-processing
@@ -1,0 +1,23 @@
+# Sandbox rootfs — flavor: image-processing
+#
+# base + numpy / Pillow / OpenCV + imagemagick, for image manipulation. See
+# docs/sandbox-flavours.md. Guardrails/hardening deferred (#116). Build via
+# rootfs/build.sh (kg-sandbox:base must exist first).
+#
+# NOTE: the Python image stack is installed from Debian (apt), NOT pip/uv wheels.
+# The `opencv-python` wheel SIGILLs on import on arm64/colima (illegal
+# instruction — the same class of issue as the RediSearch arm64 crash this
+# project already hit). Debian's `python3-opencv` is compiled for a baseline
+# arm64 ISA and imports cleanly; `python3-numpy` / `python3-pil` come with it as
+# a version-matched, ABI-consistent set (so cv2 built against numpy 1.x isn't
+# paired with a mismatched numpy 2.x). `data` keeps uv — its wheels don't SIGILL.
+
+FROM kg-sandbox:base AS image-processing
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        python3-opencv \
+        python3-pil \
+        python3-numpy \
+        imagemagick \
+    && rm -rf /var/lib/apt/lists/*

--- a/rootfs/Dockerfile.office
+++ b/rootfs/Dockerfile.office
@@ -1,0 +1,14 @@
+# Sandbox rootfs — flavor: office
+#
+# base + the MS-Office editing stack (via uv): python-docx (Word), openpyxl +
+# xlsxwriter (Excel read/edit + write), PyMuPDF (PDF read/edit/create). Focused
+# on EDITING office documents as deliverables — distinct from the ingest-side
+# many→markdown doc-convert sidecar (see docs/sandbox-flavours.md → overlap
+# note). True format *conversion* (docx↔odt, →pdf via an office engine) stays
+# deferred to a LibreOffice service (#116). Build via rootfs/build.sh.
+
+FROM kg-sandbox:base AS office
+
+COPY --from=ghcr.io/astral-sh/uv:0.11.29 /uv /uvx /bin/
+RUN uv pip install --system --break-system-packages --no-cache \
+        python-docx openpyxl xlsxwriter pymupdf

--- a/rootfs/README.md
+++ b/rootfs/README.md
@@ -14,6 +14,15 @@ project root" the sandbox needs — there is no separate pool-manager daemon.
 | `/work` | Agent working directory | The filesystem MCP is scoped to this; shell `cwd` defaults here. |
 | `/opt/mcp/init.sh` | Entry/launcher | Idle-host entrypoint + `serve <name>` launch path for `docker exec`. |
 
+### PYTHONSAFEPATH
+
+The image sets `PYTHONSAFEPATH=1`: Python does **not** prepend the script dir /
+cwd to `sys.path`. Agents name their own scripts, and a `/work/inspect.py` (or
+`types.py`, `email.py`, …) would otherwise shadow the stdlib module of the same
+name and break unrelated imports (`import pandas` fails via numpy's
+`import inspect`). Cost: importing sibling modules from `/work` needs an
+explicit `PYTHONPATH=/work` — the agents' guidance says so.
+
 ## Architecture: MCP-in-VM (Docker model)
 
 The container is a **long-lived idle host**. It does *not* run the MCP servers

--- a/rootfs/README.md
+++ b/rootfs/README.md
@@ -39,6 +39,26 @@ The build is a two-stage Dockerfile:
 1. lift the `rust-mcp-filesystem` binary from its pinned image, then
 2. assemble `node:22-bookworm-slim` + python3 + the two MCP servers.
 
+### Flavours
+
+Beyond `base`, two purpose-split flavours extend it (design:
+[`docs/sandbox-flavours.md`](../docs/sandbox-flavours.md)):
+
+| Tag | Adds | Dockerfile |
+|-----|------|------------|
+| `kg-sandbox:image-processing` | numpy, Pillow, OpenCV via apt (`python3-opencv`; the pip wheel SIGILLs on arm64) + imagemagick | `Dockerfile.image-processing` |
+| `kg-sandbox:data` | a `uv` venv (pandas, numpy, polars, pyarrow, matplotlib, seaborn + openpyxl, python-docx, python-pptx, reportlab, pypdf) | `Dockerfile.data` |
+
+Build all three (base first — the flavours are `FROM kg-sandbox:base`):
+
+```sh
+bash rootfs/build.sh
+```
+
+Flavours are opt-in via `withSandbox({ rootfs: 'data' | 'image-processing' })`;
+`base` stays the default. Guardrails/hardening for these flavours are deferred —
+see [#116](https://github.com/mknw/harness-playground/issues/116).
+
 ### Inside the nix shell
 
 The repo's `flake.nix` shellHook sets `DOCKER_CONFIG=$PWD/.docker` so the
@@ -115,6 +135,8 @@ The harness applies a `sandbox_` prefix when registering these (see plan
 ## Not in v0
 
 - Publishing to a registry (built locally for dev; image-publish is an ops step).
-- Heavier flavors (Polars / PyPDF / spaCy / sentence-transformers) — the v1
-  rootfs catalog ([#78](https://github.com/mknw/harness-playground/issues/78)).
+- Heavier flavors beyond `image-processing` / `data` (spaCy / sentence-transformers,
+  an `office`/LibreOffice flavor) — see [`docs/sandbox-flavours.md`](../docs/sandbox-flavours.md)
+  + [#78](https://github.com/mknw/harness-playground/issues/78) /
+  [#116](https://github.com/mknw/harness-playground/issues/116).
 - A Rust shell-exec server (swaps in for `mcp-shell` only if cold-start is felt).

--- a/rootfs/README.md
+++ b/rootfs/README.md
@@ -47,7 +47,8 @@ Beyond `base`, two purpose-split flavours extend it (design:
 | Tag | Adds | Dockerfile |
 |-----|------|------------|
 | `kg-sandbox:image-processing` | numpy, Pillow, OpenCV via apt (`python3-opencv`; the pip wheel SIGILLs on arm64) + imagemagick | `Dockerfile.image-processing` |
-| `kg-sandbox:data` | a `uv` venv (pandas, numpy, polars, pyarrow, matplotlib, seaborn + openpyxl, python-docx, python-pptx, reportlab, pypdf) | `Dockerfile.data` |
+| `kg-sandbox:data` | via `uv`: pandas, numpy, polars, pyarrow, matplotlib, seaborn + excel backends (openpyxl, fastexcel, xlsxwriter) + python-docx, python-pptx, reportlab, pypdf | `Dockerfile.data` |
+| `kg-sandbox:office` | via `uv`: python-docx (Word), openpyxl + xlsxwriter (Excel), PyMuPDF (PDF) — document *editing* | `Dockerfile.office` |
 
 Build all three (base first — the flavours are `FROM kg-sandbox:base`):
 

--- a/rootfs/build.sh
+++ b/rootfs/build.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Build the sandbox rootfs images: base + the image-processing / data flavours.
+#
+# The flavours are `FROM kg-sandbox:base`, so base is built first. See
+# docs/sandbox-flavours.md. Runs from anywhere (cd's to its own dir for context).
+set -euo pipefail
+cd "$(dirname "$0")"
+
+echo "==> kg-sandbox:base"
+docker build -f Dockerfile -t kg-sandbox:base .
+
+echo "==> kg-sandbox:image-processing"
+docker build -f Dockerfile.image-processing -t kg-sandbox:image-processing .
+
+echo "==> kg-sandbox:data"
+docker build -f Dockerfile.data -t kg-sandbox:data .
+
+echo "==> built:"
+docker images --format '{{.Repository}}:{{.Tag}}\t{{.Size}}' | grep '^kg-sandbox:'

--- a/rootfs/build.sh
+++ b/rootfs/build.sh
@@ -15,5 +15,8 @@ docker build -f Dockerfile.image-processing -t kg-sandbox:image-processing .
 echo "==> kg-sandbox:data"
 docker build -f Dockerfile.data -t kg-sandbox:data .
 
+echo "==> kg-sandbox:office"
+docker build -f Dockerfile.office -t kg-sandbox:office .
+
 echo "==> built:"
 docker images --format '{{.Repository}}:{{.Tag}}\t{{.Size}}' | grep '^kg-sandbox:'

--- a/ui/src/__tests__/lib/harness-client/examples/agents.test.ts
+++ b/ui/src/__tests__/lib/harness-client/examples/agents.test.ts
@@ -263,6 +263,33 @@ describe('Agent Harnesses', () => {
     })
   })
 
+  describe('flavouredSandboxAgent', () => {
+    it('should have valid config', async () => {
+      const { flavouredSandboxAgent } = await import('../../../../lib/harness-client/examples/flavoured-sandbox.server')
+      validateAgentConfig(flavouredSandboxAgent)
+      expect(flavouredSandboxAgent.id).toBe('flavoured-sandbox')
+    })
+
+    it('should create patterns: router + routes(flavoured sandboxes) + synthesizer', async () => {
+      const { flavouredSandboxAgent } = await import('../../../../lib/harness-client/examples/flavoured-sandbox.server')
+      const patterns = await validatePatterns(flavouredSandboxAgent)
+
+      const names = patterns.map(p => p.name)
+      expect(patterns.length).toBe(3)
+      expect(names).toContain('router')
+      // The routes name embeds the route keys (basic|image_processing|data).
+      expect(names.some(n => n.includes('routes') && n.includes('image_processing'))).toBe(true)
+      expect(names[2]).toBe('synthesizer')
+    })
+
+    it('exposes the durable-workspace capability (persistent flavours use syncWorkspace)', async () => {
+      const { flavouredSandboxAgent } = await import('../../../../lib/harness-client/examples/flavoured-sandbox.server')
+      const { harnessUsesSyncWorkspace } = await import('../../../../lib/harness-patterns')
+      const patterns = await flavouredSandboxAgent.createPatterns('test-session')
+      expect(harnessUsesSyncWorkspace(patterns as Parameters<typeof harnessUsesSyncWorkspace>[0])).toBe(true)
+    })
+  })
+
   describe('conversationalMemoryAgent', () => {
     it('should have valid config', async () => {
       const { conversationalMemoryAgent } = await import('../../../../lib/harness-client/examples/conversational-memory.server')

--- a/ui/src/__tests__/lib/harness-client/examples/agents.test.ts
+++ b/ui/src/__tests__/lib/harness-client/examples/agents.test.ts
@@ -277,8 +277,8 @@ describe('Agent Harnesses', () => {
       const names = patterns.map(p => p.name)
       expect(patterns.length).toBe(3)
       expect(names).toContain('router')
-      // The routes name embeds the route keys (basic|image_processing|data).
-      expect(names.some(n => n.includes('routes') && n.includes('image_processing'))).toBe(true)
+      // The routes name embeds the route keys (basic|image_processing|data|office).
+      expect(names.some(n => n.includes('routes') && n.includes('image_processing') && n.includes('office'))).toBe(true)
       expect(names[2]).toBe('synthesizer')
     })
 

--- a/ui/src/lib/harness-client/examples/flavoured-sandbox.server.ts
+++ b/ui/src/lib/harness-client/examples/flavoured-sandbox.server.ts
@@ -12,7 +12,9 @@
  *   - image_processing → PERSISTENT `image-processing` box (Pillow, OpenCV,
  *                        imagemagick).
  *   - data             → PERSISTENT `data` box (pandas/numpy/polars/pyarrow,
- *                        matplotlib/seaborn, openpyxl/python-docx/… office+pdf).
+ *                        matplotlib/seaborn, excel backends, reportlab/pypdf).
+ *   - office           → PERSISTENT `office` box (python-docx, openpyxl +
+ *                        xlsxwriter, PyMuPDF) for editing docx/xlsx/pdf files.
  *
  * The two persistent routes use a **flavour-scoped attachment id**
  * (`${sessionId}:${rootfs}`) so they get separate containers, while `sessionId`
@@ -58,9 +60,18 @@ ${WORKSPACE_NOTE}
 
 const DATA_GUIDANCE = `
 You have a PERSISTENT data sandbox. Available via sandbox_bash: Python 3 with
-pandas, numpy, polars, pyarrow, matplotlib and seaborn (plots), plus openpyxl /
-python-docx / python-pptx / reportlab / pypdf for office & PDF files. Save
-plots/spreadsheets/reports to /work/out.
+pandas, numpy, polars, pyarrow, matplotlib and seaborn (plots). Excel is fully
+supported: read xlsx with pandas (openpyxl) or polars (fastexcel/calamine),
+write with xlsxwriter/openpyxl. Also python-docx / python-pptx / reportlab /
+pypdf. Save plots/spreadsheets/reports to /work/out.
+${WORKSPACE_NOTE}
+`.trim();
+
+const OFFICE_GUIDANCE = `
+You have a PERSISTENT office sandbox for EDITING documents. Available via
+sandbox_bash: Python 3 with python-docx (Word), openpyxl + xlsxwriter (Excel),
+and PyMuPDF (\`import pymupdf\` or \`import fitz\`) for reading, editing and
+creating PDFs. Edit files from /work/in and save results to /work/out.
 ${WORKSPACE_NOTE}
 `.trim();
 
@@ -103,12 +114,22 @@ async function createPatterns(sessionId: string): Promise<ConfiguredPattern<Sess
     syncWorkspace: true,
   })(sandboxLoop("flavour-data-loop", DATA_GUIDANCE));
 
+  const office = withSandbox({
+    id: `${sessionId}:office`,
+    sessionId,
+    rootfs: "office",
+    egress: "mcp-only",
+    syncWorkspace: true,
+  })(sandboxLoop("flavour-office-loop", OFFICE_GUIDANCE));
+
   const routerPattern = router<SessionData>(
     {
       basic: "Quick one-off shell / general Linux work in a throwaway box",
       image_processing:
         "Image manipulation — Pillow, OpenCV (cv2), imagemagick (resize, convert, analyze images)",
-      data: "Data analysis & office docs — pandas/numpy/polars, matplotlib/seaborn plots, xlsx/docx/pptx/pdf",
+      data: "Data ANALYSIS — pandas/numpy/polars over datasets (incl. xlsx/csv), matplotlib/seaborn plots, reports",
+      office:
+        "Document EDITING — modify/create Word (docx), Excel (xlsx) or PDF files themselves (not analyze their data)",
     },
     { liveEvents: true },
   );
@@ -118,6 +139,7 @@ async function createPatterns(sessionId: string): Promise<ConfiguredPattern<Sess
       basic,
       image_processing: image,
       data,
+      office,
     },
     { liveEvents: true },
   );

--- a/ui/src/lib/harness-client/examples/flavoured-sandbox.server.ts
+++ b/ui/src/lib/harness-client/examples/flavoured-sandbox.server.ts
@@ -40,10 +40,15 @@ import {
 import { withSandbox } from "../../sandbox/with-sandbox.server";
 import type { SessionData } from "../session.server";
 import type { AgentConfig } from "../registry.server";
+import type { FewShot } from "../../../../baml_client/types";
 
 const WORKSPACE_NOTE = `
 Files under /work/in are restored inputs; write deliverables the user should keep
 to /work/out (saved to the Data Stash and restored next time). /work is scratch.
+Python notes: for multi-line Python, WRITE a .py file (sandbox_write) and run it,
+or use a quoted heredoc (python3 - <<'PY' ... PY) — never nest escaped quotes in
+python3 -c. Python runs with PYTHONSAFEPATH=1 (cwd is not on sys.path); to import
+your own helper modules from /work, run with PYTHONPATH=/work.
 `.trim();
 
 const BASIC_GUIDANCE = `
@@ -75,10 +80,40 @@ creating PDFs. Edit files from /work/in and save results to /work/out.
 ${WORKSPACE_NOTE}
 `.trim();
 
+/**
+ * Few-shot examples for the actor's `tool_args` formatting (#85 — mirrors
+ * `sandbox-session`'s shots, which this agent originally lacked). Observed
+ * live (.harness-logs/regression.json): Sonnet 5 emitted multiline
+ * `python3 -c \"` commands whose over-escaped quotes bash mangles into
+ * "unterminated string literal". The heredoc shot anchors the quote-free way
+ * to run multi-line Python inline; the write shot anchors write-then-run.
+ */
+const FLAVOURED_SANDBOX_FEW_SHOTS: FewShot[] = [
+  {
+    user: "Write a hello-world Python script to /work/hi.py and run it.",
+    reasoning:
+      "Write the file first. Keys and string values are double-quoted; the newline inside the script is the escape sequence \\n, not a raw line break.",
+    tool: "sandbox_write",
+    args: JSON.stringify({ path: "/work/hi.py", content: 'print("hello")\n' }),
+  },
+  {
+    user: "How many rows does /work/in/data.csv have?",
+    reasoning:
+      "Multi-line Python inline: use a quoted heredoc so no quotes need escaping inside the command. Never wrap a multi-line script in python3 -c \\\"...\\\".",
+    tool: "sandbox_bash",
+    args: JSON.stringify({
+      command: "python3 - <<'PY'\nimport csv\nwith open('/work/in/data.csv') as f:\n    print(sum(1 for _ in f) - 1)\nPY",
+    }),
+  },
+];
+
 /** A sandbox tool-loop; the actor sees the in-VM `sandbox_*` tools via the ALS
  *  scope `withSandbox` sets up, so `availableTools` is left empty. */
 function sandboxLoop(patternId: string, guidance: string) {
-  const actor = createActorControllerAdapter({ contextPrefix: guidance });
+  const actor = createActorControllerAdapter({
+    contextPrefix: guidance,
+    fewShots: FLAVOURED_SANDBOX_FEW_SHOTS,
+  });
   const critic = createCriticAdapter();
   return actorCritic<SessionData>(actor, critic, [], {
     patternId,

--- a/ui/src/lib/harness-client/examples/flavoured-sandbox.server.ts
+++ b/ui/src/lib/harness-client/examples/flavoured-sandbox.server.ts
@@ -1,0 +1,142 @@
+/**
+ * Flavoured Sandbox Agent (router over sandbox flavours)
+ *
+ * Demonstrates the composable recipe from docs/sandbox-flavours.md: a `router`
+ * that dispatches each turn to a differently-*flavoured* `withSandbox` route.
+ * Flavour selection lives entirely in the harness — the routed controller is
+ * flavour-agnostic.
+ *
+ * Routes:
+ *   - basic            → EPHEMERAL `base` box (anonymous pool: a reset,
+ *                        fresh-state VM each turn). Quick shell / general work.
+ *   - image_processing → PERSISTENT `image-processing` box (Pillow, OpenCV,
+ *                        imagemagick).
+ *   - data             → PERSISTENT `data` box (pandas/numpy/polars/pyarrow,
+ *                        matplotlib/seaborn, openpyxl/python-docx/… office+pdf).
+ *
+ * The two persistent routes use a **flavour-scoped attachment id**
+ * (`${sessionId}:${rootfs}`) so they get separate containers, while `sessionId`
+ * (the Data Stash key) is shared — so /work hydrate/promote is common across
+ * flavours, only in-VM scratch differs. This shows multiple persistent flavours
+ * in one session working today, without the deferred flavour-in-identity change.
+ *
+ * NOTE: the interactive Shell terminal attaches to the base `sessionId`
+ * container (PtyManager keys on sessionId, rootfs 'base'), NOT these flavoured
+ * ones — flavour-aware Shell is deferred (#116). See docs/sandbox-flavours.md.
+ */
+"use server";
+
+import {
+  router,
+  routes,
+  synthesizer,
+  actorCritic,
+  createActorControllerAdapter,
+  createCriticAdapter,
+  type ConfiguredPattern,
+} from "../../harness-patterns";
+import { withSandbox } from "../../sandbox/with-sandbox.server";
+import type { SessionData } from "../session.server";
+import type { AgentConfig } from "../registry.server";
+
+const WORKSPACE_NOTE = `
+Files under /work/in are restored inputs; write deliverables the user should keep
+to /work/out (saved to the Data Stash and restored next time). /work is scratch.
+`.trim();
+
+const BASIC_GUIDANCE = `
+You have an EPHEMERAL Linux sandbox — a fresh box each turn, no state persists.
+Use sandbox_bash / sandbox_write / sandbox_read for quick shell work and small
+scripts (Python 3 is available). Don't rely on files from previous turns.
+`.trim();
+
+const IMAGE_GUIDANCE = `
+You have a PERSISTENT image-processing sandbox. Available via sandbox_bash:
+Python 3 with numpy, Pillow (PIL) and OpenCV (cv2), plus imagemagick (\`convert\`).
+${WORKSPACE_NOTE}
+`.trim();
+
+const DATA_GUIDANCE = `
+You have a PERSISTENT data sandbox. Available via sandbox_bash: Python 3 with
+pandas, numpy, polars, pyarrow, matplotlib and seaborn (plots), plus openpyxl /
+python-docx / python-pptx / reportlab / pypdf for office & PDF files. Save
+plots/spreadsheets/reports to /work/out.
+${WORKSPACE_NOTE}
+`.trim();
+
+/** A sandbox tool-loop; the actor sees the in-VM `sandbox_*` tools via the ALS
+ *  scope `withSandbox` sets up, so `availableTools` is left empty. */
+function sandboxLoop(patternId: string, guidance: string) {
+  const actor = createActorControllerAdapter({ contextPrefix: guidance });
+  const critic = createCriticAdapter();
+  return actorCritic<SessionData>(actor, critic, [], {
+    patternId,
+    availableTools: [],
+    liveEvents: true,
+    maxRetries: 6,
+  });
+}
+
+async function createPatterns(sessionId: string): Promise<ConfiguredPattern<SessionData>[]> {
+  // Ephemeral: no id (anonymous pool) → a reset (fresh-state) VM each turn.
+  const basic = withSandbox({
+    rootfs: "base",
+    egress: "mcp-only",
+    sessionId,
+  })(sandboxLoop("flavour-basic-loop", BASIC_GUIDANCE));
+
+  // Persistent + flavour-scoped id → its own container, distinct from `data`.
+  // sessionId stays the conversation id, so /work is shared across flavours.
+  const image = withSandbox({
+    id: `${sessionId}:image-processing`,
+    sessionId,
+    rootfs: "image-processing",
+    egress: "mcp-only",
+    syncWorkspace: true,
+  })(sandboxLoop("flavour-image-loop", IMAGE_GUIDANCE));
+
+  const data = withSandbox({
+    id: `${sessionId}:data`,
+    sessionId,
+    rootfs: "data",
+    egress: "mcp-only",
+    syncWorkspace: true,
+  })(sandboxLoop("flavour-data-loop", DATA_GUIDANCE));
+
+  const routerPattern = router<SessionData>(
+    {
+      basic: "Quick one-off shell / general Linux work in a throwaway box",
+      image_processing:
+        "Image manipulation — Pillow, OpenCV (cv2), imagemagick (resize, convert, analyze images)",
+      data: "Data analysis & office docs — pandas/numpy/polars, matplotlib/seaborn plots, xlsx/docx/pptx/pdf",
+    },
+    { liveEvents: true },
+  );
+
+  const routesPattern = routes<SessionData>(
+    {
+      basic,
+      image_processing: image,
+      data,
+    },
+    { liveEvents: true },
+  );
+
+  const synth = synthesizer<SessionData>({
+    mode: "thread",
+    patternId: "flavoured-sandbox-synth",
+    liveEvents: true,
+  });
+
+  return [routerPattern, routesPattern, synth];
+}
+
+export const flavouredSandboxAgent: AgentConfig = {
+  id: "flavoured-sandbox",
+  name: "Sandbox · Flavoured (router)",
+  description:
+    "Routes each turn to a purpose-built sandbox flavour — base (ephemeral), image-processing, or data.",
+  icon: "🧪",
+  servers: [],
+  createPatterns,
+};

--- a/ui/src/lib/harness-client/registry.server.ts
+++ b/ui/src/lib/harness-client/registry.server.ts
@@ -199,6 +199,7 @@ import { multiSourceResearchAgent } from "./examples/multi-source-research.serve
 import { kgBuilderAgent } from "./examples/kg-builder.server";
 import { conversationalMemoryAgent } from "./examples/conversational-memory.server";
 import { sandboxSessionAgent } from "./examples/sandbox-session.server";
+import { flavouredSandboxAgent } from "./examples/flavoured-sandbox.server";
 import { retrieverAgent } from "./examples/retriever-agent.server";
 
 // Register all agents
@@ -208,4 +209,5 @@ registerAgent(multiSourceResearchAgent);
 registerAgent(kgBuilderAgent);
 registerAgent(conversationalMemoryAgent);
 registerAgent(sandboxSessionAgent);
+registerAgent(flavouredSandboxAgent);
 registerAgent(retrieverAgent);

--- a/ui/src/lib/sandbox/types.ts
+++ b/ui/src/lib/sandbox/types.ts
@@ -16,10 +16,10 @@ import type { ToolCallResult, MCPToolDescription } from '../harness-patterns/typ
 // Identity & config
 // ============================================================================
 
-/** Rootfs flavor. `base` is the default; `image-processing` / `data` are the
- *  first flavour-catalog images (#78, docs/sandbox-flavours.md). The open
- *  `(string & {})` keeps arbitrary future flavours valid. */
-export type RootfsId = 'base' | 'image-processing' | 'data' | (string & {})
+/** Rootfs flavor. `base` is the default; `image-processing` / `data` / `office`
+ *  are the first flavour-catalog images (#78, docs/sandbox-flavours.md). The
+ *  open `(string & {})` keeps arbitrary future flavours valid. */
+export type RootfsId = 'base' | 'image-processing' | 'data' | 'office' | (string & {})
 
 /** Per-VM runtime knobs. Defaults come from HarnessSettings at call time. */
 export interface RuntimeConfig {

--- a/ui/src/lib/sandbox/types.ts
+++ b/ui/src/lib/sandbox/types.ts
@@ -16,8 +16,10 @@ import type { ToolCallResult, MCPToolDescription } from '../harness-patterns/typ
 // Identity & config
 // ============================================================================
 
-/** Rootfs flavor. v0 ships only `'base'`; flavor catalog is v1 (#78). */
-export type RootfsId = 'base' | (string & {})
+/** Rootfs flavor. `base` is the default; `image-processing` / `data` are the
+ *  first flavour-catalog images (#78, docs/sandbox-flavours.md). The open
+ *  `(string & {})` keeps arbitrary future flavours valid. */
+export type RootfsId = 'base' | 'image-processing' | 'data' | (string & {})
 
 /** Per-VM runtime knobs. Defaults come from HarnessSettings at call time. */
 export interface RuntimeConfig {

--- a/ui/src/lib/settings.ts
+++ b/ui/src/lib/settings.ts
@@ -51,7 +51,7 @@ export const DEFAULT_SETTINGS: HarnessSettings = {
   sandbox: {
     globalCap: 16,
     perSessionCap: 4,
-    warmPool: { base: 1 },
+    warmPool: { base: 1, 'image-processing': 1, data: 1 },
     // Hot-cache window only: a parked VM is reused instantly within this window.
     // Durable workspace state lives in the document store (hydrated into /work on
     // first boot, promoted from /work/out on exit), so this need not be long — 1h.

--- a/ui/src/lib/settings.ts
+++ b/ui/src/lib/settings.ts
@@ -51,7 +51,7 @@ export const DEFAULT_SETTINGS: HarnessSettings = {
   sandbox: {
     globalCap: 16,
     perSessionCap: 4,
-    warmPool: { base: 1, 'image-processing': 1, data: 1 },
+    warmPool: { base: 1, 'image-processing': 1, data: 1, office: 1 },
     // Hot-cache window only: a parked VM is reused instantly within this window.
     // Durable workspace state lives in the document store (hydrated into /work on
     // first boot, promoted from /work/out on exit), so this need not be long — 1h.


### PR DESCRIPTION
## What

Adds three purpose-built sandbox rootfs **flavours** on top of `base`, opt-in via
`withSandbox({ rootfs })`, plus a router demonstrator agent that dispatches each
turn to the right flavour. `base` stays the default — existing agents are unchanged.

| Flavour | Adds | Use |
|---|---|---|
| `image-processing` | numpy, Pillow, OpenCV (`python3-opencv` via apt — the pip wheel SIGILLs on arm64) + imagemagick | image manipulation |
| `data` | pandas/numpy/polars/pyarrow, matplotlib/seaborn, excel backends (openpyxl/fastexcel/xlsxwriter), python-docx/pptx, reportlab, pypdf | data analysis & reports |
| `office` | python-docx, openpyxl + xlsxwriter, PyMuPDF | editing docx/xlsx/pdf |

The two persistent flavours use a **flavour-scoped attachment id**
(`${sessionId}:${rootfs}`) so they get distinct containers while sharing `/work`
via the Data Stash — proving multiple persistent flavours per session work today,
without the deferred flavour-in-identity change.

## Notable

- **`PYTHONSAFEPATH=1`** in the base image. Agents name their own scripts, and a
  `/work/inspect.py` (or `types.py`, `email.py`, …) would otherwise shadow the
  stdlib module of that name and break unrelated imports (`import pandas` died via
  numpy's `import inspect`). Importing your own sibling modules now needs an
  explicit `PYTHONPATH=/work` — covered in agent guidance.
- **Actor few-shots** for the flavoured agent (write-then-run + quoted heredoc):
  Sonnet 5 was emitting over-escaped multi-line `python3 -c "..."` commands that
  bash mangled into "unterminated string literal". The heredoc shot anchors the
  quote-free way to run multi-line Python inline.

## Build

`bash rootfs/build.sh` builds `base` + all three flavours (each `FROM kg-sandbox:base`).

## Scope

Implements the flavour catalog from #78. Guardrails, per-flavour tool surface,
kernel/egress hardening, flavour-in-identity and flavour-aware Shell are deferred
to #116.

## Test

Full suite green (918 passed / 1 skipped); `tsc` at the pre-existing baseline.
Verified live in fresh `kg-sandbox:data` / `kg-sandbox:office` containers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TcfhRkKX6eijTywPSURFYS
