### PR TITLE
fix(llm): Sonnet 5 controller chain, larger output caps & truncation-aware retry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,11 +121,13 @@ view.fromPatterns(['neo4j-query']).serialize()        // → XML for LLM
 
 | Client | Role | Chain |
 |--------|------|-------|
-| `RouterAnthropic` | Intent classification | AnthropicHaiku45 → AnthropicSonnet46 |
-| `ControllerAnthropic` | Tool loop controllers (simpleLoop + actor) | AnthropicSonnet46 → AnthropicHaiku45 |
-| `CriticAnthropic` | Evaluation/critique | AnthropicHaiku45 → AnthropicSonnet46 |
-| `SynthesizerAnthropic` | Response synthesis | AnthropicSonnet46 → AnthropicHaiku45 |
+| `RouterAnthropic` | Intent classification | AnthropicHaiku45 → AnthropicSonnet5 |
+| `ControllerAnthropic` | Tool loop controllers (simpleLoop + actor) | AnthropicSonnet5 → AnthropicSonnet46 (backstop stays Sonnet-tier — no Haiku fallback on structured output) |
+| `CriticAnthropic` | Evaluation/critique | AnthropicHaiku45 → AnthropicSonnet5 |
+| `SynthesizerAnthropic` | Response synthesis | AnthropicSonnet5 → AnthropicHaiku45 |
 | `DescribeAnthropic` | Lightweight tool result summarization, titles, intent compaction (`compactIntent`) | AnthropicHaiku45 |
+
+**Output caps + truncation recovery:** Anthropic client `max_tokens` are 32768 (Sonnet 5) / 16384 (Sonnet 4.6, Haiku 4.5) — mirrored in `CLIENT_MAX_OUTPUT_TOKENS` (`ui/src/lib/settings.ts`); keep the two in sync. A controller response that hits its cap truncates mid-JSON (historically: `BamlValidationError: missing status/is_final` when a sandbox actor inlined a huge script into `tool_args`). The adapters detect cap-hits and do ONE corrective retry with truncation guidance appended to the per-call `context`; the loops emit truncation-specific feedback instead of generic "invalid JSON" when `tool_args` were cut off (`llmCallHitOutputCap`).
 
 **Mixed-provider chains** (gated by `USE_MIXED_CHAINS=1`, see top of file) — declared in `baml_src/clients.baml`:
 

--- a/ui/baml_src/anthropic-only.baml
+++ b/ui/baml_src/anthropic-only.baml
@@ -11,16 +11,18 @@
 client<llm> RouterAnthropic {
   provider fallback
   options {
-    strategy [AnthropicHaiku45, AnthropicSonnet46]
+    strategy [AnthropicHaiku45, AnthropicSonnet5]
   }
 }
 
 client<llm> ControllerAnthropic {
   provider fallback
   options {
-    // Sonnet 4.6 leads — best structured-output adherence for tool selection.
-    // Haiku 4.5 as cheap backstop if Sonnet rate-limits.
-    strategy [AnthropicSonnet46, AnthropicHaiku45]
+    // Sonnet 5 leads — near-Opus structured-output/agentic quality at Sonnet
+    // cost. Backstop is Sonnet 4.6, NOT Haiku: a rate-limit fallback on the
+    // controller must stay Sonnet-tier (Haiku's weaker structured output was
+    // implicated in tool-loop parse failures).
+    strategy [AnthropicSonnet5, AnthropicSonnet46]
   }
 }
 
@@ -28,15 +30,15 @@ client<llm> CriticAnthropic {
   provider fallback
   options {
     // Haiku 4.5 leads — critic is short evaluative judgment, doesn't need
-    // Sonnet-tier reasoning. Sonnet as backstop.
-    strategy [AnthropicHaiku45, AnthropicSonnet46]
+    // Sonnet-tier reasoning. Sonnet 5 as backstop.
+    strategy [AnthropicHaiku45, AnthropicSonnet5]
   }
 }
 
 client<llm> SynthesizerAnthropic {
   provider fallback
   options {
-    strategy [AnthropicSonnet46, AnthropicHaiku45]
+    strategy [AnthropicSonnet5, AnthropicHaiku45]
   }
 }
 

