### PR TITLE
feat(harness): criticCadence for actorCritic — actor free-runs, critic gates exit

### DIFF
--- a/ui/baml_src/actorCritic.baml
+++ b/ui/baml_src/actorCritic.baml
@@ -45,10 +45,15 @@ function ActorController(
       {% if tool.args_schema %}  Args: {{ tool.args_schema }}{% endif %}
     {% endfor %}
 
-    The critic evaluates whether the data you've gathered is sufficient and
-    decides when the task is complete — you don't need a "Return" tool. Focus
-    on calling the right tool to make progress; the loop exits when the critic
-    says so.
+    A critic decides when the task is complete and when the loop exits — you
+    don't need a "Return" tool. Focus on calling the right tool to make progress.
+
+    When you believe the task is fully complete — every requested deliverable
+    actually produced, not merely planned — set is_final=true. The critic then
+    VERIFIES before the loop exits, so is_final is a signal, not a guarantee.
+    While you still have work to do, keep is_final=false and call the next tool.
+    In particular, a script you have only WRITTEN is not done: keep is_final=false
+    and run it (and confirm its output) before you set is_final=true.
 
     {% if attempts|length > 0 %}
     PREVIOUS ATTEMPTS:

--- a/ui/src/__tests__/lib/harness-patterns/patterns/actorCritic.test.ts
+++ b/ui/src/__tests__/lib/harness-patterns/patterns/actorCritic.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { mockAction, mockFinalAction, mockCriticResult, mockBAMLClient } from '../../../mocks/baml'
 import { mockCallTool, mockListTools, fixtures } from '../../../mocks/mcp'
+import type { CodeModeControllerFnWithLLMData, CriticFnWithLLMData } from '../../../../lib/harness-patterns/baml-adapters.server'
 
 // Mock server-only imports
 vi.mock('../../../../lib/harness-patterns/assert.server', () => ({
@@ -462,5 +463,137 @@ describe('actorCritic execution', () => {
     await pattern.fn(scope, view)
 
     expect(receivedAvailableTools).toEqual(['custom-tool-1', 'custom-tool-2'])
+  })
+})
+
+describe('actorCritic criticCadence', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    callToolMock.mockResolvedValue({ success: true, data: { result: 'ok' } })
+  })
+
+  // Minimal scope/view/context builder shared by the cadence tests.
+  async function run(
+    mockActor: CodeModeControllerFnWithLLMData,
+    mockCritic: CriticFnWithLLMData,
+    config: Record<string, unknown>,
+  ) {
+    const { actorCritic } = await import('../../../../lib/harness-patterns/patterns/actorCritic.server')
+    const { createScope } = await import('../../../../lib/harness-patterns/context.server')
+    const { createEventView } = await import('../../../../lib/harness-patterns/patterns')
+
+    const pattern = actorCritic(mockActor, mockCritic, ['code-mode'], {
+      patternId: 'cadence',
+      ...config,
+    })
+    const scope = createScope('test', {})
+    const mockContext = {
+      sessionId: 'test',
+      createdAt: Date.now(),
+      events: [
+        { type: 'user_message' as const, ts: Date.now(), patternId: 'harness', data: { content: 'do it' } },
+      ],
+      status: 'running' as const,
+      data: {},
+      input: 'do it',
+    }
+    return pattern.fn(scope, createEventView(mockContext))
+  }
+
+  it('skips the critic until the Nth successful turn (cadence backstop)', async () => {
+    // Actor never signals is_final; critic accepts when it finally runs.
+    const mockActor = vi.fn().mockResolvedValue({
+      action: mockAction({ tool_name: 'code-mode', tool_args: '{"script":"step"}' }),
+      llmCall: undefined,
+    })
+    const mockCritic = vi.fn().mockResolvedValue({
+      result: mockCriticResult({ is_sufficient: true }),
+      llmCall: undefined,
+    })
+
+    const result = await run(mockActor, mockCritic, { maxRetries: 6, criticCadence: 3 })
+
+    // Turns 0,1 skip the critic; turn 2 (3rd successful turn) runs it → exits.
+    expect(mockActor).toHaveBeenCalledTimes(3)
+    expect(mockCritic).toHaveBeenCalledTimes(1)
+    expect(result.data.result).toBeDefined()
+  })
+
+  it('runs the critic immediately when the actor sets is_final (early trigger)', async () => {
+    // First action is already is_final → critic runs on turn 0 despite cadence 3.
+    // Use an allowlisted tool (not mockFinalAction's 'Return', which the loop
+    // rejects before the critic) so is_final is what triggers the critic.
+    const mockActor = vi.fn().mockResolvedValue({
+      action: mockAction({ tool_name: 'code-mode', tool_args: '{"script":"done"}', is_final: true }),
+      llmCall: undefined,
+    })
+    const mockCritic = vi.fn().mockResolvedValue({
+      result: mockCriticResult({ is_sufficient: true }),
+      llmCall: undefined,
+    })
+
+    const result = await run(mockActor, mockCritic, { maxRetries: 6, criticCadence: 3 })
+
+    expect(mockActor).toHaveBeenCalledTimes(1)
+    expect(mockCritic).toHaveBeenCalledTimes(1)
+    expect(result.data.result).toBeDefined()
+  })
+
+  it('encodes the write-then-run fix: never critiques the written-but-unrun step', async () => {
+    // Turn 0: WRITE the script (is_final=false) → must be skipped by the critic.
+    // Turn 1: RUN it (is_final=true) → critic runs and accepts. The regression
+    // (.harness-logs/context-3817275e-*.json) was the critic accepting turn 0.
+    const mockActor = vi.fn()
+      .mockResolvedValueOnce({
+        action: mockAction({ tool_name: 'code-mode', tool_args: '{"script":"write report"}', is_final: false }),
+        llmCall: undefined,
+      })
+      .mockResolvedValueOnce({
+        action: mockAction({ tool_name: 'code-mode', tool_args: '{"script":"run report"}', is_final: true }),
+        llmCall: undefined,
+      })
+    const mockCritic = vi.fn().mockResolvedValue({
+      result: mockCriticResult({ is_sufficient: true }),
+      llmCall: undefined,
+    })
+
+    await run(mockActor, mockCritic, { maxRetries: 6, criticCadence: 3 })
+
+    // The critic must NOT have been consulted after the write-only turn.
+    expect(mockActor).toHaveBeenCalledTimes(2)
+    expect(mockCritic).toHaveBeenCalledTimes(1)
+  })
+
+  it('always critiques on the final attempt even if cadence never hits', async () => {
+    const mockActor = vi.fn().mockResolvedValue({
+      action: mockAction({ tool_name: 'code-mode', tool_args: '{"script":"step"}' }),
+      llmCall: undefined,
+    })
+    const mockCritic = vi.fn().mockResolvedValue({
+      result: mockCriticResult({ is_sufficient: true }),
+      llmCall: undefined,
+    })
+
+    // cadence 5 never divides turns 1..2, but the last attempt forces a critic run.
+    const result = await run(mockActor, mockCritic, { maxRetries: 2, criticCadence: 5 })
+
+    expect(mockActor).toHaveBeenCalledTimes(2)
+    expect(mockCritic).toHaveBeenCalledTimes(1)
+    expect(result.data.result).toBeDefined()
+  })
+
+  it('clamps criticCadence < 1 to every-turn (critic can never be disabled)', async () => {
+    const mockActor = vi.fn().mockResolvedValue({
+      action: mockAction({ tool_name: 'code-mode', tool_args: '{"script":"step"}' }),
+      llmCall: undefined,
+    })
+    // Not sufficient on turn 0, sufficient on turn 1 — proves the critic ran both.
+    const mockCritic = vi.fn()
+      .mockResolvedValueOnce({ result: mockCriticResult({ is_sufficient: false, explanation: 'more' }), llmCall: undefined })
+      .mockResolvedValueOnce({ result: mockCriticResult({ is_sufficient: true }), llmCall: undefined })
+
+    await run(mockActor, mockCritic, { maxRetries: 2, criticCadence: 0 })
+
+    expect(mockCritic).toHaveBeenCalledTimes(2)
   })
 })

