### PR TITLE
feat(sandbox): timer-driven idle sweep + LRU cap on parked attachments (#82)

### DIFF
--- a/docs/sandbox-plan.md
+++ b/docs/sandbox-plan.md
@@ -400,10 +400,11 @@ Devs working specifically on `FirecrackerBackend` bugs opt into Lima / UTM / Orb
 
 | Setting | Default | Notes |
 |---------|---------|-------|
-| `sandbox.globalCap` | 16 | Max concurrent sandbox VMs across all sessions |
-| `sandbox.perSessionCap` | 4 | Max concurrent sandbox VMs per session |
+| `sandbox.globalCap` | 16 | Max concurrent **in-flight** sandbox VMs across all sessions |
+| `sandbox.perSessionCap` | 4 | Max concurrent in-flight sandbox VMs per session |
+| `sandbox.maxAttachments` | 8 | Hard ceiling on **parked (at-rest)** attachments in the `AttachmentTable`. When a new boot would exceed it, the least-recently-used refCount=0 attachment is evicted (#82). `globalCap` bounds in-flight; this bounds at-rest. |
 | `sandbox.warmPool.base` | 1–2 | Pre-booted VMs of the base flavor |
-| `sandbox.idleEvictMs` | 3_600_000 | Idle time before a parked VM is destroyed. With durable workspaces (#89) this is only the *warm-cache* horizon — instant reuse of the live container within the window; beyond it, the next turn re-hydrates `/work/in` from the DataStash. Was 300_000 before #89. |
+| `sandbox.idleEvictMs` | 3_600_000 | Idle time before a parked VM is destroyed. Reaped by the per-acquire lazy sweep *and* a 60s timer-driven sweep (#82) so a fully idle harness still releases parked VMs. With durable workspaces (#89) this is only the *warm-cache* horizon — instant reuse of the live container within the window; beyond it, the next turn re-hydrates `/work/in` from the DataStash. Was 300_000 before #89. |
 | `sandbox.defaultTimeoutSec` | 60 | Per-tool-call wall-clock cap |
 | `sandbox.defaultMemoryMB` | 512 | Per-VM memory cap |
 | `sandbox.defaultEgress` | `'mcp-only'` | Default egress profile |

--- a/ui/src/__tests__/lib/sandbox/attachment-table.test.ts
+++ b/ui/src/__tests__/lib/sandbox/attachment-table.test.ts
@@ -334,3 +334,131 @@ describe('AttachmentTable.shutdown', () => {
     expect(table.size()).toBe(0)
   })
 })
+
+describe('AttachmentTable maxAttachments — LRU cap (#82)', () => {
+  it('evicts the least-recently-used parked entry when a new boot exceeds the cap', async () => {
+    vi.useFakeTimers()
+    try {
+      const backend = makeBackend()
+      const pool = new WarmPool(backend, { caps: { base: 3 }, idleEvictMs: 60_000 })
+      const table = new AttachmentTable(backend, pool, { idleMs: 60_000, maxAttachments: 2 })
+
+      vi.setSystemTime(1_000)
+      const a = await table.acquire('alpha', 'base', {})
+      table.release(a) // parked, lastUsedAt = 1_000 (oldest)
+
+      vi.setSystemTime(2_000)
+      const b = await table.acquire('beta', 'base', {})
+      table.release(b) // parked, lastUsedAt = 2_000 (more recent)
+      expect(table.size()).toBe(2)
+
+      // Third distinct id at cap → evict the LRU parked entry (alpha).
+      vi.setSystemTime(3_000)
+      await table.acquire('gamma', 'base', {})
+
+      expect(table.has('alpha')).toBe(false) // LRU evicted
+      expect(table.has('beta')).toBe(true)
+      expect(table.has('gamma')).toBe(true)
+      expect(table.size()).toBe(2) // cap held
+      expect((a.transport as FakeTransport).closes).toBe(1) // stale transport torn down
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('overflows rather than evicting in-use (refCount>0) entries', async () => {
+    const backend = makeBackend()
+    const pool = new WarmPool(backend, { caps: { base: 4 }, idleEvictMs: 60_000 })
+    const table = new AttachmentTable(backend, pool, { idleMs: 60_000, maxAttachments: 2 })
+
+    await table.acquire('alpha', 'base', {}) // refCount 1 (not released)
+    await table.acquire('beta', 'base', {}) // refCount 1 (not released)
+    expect(table.size()).toBe(2)
+
+    // Both in use → cap cannot evict; overflow rather than kill a live session.
+    await table.acquire('gamma', 'base', {})
+    expect(table.size()).toBe(3)
+    expect(table.has('alpha')).toBe(true)
+    expect(table.has('beta')).toBe(true)
+  })
+})
+
+describe('AttachmentTable.startSweepTimer (#82)', () => {
+  it('fires sweepIdle on the interval WITHOUT an acquire, reaping idle parked VMs', async () => {
+    vi.useFakeTimers()
+    try {
+      const backend = makeBackend()
+      const pool = new WarmPool(backend, { caps: { base: 1 }, idleEvictMs: 10_000 })
+      const table = new AttachmentTable(backend, pool, { idleMs: 10_000 })
+
+      vi.setSystemTime(1_000_000)
+      const att = await table.acquire('alpha', 'base', {})
+      table.release(att) // parked at t0
+
+      table.startSweepTimer(30_000)
+      // No further acquire — only the timer drives the sweep. Advancing the fake
+      // clock 30s both fires the interval and ages the entry past idleMs.
+      await vi.advanceTimersByTimeAsync(30_000)
+
+      expect(table.has('alpha')).toBe(false)
+      table.stopSweepTimer()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('stopSweepTimer halts the periodic sweep', async () => {
+    vi.useFakeTimers()
+    try {
+      const backend = makeBackend()
+      const pool = new WarmPool(backend, { caps: { base: 1 }, idleEvictMs: 10_000 })
+      const table = new AttachmentTable(backend, pool, { idleMs: 10_000 })
+      const sweepSpy = vi.spyOn(table, 'sweepIdle')
+
+      table.startSweepTimer(30_000)
+      table.stopSweepTimer()
+      await vi.advanceTimersByTimeAsync(90_000)
+
+      expect(sweepSpy).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('startSweepTimer is idempotent (no duplicate timers)', async () => {
+    vi.useFakeTimers()
+    try {
+      const backend = makeBackend()
+      const pool = new WarmPool(backend, { caps: { base: 1 }, idleEvictMs: 10_000 })
+      const table = new AttachmentTable(backend, pool, { idleMs: 10_000 })
+      const sweepSpy = vi.spyOn(table, 'sweepIdle')
+
+      table.startSweepTimer(30_000)
+      table.startSweepTimer(30_000) // second call is a no-op
+      await vi.advanceTimersByTimeAsync(30_000)
+
+      expect(sweepSpy).toHaveBeenCalledTimes(1) // one tick, not two
+      table.stopSweepTimer()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('shutdown stops the sweep timer', async () => {
+    vi.useFakeTimers()
+    try {
+      const backend = makeBackend()
+      const pool = new WarmPool(backend, { caps: { base: 1 }, idleEvictMs: 10_000 })
+      const table = new AttachmentTable(backend, pool, { idleMs: 10_000 })
+
+      table.startSweepTimer(30_000)
+      await table.shutdown()
+      const sweepSpy = vi.spyOn(table, 'sweepIdle')
+      await vi.advanceTimersByTimeAsync(90_000)
+
+      expect(sweepSpy).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/ui/src/lib/sandbox/attachment-table.server.ts
+++ b/ui/src/lib/sandbox/attachment-table.server.ts
@@ -7,12 +7,15 @@
  * reference counting; release decrements; refCount=0 leaves the entry
  * parked under the id (a sweeper destroys it after `idleMs`).
  *
- * Sweep model: lazy, not timer-driven. Each `acquire` fires a best-effort
+ * Sweep model: lazy + optional timer. Each `acquire` fires a best-effort
  * background sweep that destroys idle attachments AND cascades to
- * `pool.evictIdle()`. Skipping the timer keeps test lifecycle simple — no
- * unref/clear, no leak warnings — at the cost that a fully idle harness
- * never sweeps. That's fine: idle means no resources are being held by
- * the agent layer beyond the parked VMs themselves.
+ * `pool.evictIdle()`. Because that only fires on activity, `startSweepTimer`
+ * adds a periodic (unref'd) sweep so a *fully idle* harness still reaps its
+ * parked VMs (#82); production arms it in `with-sandbox`, tests opt in.
+ *
+ * At-rest cap: `maxAttachments` (optional) bounds parked VMs regardless of
+ * idleness — a new boot evicts the least-recently-used refCount=0 entry
+ * (#82). `globalCap` only bounds in-flight allocations, not the at-rest table.
  *
  * Race-safe: parallel callers requesting the same id share the same boot
  * promise via an `inFlight` map; only the first call does the work.
@@ -50,11 +53,19 @@ export interface Attachment {
 export interface AttachmentTableConfig {
   /** Idle time before a refCount=0 attachment is destroyed (ms). */
   idleMs: number
+  /**
+   * Hard ceiling on entries in the table (#82). When a new boot would exceed
+   * it, the least-recently-used refCount=0 (parked) attachment is evicted to
+   * make room. `undefined` = no cap (the historical behavior). Bounds at-rest
+   * VMs regardless of idleness; `globalCap` only bounds in-flight allocations.
+   */
+  maxAttachments?: number
 }
 
 export class AttachmentTable {
   private readonly table = new Map<string, Attachment>()
   private readonly inFlight = new Map<string, Promise<Attachment>>()
+  private sweepTimer: ReturnType<typeof setInterval> | null = null
 
   constructor(
     private readonly backend: ComputeBackend,
@@ -98,6 +109,9 @@ export class AttachmentTable {
       return att
     }
     const p = (async (): Promise<Attachment> => {
+      // Make room under the at-rest cap BEFORE booting, so peak VM count stays
+      // at the cap rather than cap+1 (#82).
+      await this.enforceCap()
       const vm = await this.pool.acquire(rootfs, runtime)
       let transport: McpTransport
       try {
@@ -158,9 +172,59 @@ export class AttachmentTable {
   }
 
   /**
+   * LRU cap enforcement (#82). Before booting a new attachment, if the table
+   * is at `maxAttachments`, evict the least-recently-used PARKED (refCount=0)
+   * entry to make room. If every entry is still in use, the cap overflows
+   * rather than kill a live session — the scheduler's `globalCap` remains the
+   * in-flight backstop. No-op when `maxAttachments` is unset.
+   */
+  private async enforceCap(): Promise<void> {
+    const max = this.config.maxAttachments
+    if (max === undefined) return
+    while (this.table.size >= max) {
+      let lru: Attachment | undefined
+      for (const att of this.table.values()) {
+        if (att.refCount === 0 && (lru === undefined || att.lastUsedAt < lru.lastUsedAt)) {
+          lru = att
+        }
+      }
+      if (lru === undefined) break // all in use — allow overflow
+      this.table.delete(lru.id)
+      await lru.transport.close().catch(() => {})
+      await this.pool.release(lru.vm).catch(() => {})
+    }
+  }
+
+  /**
+   * Start a periodic idle sweep (#82). The per-`acquire` lazy sweep only fires
+   * on activity; this covers a *fully idle* harness whose parked VMs would
+   * otherwise sit until the next sandbox action. Idempotent. `unref()`'d so it
+   * never keeps the process alive on its own. Clear via `stopSweepTimer` /
+   * `shutdown`.
+   */
+  startSweepTimer(intervalMs: number): void {
+    if (this.sweepTimer) return
+    const timer = setInterval(() => {
+      void this.sweepIdle().catch(() => {})
+    }, intervalMs)
+    // Node's Timeout has unref(); guard in case the runtime's return type differs.
+    timer.unref?.()
+    this.sweepTimer = timer
+  }
+
+  /** Stop the periodic sweep started by `startSweepTimer` (idempotent). */
+  stopSweepTimer(): void {
+    if (this.sweepTimer) {
+      clearInterval(this.sweepTimer)
+      this.sweepTimer = null
+    }
+  }
+
+  /**
    * Destroy refCount=0 attachments idle past the threshold, and cascade to
    * `pool.evictIdle` so warm-pool entries don't accumulate either. Public
-   * for tests; production calls it via the lazy hook in `acquire`.
+   * for tests; production calls it via the lazy hook in `acquire` and the
+   * periodic `startSweepTimer`.
    */
   async sweepIdle(now: number = Date.now()): Promise<void> {
     const toEvict: Attachment[] = []
@@ -183,6 +247,7 @@ export class AttachmentTable {
 
   /** Destroy every attachment. Called on harness shutdown / between tests. */
   async shutdown(): Promise<void> {
+    this.stopSweepTimer()
     const all = [...this.table.values()]
     this.table.clear()
     await Promise.all(

--- a/ui/src/lib/sandbox/with-sandbox.server.ts
+++ b/ui/src/lib/sandbox/with-sandbox.server.ts
@@ -74,6 +74,12 @@ export interface WithSandboxConfig {
   syncWorkspace?: boolean
 }
 
+/** How often the default attachment table sweeps idle parked VMs (#82). This is
+ *  a check *cadence*, not the idle threshold — eviction still respects
+ *  `idleEvictMs`. The per-acquire lazy sweep covers active harnesses; this timer
+ *  covers a fully idle one whose parked VMs would otherwise never be reaped. */
+const SANDBOX_SWEEP_INTERVAL_MS = 60_000
+
 // Process-shared singletons, lazily constructed from DEFAULT_SETTINGS. Cap
 // values are read once at first use; the settings panel can't reshape an
 // already-built scheduler/pool/table at runtime (those caps are process-
@@ -140,7 +146,13 @@ export function getDefaultAttachments(): AttachmentTable {
   if (!defaultAttachments) {
     defaultAttachments = new AttachmentTable(getDefaultBackend(), getDefaultPool(), {
       idleMs: DEFAULT_SETTINGS.sandbox.idleEvictMs,
+      maxAttachments: DEFAULT_SETTINGS.sandbox.maxAttachments,
     })
+    // Timer-driven sweep (#82): reap parked VMs even on a fully idle harness,
+    // which the per-acquire lazy sweep never reaches. Only the default
+    // (production) singleton is armed; tests inject their own table and opt in
+    // explicitly. The timer is unref'd, so it never blocks process exit.
+    defaultAttachments.startSweepTimer(SANDBOX_SWEEP_INTERVAL_MS)
   }
   return defaultAttachments
 }
@@ -150,6 +162,7 @@ export function getDefaultAttachments(): AttachmentTable {
  * reaper so a test can observe a fresh first-build. Production never calls this.
  */
 export function __resetSandboxDefaultsForTests(): void {
+  defaultAttachments?.stopSweepTimer()
   defaultBackend = null
   defaultPool = null
   defaultScheduler = null

--- a/ui/src/lib/settings.ts
+++ b/ui/src/lib/settings.ts
@@ -19,6 +19,11 @@ export interface SandboxSettings {
   globalCap: number
   /** Max concurrent sandbox attachments per session. */
   perSessionCap: number
+  /** Hard ceiling on parked (at-rest) attachments in the AttachmentTable. When
+   *  a new boot would exceed it, the least-recently-used idle attachment is
+   *  evicted. Bounds at-rest VMs regardless of idleness; `globalCap` only
+   *  bounds in-flight allocations. */
+  maxAttachments: number
   /** Per-rootfs warm-pool depth. e.g. `{ base: 1 }`. */
   warmPool: Partial<Record<string, number>>
   /** Idle time before a pooled VM is destroyed (ms). */
@@ -51,6 +56,10 @@ export const DEFAULT_SETTINGS: HarnessSettings = {
   sandbox: {
     globalCap: 16,
     perSessionCap: 4,
+    // At-rest ceiling on the attachment table (#82). 8 = 2× perSessionCap, so a
+    // handful of persistent-flavour sessions can coexist while a runaway
+    // accumulation of parked VMs is capped even if the idle sweep hasn't fired.
+    maxAttachments: 8,
     warmPool: { base: 1, 'image-processing': 1, data: 1, office: 1 },
     // Hot-cache window only: a parked VM is reused instantly within this window.
     // Durable workspace state lives in the document store (hydrated into /work on


### PR DESCRIPTION
Closes #82.

## Problem

The attachment-table sweep was **lazy** — `sweepIdle()` only fired inside
`acquire()`. A fully idle harness never reaped its parked (refCount=0) VMs until
the next sandbox action, and there was **no ceiling on the at-rest table**
(`globalCap` bounds only *in-flight* allocations).

## Changes (items 1 & 2 of #82)

- **Timer-driven sweep.** `AttachmentTable.startSweepTimer(intervalMs)` runs a
  periodic, `unref()`'d `sweepIdle()`. `with-sandbox` arms it on the default
  singleton at **60s** (`SANDBOX_SWEEP_INTERVAL_MS`); the test reset seam and
  `shutdown()` clear it. Eviction still respects `idleMs` — the timer only
  changes *when* the check runs, not the idle threshold.
- **LRU cap.** `AttachmentTableConfig.maxAttachments` (default **8** via
  `DEFAULT_SETTINGS.sandbox`). A new boot evicts the least-recently-used
  `refCount=0` entry to stay under the cap — **evict-before-boot**, so peak VM
  count is `cap`, not `cap+1`. If every entry is still in use, it overflows
  rather than kill a live session; `globalCap` remains the in-flight backstop.

Item **3** (startup orphan reap) already shipped via **#97** (`reapOrphansOnce`),
so this PR completes #82.

## Design notes

- The timer lives **on `AttachmentTable`** (not `with-sandbox`) so it's unit-
  testable without the production Docker singletons, and so `shutdown()` can
  clear it. Only the default (production) table is armed; injected test tables
  opt in explicitly.
- LRU is a **soft** cap by construction: it can't evict in-use VMs. That's
  intentional — the hard in-flight ceiling is `globalCap`/`perSessionCap`.

## Tests

+6 (`attachment-table.test.ts`): LRU evicts the LRU parked entry; overflows when
all in use; **timer fires the sweep with no `acquire`** (the issue's explicit
ask); `stopSweepTimer` halts; `startSweepTimer` idempotent; `shutdown` clears the
timer. Full suite **924 pass**; tsc at baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TcfhRkKX6eijTywPSURFYS