--- a/ui/baml_src/clients.baml
+++ b/ui/baml_src/clients.baml
@@ -131,12 +131,27 @@ client<llm> AnthropicOpus4 {
   }
 }
 
+// Sonnet 5: adaptive thinking is ON by default (thinking spend counts against
+// max_tokens), and the new tokenizer runs ~30% more tokens for the same text —
+// so the output cap is deliberately generous. 4096 was proven inadequate for
+// sandbox actors (a report-generation script truncated mid-tool_args →
+// BamlValidationError; see baml-adapters truncation handling). Keep these caps
+// in sync with CLIENT_MAX_OUTPUT_TOKENS in ui/src/lib/settings.ts.
+client<llm> AnthropicSonnet5 {
+  provider anthropic
+  options {
+    model "claude-sonnet-5"
+    api_key env.ANTHROPIC_API_KEY
+    max_tokens 32768
+  }
+}
+
 client<llm> AnthropicSonnet46 {
   provider anthropic
   options {
     model "claude-sonnet-4-6"
     api_key env.ANTHROPIC_API_KEY
-    max_tokens 4096
+    max_tokens 16384
   }
 }
 
@@ -146,7 +161,7 @@ client<llm> AnthropicHaiku45 {
   options {
     model "claude-haiku-4-5"
     api_key env.ANTHROPIC_API_KEY
-    max_tokens 4096
+    max_tokens 16384
   }
 }
 