--- a/ui/src/lib/harness-client/examples/flavoured-sandbox.server.ts
+++ b/ui/src/lib/harness-client/examples/flavoured-sandbox.server.ts
@@ -120,6 +120,12 @@ function sandboxLoop(patternId: string, guidance: string) {
     availableTools: [],
     liveEvents: true,
     maxRetries: 6,
+    // Deliverable-producing routes: the actor typically inspects inputs, WRITES
+    // a script, RUNS it, then confirms the output — a multi-step chain. Let it
+    // free-run and have the critic judge only when the actor signals is_final
+    // (or every 3rd turn as a backstop), so the critic can't accept a written-
+    // but-unrun script as "done" (see .harness-logs/context-3817275e-*.json).
+    criticCadence: 3,
   });
 }
 

--- a/ui/src/lib/harness-patterns/README.md
+++ b/ui/src/lib/harness-patterns/README.md
@@ -162,7 +162,7 @@ interface ControllerAction {
   tool_name: string      // Tool to call. simpleLoop: `'Return'` exits the loop. actorCritic: actor's `'Return'` is ignored — the critic alone owns termination.
   tool_args: string      // JSON payload
   status: string         // User-facing message
-  is_final: boolean      // simpleLoop only — actorCritic ignores it on the actor side
+  is_final: boolean      // simpleLoop: exits the loop. actorCritic: cannot exit (critic owns that), but is an advisory *critic trigger* — see criticCadence.
 }
 
 // Critic result for actor-critic pattern
@@ -352,6 +352,7 @@ actorCritic(b.CodeModeController.bind(b), b.CodeModeCritic.bind(b), tools.all, {
 interface ActorCriticConfig extends PatternConfig {
   maxRetries?: number             // Default: 3
   onToolResult?: OnToolResult     // Same shape + semantics as in SimpleLoopConfig
+  criticCadence?: number          // Default: 1 (critic every turn). See below.
 }
 ```
 
@@ -361,6 +362,20 @@ interface ActorCriticConfig extends PatternConfig {
 3. Critic evaluates result
 4. Retry with feedback if insufficient
 5. Exit when sufficient or max retries
+
+**`criticCadence` — let the actor free-run a multi-step sequence.** By default
+(`1`) the critic runs after every successful turn. This interrupts multi-step
+deliverables mid-plan: the actor writes a script, and the critic — the loop's
+*sole* exit authority — can wrongly accept the written-but-unrun script as "done"
+(observed live: a report loop exited with no `.docx` because the critic judged the
+generator script before it ran). With `criticCadence: N` the actor free-runs and
+the critic evaluates only (a) every Nth successful turn, (b) when the actor sets
+`is_final: true` ("I think I'm done" — it still can't exit by itself; the critic
+verifies), and (c) on the final attempt. This is the composable "actor free-runs,
+judge gates exit" shape without a second pattern. `is_final` is thus an advisory
+critic *trigger* here, never an exit. With `N > 1`, `maxRetries` bounds actor
+turns (tool steps), not critic calls; values `< 1` are clamped to `1` so the
+critic can never be disabled.
 
 ### `parallel(...patterns)`
 
@@ -893,7 +908,7 @@ BAML Inputs (ActorController):
   tools        : ToolDescription[]← MCP listTools()
   attempts     : Attempt[]        ← assembled from scope events per attempt
 
-BAML Return → ControllerAction (same shape as simpleLoop; actor's `is_final` / `tool_name: 'Return'` are *not* honored — exit is the critic's call)
+BAML Return → ControllerAction (same shape as simpleLoop; the actor cannot exit — `tool_name: 'Return'` is rejected and `is_final` only *triggers* a critic check under `criticCadence`. Exit is the critic's call.)
 
 BAML Inputs (Critic):
   intent   : string      ← same intent

--- a/ui/src/lib/harness-patterns/patterns/actorCritic.server.ts
+++ b/ui/src/lib/harness-patterns/patterns/actorCritic.server.ts
@@ -76,6 +76,12 @@ export function actorCritic<T extends ActorCriticData>(
     view: EventView
   ): Promise<PatternScope<T>> => {
     const maxRetries = config?.maxRetries ?? getRequestSettings().maxRetries
+    // Critic cadence: run the critic every Nth *successful* actor turn (default
+    // 1 = every turn, the original behavior). Clamped to >= 1 so a stray 0 /
+    // negative value can't disable the critic — the loop's only exit authority.
+    // See `ActorCriticConfig.criticCadence` and the cadence gate below.
+    const criticCadence = Math.max(1, Math.floor(config?.criticCadence ?? 1))
+    let successfulTurns = 0
     const previousAttempts: ScriptExecutionEvent[] = []
     let errorMessage: string | undefined
 
@@ -119,17 +125,18 @@ export function actorCritic<T extends ActorCriticData>(
           actorLlmCall
         )
 
-        // P0 (Return-from-critic redesign): the actor used to be able to exit
-        // the loop by calling `tool_name === 'Return'` or setting `is_final`.
-        // We removed that — sufficiency-to-exit is the critic's job by
-        // definition, and the dual responsibility let the actor self-terminate
-        // with fabricated data (see `.harness-logs/one-turn-codemode.json`).
-        // If the actor still proposes `Return` (or anything else not on the
-        // allowlist), it falls through to the allowlist check below, which
-        // rejects it as "Tool not allowed: Return" and continues the loop —
-        // letting the critic actually evaluate the next real tool call.
-        // `is_final` is preserved on `ControllerAction` for backwards compat
-        // but is now advisory; nothing in the loop honours it.
+        // P0 (Return-from-critic redesign): the actor cannot EXIT the loop on
+        // its own — sufficiency-to-exit is the critic's job by definition, and
+        // the dual responsibility once let the actor self-terminate with
+        // fabricated data (see `.harness-logs/one-turn-codemode.json`). That
+        // invariant still holds: the critic is the SOLE exit authority below.
+        //
+        // `is_final` is now an advisory *critic trigger*, not an exit: when the
+        // actor sets it, the cadence gate (after the tool call) runs the critic
+        // this turn even under `criticCadence` > 1 — but the critic still
+        // decides whether the loop exits. If the actor proposes a `Return` tool
+        // (or anything not on the allowlist) it falls through to the allowlist
+        // check below, is rejected as "Tool not allowed", and the loop continues.
 
         // Validate tool. The strict allowlist is augmented by an optional
         // `dynamicToolPattern` regex so agents whose backends create tools at
@@ -311,6 +318,39 @@ export function actorCritic<T extends ActorCriticData>(
         )
 
         if (!result.success) {
+          continue
+        }
+
+        // Cadence gate. The actor free-runs successful tool calls; the critic
+        // (the loop's sole exit authority) only weighs in periodically, so a
+        // multi-step deliverable isn't interrupted mid-plan and wrongly judged
+        // "done" on an intermediate state. Run the critic when ANY of:
+        //   - the actor set `is_final: true` — it believes the task is done and
+        //     is asking to be judged (it still can't exit by itself);
+        //   - this is the final attempt — so work that completes on the last
+        //     turn is still evaluated (and can be accepted) instead of falling
+        //     through to "Max retries exceeded";
+        //   - it's the Nth successful turn — a backstop for an actor that never
+        //     sets `is_final`.
+        // At criticCadence === 1 the modulo is always true → critic every turn
+        // (unchanged default behavior).
+        successfulTurns++
+        const isLastAttempt = attempt === maxRetries - 1
+        const shouldCritique =
+          action.is_final === true ||
+          isLastAttempt ||
+          successfulTurns % criticCadence === 0
+
+        if (!shouldCritique) {
+          // Skip the critic this turn and let the actor take the next step. The
+          // tool result is already in `previousAttempts` (the actor's
+          // self-correction channel), so the next actor call sees what happened.
+          scope.data = {
+            ...scope.data,
+            attempt,
+            lastAction: action,
+            lastResult: result.data,
+          }
           continue
         }
 

--- a/ui/src/lib/harness-patterns/types.ts
+++ b/ui/src/lib/harness-patterns/types.ts
@@ -266,6 +266,19 @@ export interface ActorCriticConfig extends PatternConfig {
    *  and the loop's strict allowlist stay in sync when the user mutates the
    *  selection mid-conversation. */
   dynamicToolAllowlist?: () => Promise<string[]>
+  /** How often the critic runs, in successful actor turns (default: 1 = every
+   *  turn, the original behavior). With `criticCadence: N` the actor free-runs a
+   *  sequence of tool calls and the critic — still the loop's SOLE exit
+   *  authority — evaluates only (a) every Nth successful turn, (b) whenever the
+   *  actor sets `is_final: true` ("I think I'm done"), and (c) on the final
+   *  attempt. This lets a multi-step deliverable (e.g. write a script, THEN run
+   *  it) finish before the critic judges, so it can't wrongly accept an
+   *  intermediate state as complete — the failure in
+   *  `.harness-logs/context-3817275e-*.json`, where a critic ran right after the
+   *  report script was WRITTEN (before it ran) and exited with no .docx. Values
+   *  < 1 are clamped to 1 so the critic can never be disabled. Note: with N > 1,
+   *  `maxRetries` bounds actor turns (tool steps), not critic evaluations. */
+  criticCadence?: number
 }
 
 /** Synthetic tool injected into LoopController's tools list when prior results


### PR DESCRIPTION
## Problem

`actorCritic`'s critic is the loop's **sole exit authority**, and it runs after
*every* successful turn. That interrupts multi-step deliverables mid-plan: a
report agent wrote its `.docx`-generator script, and the critic — judging the
*written-but-unrun* script — returned `is_sufficient=true`, so the loop exited
with no `.docx` produced (`.harness-logs/context-3817275e-*.json`). The identical
state was judged the opposite way on a retry: a soft, non-deterministic
false-positive from the weakest model in the chain (Haiku-led critic).

## Fix

Add **`criticCadence`** to `ActorCriticConfig` (default `1` = every turn, fully
back-compat). With `N>1` the actor free-runs a tool sequence and the critic
evaluates only:
- when the actor sets **`is_final: true`** ("I think I'm done"),
- on the **final attempt**,
- every **Nth** successful turn (backstop).

`is_final` becomes an advisory **critic trigger**, not an exit — the P0 invariant
(critic is sole exit authority) is fully preserved; `is_final` only *requests*
judgment. The shared BAML actor prompt now instructs the actor to set `is_final`
only when every deliverable is actually **produced** (not merely planned) —
explicitly *"a script you've only WRITTEN is not done: run it first"* — so the
critic evaluates a state the actor itself declares terminal (the call it's good
at), not an ambiguous mid-plan one.

This is the composable "actor free-runs, judge gates exit" shape without a second
pattern. Flavoured-sandbox routes opt into `criticCadence: 3` (`maxRetries` stays
6). Clamped to `>=1` so the critic can never be disabled.

## Tests

+5 cadence cases (skip-until-Nth, `is_final` early trigger, **write-then-run
never critiques the unrun step** = the regression encoded, last-attempt backstop,
clamp). Full suite green; tsc at baseline.

## Follow-up (out of scope, noted)

The critic's `suggested_approach` is still not threaded back to the actor
(`baml-adapters` maps `Attempt.feedback = undefined`). With fewer critic calls,
making each verdict corrective is more valuable — a good next change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TcfhRkKX6eijTywPSURFYS