--- a/ui/src/__tests__/lib/harness-patterns/truncation-retry.test.ts
+++ b/ui/src/__tests__/lib/harness-patterns/truncation-retry.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Output-cap truncation handling in the BAML adapters.
+ *
+ * A controller response that hits its client's `max_tokens` truncates mid-JSON
+ * (observed live: a sandbox actor inlined a full report-generation script into
+ * `tool_args`, was cut at exactly the cap, and lost the trailing required
+ * fields → BamlValidationError). The adapters detect the cap-hit via the
+ * collector's usage + clientName against CLIENT_MAX_OUTPUT_TOKENS and do ONE
+ * corrective retry with truncation guidance appended to the per-call `context`.
+ *
+ * Hermetic: baml_client + MCP are mocked; the "collector" is a plain object
+ * shaped like Collector.last (the adapters only read `.last`).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mockFinalAction } from '../../mocks/baml'
+import { mockListTools } from '../../mocks/mcp'
+import type { Collector } from '@boundaryml/baml'
+
+vi.mock('../../../lib/harness-patterns/assert.server', () => ({
+  assertServerOnImport: vi.fn(),
+}))
+
+vi.mock('../../../lib/harness-patterns/mcp-client.server', () => ({
+  listTools: mockListTools(['read_neo4j_cypher', 'sandbox_bash', 'Return']),
+}))
+
+const mockLoopController = vi.fn()
+const mockActorController = vi.fn()
+
+vi.mock('../../../../baml_client', () => ({
+  b: {
+    LoopController: mockLoopController,
+    ActorController: mockActorController,
+  },
+}))
+
+/** Fake collector whose last call reports the given output tokens + client. */
+function fakeCollector(outputTokens: number, clientName: string): Collector {
+  return {
+    last: {
+      usage: { inputTokens: 1000, outputTokens, cachedInputTokens: 0 },
+      calls: [{ selected: true, provider: 'anthropic', clientName }],
+      rawLlmResponse: '{"reasoning": "truncated mid-way',
+    },
+  } as unknown as Collector
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  // Anthropic-only default routing (no client override) — the truncation retry
+  // must work exactly where the old Groq-only escalation did not.
+  delete process.env.USE_MIXED_CHAINS
+})
+
+describe('llmCallHitOutputCap', () => {
+  it('detects a call that hit its configured cap', async () => {
+    const { llmCallHitOutputCap } = await import('../../../lib/harness-patterns/baml-adapters.server')
+    expect(
+      llmCallHitOutputCap({
+        clientName: 'AnthropicSonnet5',
+        usage: { inputTokens: 1, outputTokens: 32_768, cachedInputTokens: 0, totalTokens: 32_769 },
+      }),
+    ).toBe(true)
+  })
+
+  it('is false below the cap, for unknown clients, and without usage', async () => {
+    const { llmCallHitOutputCap } = await import('../../../lib/harness-patterns/baml-adapters.server')
+    expect(
+      llmCallHitOutputCap({
+        clientName: 'AnthropicSonnet5',
+        usage: { inputTokens: 1, outputTokens: 512, cachedInputTokens: 0, totalTokens: 513 },
+      }),
+    ).toBe(false)
+    expect(
+      llmCallHitOutputCap({
+        clientName: 'SomeUnknownClient',
+        usage: { inputTokens: 1, outputTokens: 999_999, cachedInputTokens: 0, totalTokens: 1_000_000 },
+      }),
+    ).toBe(false)
+    expect(llmCallHitOutputCap({ clientName: 'AnthropicSonnet5' })).toBe(false)
+    expect(llmCallHitOutputCap(undefined)).toBe(false)
+  })
+})
+
+describe('ActorController truncation retry (Anthropic-only path)', () => {
+  it('retries ONCE with truncation guidance appended to context when the output hit the cap', async () => {
+    const { createActorControllerAdapter, TRUNCATION_RETRY_GUIDANCE } = await import(
+      '../../../lib/harness-patterns/baml-adapters.server'
+    )
+    const { BamlValidationError } = await import('@boundaryml/baml')
+
+    mockActorController
+      .mockRejectedValueOnce(new BamlValidationError('prompt', 'raw', 'missing status/is_final', 'missing status/is_final'))
+      .mockResolvedValueOnce(mockFinalAction('Recovered'))
+
+    const actor = createActorControllerAdapter({
+      toolNames: ['sandbox_bash'],
+      contextPrefix: 'You have a sandbox.',
+    })
+    const result = await actor('do the thing', 'intent', [], [], fakeCollector(32_768, 'AnthropicSonnet5'), 1, 6)
+
+    expect(result.action).toBeDefined()
+    expect(mockActorController).toHaveBeenCalledTimes(2)
+    // context is the 5th positional arg — the retry must carry the guidance.
+    const retryContext = mockActorController.mock.calls[1][4] as string
+    expect(retryContext).toContain('You have a sandbox.')
+    expect(retryContext).toContain(TRUNCATION_RETRY_GUIDANCE)
+    // First call must NOT have the guidance (it's retry-only, per-call scoped).
+    expect(String(mockActorController.mock.calls[0][4])).not.toContain('CUT OFF')
+  })
+
+  it('does NOT retry when the parse failure was not a cap-hit (rethrows as LLMCallError)', async () => {
+    const { createActorControllerAdapter } = await import('../../../lib/harness-patterns/baml-adapters.server')
+    const { BamlValidationError } = await import('@boundaryml/baml')
+
+    mockActorController.mockRejectedValueOnce(new BamlValidationError('prompt', 'raw', 'bad output', 'bad output'))
+
+    const { LLMCallError } = await import('../../../lib/harness-patterns/baml-adapters.server')
+    const actor = createActorControllerAdapter({ toolNames: ['sandbox_bash'] })
+    await expect(
+      actor('do the thing', 'intent', [], [], fakeCollector(512, 'AnthropicSonnet5'), 1, 6),
+    ).rejects.toBeInstanceOf(LLMCallError)
+    expect(mockActorController).toHaveBeenCalledTimes(1)
+  })
+
+  it('throws LLMCallError when the truncation retry also fails (exactly one retry)', async () => {
+    const { createActorControllerAdapter } = await import('../../../lib/harness-patterns/baml-adapters.server')
+    const { BamlValidationError } = await import('@boundaryml/baml')
+
+    mockActorController
+      .mockRejectedValueOnce(new BamlValidationError('prompt', 'raw', 'truncated', 'truncated'))
+      .mockRejectedValueOnce(new BamlValidationError('prompt', 'raw', 'truncated again', 'truncated again'))
+
+    const { LLMCallError } = await import('../../../lib/harness-patterns/baml-adapters.server')
+    const actor = createActorControllerAdapter({ toolNames: ['sandbox_bash'] })
+    await expect(
+      actor('do the thing', 'intent', [], [], fakeCollector(16_384, 'AnthropicHaiku45'), 1, 6),
+    ).rejects.toBeInstanceOf(LLMCallError)
+    expect(mockActorController).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('LoopController truncation retry (Anthropic-only path)', () => {
+  it('retries ONCE with truncation guidance appended to context', async () => {
+    const { createLoopControllerAdapter, TRUNCATION_RETRY_GUIDANCE } = await import(
+      '../../../lib/harness-patterns/baml-adapters.server'
+    )
+    const { BamlValidationError } = await import('@boundaryml/baml')
+
+    mockLoopController
+      .mockRejectedValueOnce(new BamlValidationError('prompt', 'raw', 'missing fields', 'missing fields'))
+      .mockResolvedValueOnce(mockFinalAction('Recovered'))
+
+    const controller = createLoopControllerAdapter(['read_neo4j_cypher', 'Return'], 'Prefix.')
+    const result = await controller(
+      'user message', 'intent', '[]', 0, undefined,
+      fakeCollector(16_384, 'AnthropicSonnet46'),
+    )
+
+    expect(result.action).toBeDefined()
+    expect(mockLoopController).toHaveBeenCalledTimes(2)
+    const retryContext = mockLoopController.mock.calls[1][4] as string
+    expect(retryContext).toContain('Prefix.')
+    expect(retryContext).toContain(TRUNCATION_RETRY_GUIDANCE)
+  })
+
+  it('without a cap-hit, the Anthropic-only path still rethrows (no Groq escalation, no retry)', async () => {
+    const { createLoopControllerAdapter } = await import('../../../lib/harness-patterns/baml-adapters.server')
+    const { BamlValidationError } = await import('@boundaryml/baml')
+
+    mockLoopController.mockRejectedValueOnce(new BamlValidationError('prompt', 'raw', 'bad output', 'bad output'))
+
+    const { LLMCallError } = await import('../../../lib/harness-patterns/baml-adapters.server')
+    const controller = createLoopControllerAdapter(['Return'])
+    await expect(
+      controller('user message', 'intent', '[]', 0, undefined, fakeCollector(512, 'AnthropicSonnet46')),
+    ).rejects.toBeInstanceOf(LLMCallError)
+    expect(mockLoopController).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('mixed-chains interaction', () => {
+  it('truncation retry takes precedence over Groq escalation when the cap was hit', async () => {
+    process.env.USE_MIXED_CHAINS = '1'
+    try {
+      const { createLoopControllerAdapter, TRUNCATION_RETRY_GUIDANCE } = await import(
+        '../../../lib/harness-patterns/baml-adapters.server'
+      )
+      const { BamlValidationError } = await import('@boundaryml/baml')
+
+      mockLoopController
+        .mockRejectedValueOnce(new BamlValidationError('prompt', 'raw', 'truncated', 'truncated'))
+        .mockResolvedValueOnce(mockFinalAction('Recovered'))
+
+      const controller = createLoopControllerAdapter(['Return'])
+      const result = await controller(
+        'user message', 'intent', '[]', 0, undefined,
+        fakeCollector(16_384, 'AnthropicSonnet46'),
+      )
+
+      expect(result.action).toBeDefined()
+      expect(mockLoopController).toHaveBeenCalledTimes(2)
+      // The retry keeps the SAME chain with corrective context — it must not
+      // hop to the Groq client (that path is for structured-output failures,
+      // not transport truncation).
+      const retryOpts = mockLoopController.mock.calls[1][7] as Record<string, unknown> | undefined
+      expect(retryOpts && (retryOpts as { client?: string }).client).not.toBe('GroqGPT120B')
+      expect(String(mockLoopController.mock.calls[1][4])).toContain(TRUNCATION_RETRY_GUIDANCE)
+    } finally {
+      delete process.env.USE_MIXED_CHAINS
+    }
+  })
+})

--- a/ui/src/lib/harness-client/examples/sandbox-session.server.ts
+++ b/ui/src/lib/harness-client/examples/sandbox-session.server.ts
@@ -51,7 +51,9 @@ Guidance:
 3. When a task produces a FILE the user should keep, write it to /work/out
    (don't just compute the answer with a throwaway python3 -c). That file is the
    deliverable and is what persists to the Data Stash.
-4. Let the critic decide completion — you don't need a Return tool. Focus on
+4. To continue a partial or large file, APPEND to it (bash \`cat >> file <<'EOF'\`)
+   — don't regenerate the whole file from scratch.
+5. Let the critic decide completion — you don't need a Return tool. Focus on
    producing the right tool call; the critic ends the loop when the result is
    sufficient.
 `.trim();

--- a/ui/src/lib/harness-patterns/baml-adapters.server.ts
+++ b/ui/src/lib/harness-patterns/baml-adapters.server.ts
@@ -25,6 +25,7 @@ import { getActiveSandbox } from '../sandbox/scope.server'
 import { Collector, BamlValidationError } from '@boundaryml/baml'
 import { getBamlFiles } from '../../../baml_client/inlinedbaml'
 import { clientOverrideFor } from './clients.server'
+import { CLIENT_MAX_OUTPUT_TOKENS } from '../settings'
 
 assertServerOnImport()
 
@@ -161,6 +162,53 @@ export function extractFailureLLMCallData(
     durationMs: Date.now() - startTime
   }
 }
+
+// ============================================================================
+// Output-cap truncation detection (#see .harness-logs/baml-validation-sandbox.json)
+// ============================================================================
+
+/**
+ * Whether an LLM call's output was cut off at its client's `max_tokens` cap.
+ * Anthropic reports `outputTokens` == the cap exactly on a max_tokens stop, so
+ * `>= cap` is a precise signal, not a heuristic. Unknown clients (no entry in
+ * CLIENT_MAX_OUTPUT_TOKENS) → false, never a false positive.
+ *
+ * Why it matters: a truncated ControllerAction either loses its trailing
+ * required fields (`status`, `is_final`) → hard BamlValidationError, or ends
+ * mid-`tool_args` → invalid-JSON rejection in the loop. Both used to feed the
+ * model generic feedback, so it would regenerate the same oversized response
+ * until retries exhausted. Detection lets the retry say WHY it failed.
+ */
+export function llmCallHitOutputCap(
+  llmCall: Pick<LLMCallData, 'clientName' | 'usage'> | undefined,
+): boolean {
+  if (!llmCall?.clientName || !llmCall.usage?.outputTokens) return false
+  const cap = CLIENT_MAX_OUTPUT_TOKENS[llmCall.clientName]
+  return cap !== undefined && llmCall.usage.outputTokens >= cap
+}
+
+/** Collector-side variant for adapter catch blocks (pre-LLMCallData). */
+function collectorHitOutputCap(collector: Collector | undefined): boolean {
+  const last = collector?.last
+  if (!last?.usage?.outputTokens) return false
+  const calls = (last.calls ?? []) as Array<{ selected?: boolean; clientName?: string }>
+  const call = calls.find((c) => c.selected) ?? calls[calls.length - 1]
+  const cap = call?.clientName ? CLIENT_MAX_OUTPUT_TOKENS[call.clientName] : undefined
+  return cap !== undefined && (last.usage.outputTokens ?? 0) >= cap
+}
+
+/**
+ * Corrective guidance appended to `context` on the one truncation retry. Goes
+ * through the per-call context field (transient — influences only the retry,
+ * not other actors or turns). Recovery-oriented per design review: tells the
+ * model to APPEND large content across calls, not to pre-emptively chunk.
+ */
+export const TRUNCATION_RETRY_GUIDANCE =
+  'IMPORTANT: your previous response exceeded the output-token limit and was CUT OFF ' +
+  'mid-generation, so it could not be parsed. Respond again with a materially SMALLER ' +
+  'response. Keep tool_args compact; when a file or script is large, write the first ' +
+  "part now and CONTINUE BY APPENDING in later calls (e.g. bash `cat >> file <<'EOF'`) " +
+  'instead of inlining everything in a single call.'
 
 /** Error thrown by BAML adapters when an LLM call fails after all in-adapter
  *  fallbacks have been exhausted. Carries the captured prompt/variables/HTTP
@@ -381,6 +429,24 @@ export function createLoopControllerAdapter(
         ? await b.LoopController(user_message, intent, tools, turns, context, priorResults, fewShots, baseOpts)
         : await b.LoopController(user_message, intent, tools, turns, context, priorResults, fewShots)
     } catch (e) {
+      // Output-cap truncation (any chain, incl. Anthropic-only): the parse
+      // failed because the response was cut off, not because the model can't
+      // do structured output. ONE corrective retry with the truncation notice
+      // appended to `context` (per-call, transient); a second failure throws.
+      if (e instanceof BamlValidationError && collectorHitOutputCap(collector)) {
+        const retryContext = [context, TRUNCATION_RETRY_GUIDANCE].filter(Boolean).join('\n\n')
+        try {
+          action = hasBaseOpts
+            ? await b.LoopController(user_message, intent, tools, turns, retryContext, priorResults, fewShots, baseOpts)
+            : await b.LoopController(user_message, intent, tools, turns, retryContext, priorResults, fewShots)
+          const llmCall = collector
+            ? extractLLMCallData(collector, 'LoopController', variables, startTime, action)
+            : undefined
+          return { action, llmCall }
+        } catch (eRetry) {
+          throw wrapAsLLMCallError(eRetry, 'LoopController', variables, startTime, collector)
+        }
+      }
       if (!(e instanceof BamlValidationError) || !clientOverride) {
         throw wrapAsLLMCallError(e, 'LoopController', variables, startTime, collector)
       }
@@ -621,6 +687,22 @@ export function createActorControllerAdapter(
         ? await b.ActorController(user_message, intent, tools, attempts, context, fewShots, attemptNumber, maxAttempts, baseOpts)
         : await b.ActorController(user_message, intent, tools, attempts, context, fewShots, attemptNumber, maxAttempts)
     } catch (e) {
+      // Output-cap truncation: one corrective retry with the truncation notice
+      // appended to `context` — see createLoopControllerAdapter for rationale.
+      if (e instanceof BamlValidationError && collectorHitOutputCap(collector)) {
+        const retryContext = [context, TRUNCATION_RETRY_GUIDANCE].filter(Boolean).join('\n\n')
+        try {
+          action = hasBaseOpts
+            ? await b.ActorController(user_message, intent, tools, attempts, retryContext, fewShots, attemptNumber, maxAttempts, baseOpts)
+            : await b.ActorController(user_message, intent, tools, attempts, retryContext, fewShots, attemptNumber, maxAttempts)
+          const llmCall = collector
+            ? extractLLMCallData(collector, 'ActorController', variables, startTime, action)
+            : undefined
+          return { action, llmCall }
+        } catch (eRetry) {
+          throw wrapAsLLMCallError(eRetry, 'ActorController', variables, startTime, collector)
+        }
+      }
       if (!(e instanceof BamlValidationError) || !clientOverride) {
         throw wrapAsLLMCallError(e, 'ActorController', variables, startTime, collector)
       }

--- a/ui/src/lib/harness-patterns/patterns/actorCritic.server.ts
+++ b/ui/src/lib/harness-patterns/patterns/actorCritic.server.ts
@@ -29,7 +29,7 @@ import { trackEvent, resolveConfig, generateId } from '../context.server'
 import { getRequestSettings } from '../../settings-context.server'
 import { getActiveSandbox } from '../../sandbox/scope.server'
 import type { CodeModeControllerFnWithLLMData, CriticFnWithLLMData } from '../baml-adapters.server'
-import { LLMCallError } from '../baml-adapters.server'
+import { LLMCallError, llmCallHitOutputCap } from '../baml-adapters.server'
 
 assertServerOnImport()
 
@@ -196,17 +196,31 @@ export function actorCritic<T extends ActorCriticData>(
         } catch {
           // Surface unparseable tool_args as a recoverable error too — same
           // observability reasoning as the allowlist branch above.
-          const errMsg = `Invalid tool_args JSON for ${action.tool_name}: ${action.tool_args}`
+          //
+          // Truncation-aware feedback: when the actor call hit its client's
+          // output-token cap, the args aren't malformed — they were CUT OFF.
+          // Generic "fix your JSON quoting" feedback makes the model regenerate
+          // the same oversized payload until retries exhaust; say the real
+          // cause so the retry converges (write smaller, append to continue).
+          const truncated = llmCallHitOutputCap(actorLlmCall)
+          const errMsg = truncated
+            ? `tool_args for ${action.tool_name} were CUT OFF at the output-token limit ` +
+              `(response truncated mid-generation, not a formatting mistake). Produce a ` +
+              `materially smaller tool_args: write the first part of any large file now ` +
+              `and CONTINUE BY APPENDING in later calls (e.g. bash \`cat >> file <<'EOF'\`).`
+            : `Invalid tool_args JSON for ${action.tool_name}: ${action.tool_args}`
           trackEvent(
             scope,
             'error',
             {
               error: errMsg,
               severity: 'recoverable',
-              hint:
-                'Actor produced unparseable tool_args. Common causes: unquoted ' +
-                'keys/values, unescaped newlines inside scripts. The actor will ' +
-                'see this in previousAttempts and (hopefully) retry with valid JSON.',
+              hint: truncated
+                ? 'Actor response hit the max_tokens cap mid-tool_args. The actor sees ' +
+                  'truncation-specific feedback in previousAttempts and should split the work.'
+                : 'Actor produced unparseable tool_args. Common causes: unquoted ' +
+                  'keys/values, unescaped newlines inside scripts. The actor will ' +
+                  'see this in previousAttempts and (hopefully) retry with valid JSON.',
               iteration: attempt,
             } as ErrorEventData,
             resolved.trackHistory,

--- a/ui/src/lib/harness-patterns/patterns/simpleLoop.server.ts
+++ b/ui/src/lib/harness-patterns/patterns/simpleLoop.server.ts
@@ -29,7 +29,7 @@ import { getActiveSandbox } from '../../sandbox/scope.server'
 import { trimToFit, getContextWindow } from '../token-budget.server'
 import { resolveClientForRole } from '../clients.server'
 import type { ControllerFnWithLLMData } from '../baml-adapters.server'
-import { dedupByRefId, annotateExpansions, LLMCallError } from '../baml-adapters.server'
+import { dedupByRefId, annotateExpansions, LLMCallError, llmCallHitOutputCap } from '../baml-adapters.server'
 import type { LLMCallData } from '../types'
 
 assertServerOnImport()
@@ -219,6 +219,9 @@ export function simpleLoop<T extends SimpleLoopData>(
         // Call BAML controller — catch validation errors gracefully
         // so partial results from earlier turns are preserved
         let action: ControllerAction
+        // Hoisted so the tool_args-parse branch below can check for output-cap
+        // truncation on the call that produced this turn's action.
+        let controllerLlmCall: LLMCallData | undefined
         const collector = new Collector('simpleLoop')
         try {
           const controllerResult = await controller(
@@ -232,6 +235,7 @@ export function simpleLoop<T extends SimpleLoopData>(
             config?.fewShots
           )
           action = controllerResult.action
+          controllerLlmCall = controllerResult.llmCall
 
           // Track controller action event with LLM call data.
           // `turn` and `maxTurns` are surfaced so live consumers can size
@@ -395,7 +399,13 @@ export function simpleLoop<T extends SimpleLoopData>(
           args = repairJson(action.tool_args)
         } catch {
           hasError = true
-          errorMessage = `Invalid tool_args JSON: ${action.tool_args}`
+          // Truncation-aware message: a response cut off at the client's
+          // max_tokens cap is not malformed JSON — name the real cause so the
+          // synthesizer/user sees it (actorCritic carries the retrying variant).
+          errorMessage = llmCallHitOutputCap(controllerLlmCall)
+            ? `tool_args for ${action.tool_name} were CUT OFF at the output-token ` +
+              `limit (response truncated mid-generation)`
+            : `Invalid tool_args JSON: ${action.tool_args}`
           errorTurn = turn
           break
         }

--- a/ui/src/lib/settings.ts
+++ b/ui/src/lib/settings.ts
@@ -82,6 +82,7 @@ export const MODEL_CONTEXT_WINDOWS: Record<string, number> = {
   CustomHaiku: 200_000,
   CustomOpus4: 200_000,
   CustomSonnet4: 200_000,
+  AnthropicSonnet5: 1_000_000,
   // Cerebras — separate-quota safety nets at end of each fallback chain
   CerebrasGPT120B: 131_072,        // gpt-oss-120b
   CerebrasZaiGLM4_7: 131_072,      // zai-glm-4.7
@@ -107,6 +108,27 @@ export const MODEL_CONTEXT_WINDOWS: Record<string, number> = {
   CriticFallback: 32_768,
   SynthesizerFallback: 32_768,
   DescribeFallback: 32_768,
+}
+
+/**
+ * Configured `max_tokens` per BAML client — MUST mirror `baml_src/clients.baml`.
+ *
+ * Used by the adapters' truncation detection: a response whose
+ * `usage.outputTokens` reaches its client's cap was cut off mid-generation
+ * (Anthropic reports exactly the cap on a max_tokens stop). A truncated
+ * ControllerAction loses its trailing fields (`status`, `is_final`) or ends
+ * mid-`tool_args` → BamlValidationError / invalid tool_args. Detection lets the
+ * retry path tell the actor to produce a smaller response instead of blindly
+ * regenerating the same oversized one (see `.harness-logs/baml-validation-sandbox.json`).
+ *
+ * Only clients with an explicit cap in clients.baml are listed; unknown clients
+ * are treated as not-detectable (no false positives).
+ */
+export const CLIENT_MAX_OUTPUT_TOKENS: Record<string, number> = {
+  AnthropicSonnet5: 32_768,
+  AnthropicSonnet46: 16_384,
+  AnthropicHaiku45: 16_384,
+  AnthropicOpus4: 4_096,
 }
 
 export const SETTINGS_STORAGE_KEY = 'kg_agent_settings'


### PR DESCRIPTION
## Problem

Controller responses were truncating mid-JSON at the 4096 `max_tokens` cap. A
sandbox actor inlining a large script into `tool_args` would get cut off,
dropping the trailing `status` / `is_final` fields → `BamlValidationError:
missing status/is_final` (see `.harness-logs/baml-validation-sandbox.json`). Every
retry then regenerated the same oversized payload until the retry budget
exhausted.

## Fix

- **Bigger output caps.** Sonnet 5 → 32768, Sonnet 4.6 / Haiku 4.5 → 16384 (were
  4096). Mirrored in a new `CLIENT_MAX_OUTPUT_TOKENS` (`ui/src/lib/settings.ts`),
  kept in sync with `baml_src/clients.baml`.
- **Sonnet 5 controller chain.** `ControllerAnthropic` = AnthropicSonnet5 →
  AnthropicSonnet46 — the backstop stays Sonnet-tier (no Haiku fallback on
  structured output, which is where truncation bit hardest).
- **Truncation-aware retry.** The adapters detect a cap-hit (Anthropic reports
  `usage.outputTokens == cap` exactly on a `max_tokens` stop) and do ONE
  corrective retry with truncation guidance appended to the **per-call `context`**
  (so it doesn't leak into every actor). Both loops (`simpleLoop`, `actorCritic`)
  now emit truncation-specific feedback — "write smaller / append to continue" —
  instead of generic "invalid JSON" when `tool_args` were cut off.
- The `status` / `is_final` output schema is intentionally **unchanged**.

## Test

New `truncation-retry.test.ts` (8 cases) covering cap detection + the corrective
retry path. Full suite green; `tsc` at baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TcfhRkKX6eijTywPSURFYS
