### PR TITLE
docs: plan/ subfolder + ROADMAP, post-#125 sweep, #124/#126 review hardening

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ n8n_data/
 
 # Working memory — Claude session notes
 SCRATCHPAD.md
+docker-compose.override.yml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@ docker compose ps
 
 **Graph tabs:** `SupportPanel` uses `lazyMount` + `unmountOnExit` on `Tabs.Root` — Cytoscape instances only exist for the active tab. The Neo4j/Memory tabs consume accumulated `graphElements` from `index.tsx`. The All tab derives elements on-demand from `contextEvents` via `turn-utils.ts` based on user-selected turns, with per-turn color coding via `GraphVisualization`'s `extraStyles` prop.
 
-**Probe before scaffolding:** For architectural questions (new patterns, infrastructure, deployment shapes, anything with multiple non-obvious options), sample the option space first and converge with the user on the shape before writing implementation docs or code. Going straight to a fully-detailed design tends to lock in defaults the user would have redirected. See [`docs/sandbox-plan.md`](docs/sandbox-plan.md) for the kind of doc that should *follow* such a conversation, not start it.
+**Probe before scaffolding:** For architectural questions (new patterns, infrastructure, deployment shapes, anything with multiple non-obvious options), sample the option space first and converge with the user on the shape before writing implementation docs or code. Going straight to a fully-detailed design tends to lock in defaults the user would have redirected. See [`docs/plan/sandbox.md`](docs/plan/sandbox.md) for the kind of doc that should *follow* such a conversation, not start it.
 
 ---
 
@@ -188,7 +188,8 @@ Custom tokens: `dark-bg-{primary,secondary,tertiary}`, `dark-text-{primary,secon
 | Doc | Contents |
 |-----|----------|
 | [`docs/INDEX.md`](docs/INDEX.md) | Full documentation index |
-| [GitHub Project — "Harness Playground tasks"](https://github.com/users/mknw/projects/5) | Planning board / roadmap — replaced `docs/ROADMAP.md`; planning lives in GitHub Projects now |
+| [GitHub Project — "Harness Playground tasks"](https://github.com/users/mknw/projects/5) | Live planning board (Status / Priority / MSCW per issue) — item tracking lives here |
+| [`docs/plan/ROADMAP.md`](docs/plan/ROADMAP.md) | Roadmap *shape*: multi-user target architecture + phased MoSCoW plan (Entra SSO #119 gates; keep in sync with the board's MSCW field) |
 | [`docs/UI_ARCHITECTURE.md`](docs/UI_ARCHITECTURE.md) | Component structure, data flow, Chat-Graph linking |
 | [`docs/DATA_STASH.md`](docs/DATA_STASH.md) | Data Stash pipeline: upload → chunk → embed → search (#6/#9/#8), API routes, Redis storage, redis-stack + local-embedder requirements |
 | [`docs/AGENT_TRIGGER.md`](docs/AGENT_TRIGGER.md) | `POST /api/agents/:id` async agent trigger → action rows: contract, fire-and-forget model, `kind`/`source`/`status` columns, token auth (`configs/action-tokens.yaml`), recording playback via Data Stash, promotion gate |

--- a/docs/DATA_STASH.md
+++ b/docs/DATA_STASH.md
@@ -136,5 +136,5 @@ llama-server --embedding -m models/Qwen3-Embedding-0.6B-Q8_0.gguf --port 8090 --
 
 ## Relationships
 
-- **#89** (sandbox `/work` ⇄ DataStash artifact sync) builds on the store/retrieve path (`storeDocument` / `getDocument` / `listDocuments`) and added the base64 `encoding` field + the `?download` route for byte-faithful binaries. It does not require vector search. Mechanism: [`docs/sandbox-plan.md → Durable workspaces`](sandbox-plan.md#durable-workspaces-89).
+- **#89** (sandbox `/work` ⇄ DataStash artifact sync) builds on the store/retrieve path (`storeDocument` / `getDocument` / `listDocuments`) and added the base64 `encoding` field + the `?download` route for byte-faithful binaries. It does not require vector search. Mechanism: [`docs/plan/sandbox.md → Durable workspaces`](plan/sandbox.md#durable-workspaces-89).
 - Distinct from **#17** (RDF/OWL → Neo4j): this is documents → Redis + vectors.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -7,7 +7,19 @@
 | Document | Description |
 |----------|-------------|
 | [README.md](../README.md) | Project overview and quick start |
-| [GitHub Project — "Harness Playground tasks"](https://github.com/users/mknw/projects/5) | Planning board / roadmap (replaced `docs/ROADMAP.md`; planning now in GitHub Projects) |
+| [GitHub Project — "Harness Playground tasks"](https://github.com/users/mknw/projects/5) | Live planning board (Status / Priority / MSCW per issue) |
+| [plan/ROADMAP.md](plan/ROADMAP.md) | The roadmap *shape*: target multi-user architecture, phases 0–4 with MoSCoW ratings + dependency spine (Entra SSO #119 as the gate) |
+
+---
+
+## Planning (`docs/plan/`)
+
+Forward-looking design docs. Live item-tracking stays on the GitHub project board; these hold the converged shapes.
+
+| Document | Description |
+|----------|-------------|
+| [plan/ROADMAP.md](plan/ROADMAP.md) | Multi-user target architecture + phased MoSCoW roadmap (#107 identity patterns, #119–#122) |
+| [plan/sandbox.md](plan/sandbox.md) | Sandbox compute design — core shipped (#79/#89/#97/#78 flavours); still plan-only: Swarm, Firecracker, ephemeral one-shot, #82 |
 
 ---
 
@@ -20,7 +32,7 @@
 | [harness-patterns/README.md](harness-patterns/README.md) | Overview, core concepts, quick start |
 | [harness-patterns/api.md](harness-patterns/api.md) | Complete API reference |
 | [harness-patterns/frontend.md](harness-patterns/frontend.md) | SolidStart integration, server actions, sessions |
-| [harness-patterns/examples.md](harness-patterns/examples.md) | Example agent catalog (6 agents) |
+| [harness-patterns/examples.md](harness-patterns/examples.md) | Example agent catalog (7 agents) |
 | [harness-patterns/parallel.md](harness-patterns/parallel.md) | Parallel pattern design notes |
 | [harness-patterns/with-references.md](harness-patterns/with-references.md) | `withReferences` meta-pattern + `expandPreviousResult` synthetic tool design (#30, #19) |
 | [harness-patterns/withReferences-tutorial.md](harness-patterns/withReferences-tutorial.md) | Hands-on walkthrough — search the web, attach refs at ingress, write to Neo4j |
@@ -58,9 +70,9 @@ Source-level index: see [ui/README.md](../ui/README.md#documentation-index).
 |----------|-------------|
 | [DOCKER_COMPOSE.md](DOCKER_COMPOSE.md) | Neo4j, MCP Gateway, Redis service configuration |
 | [MCP_GATEWAY.md](MCP_GATEWAY.md) | MCP Gateway reference, CLI, troubleshooting |
-| [sandbox-plan.md](sandbox-plan.md) | Sandbox compute plan — `withSandbox` wrapper, attachment model, MCP-in-VM architecture, durable workspaces (`syncWorkspace`, #89), backend interface (Docker + Firecracker), substrate options, failure modes |
-| [sandbox-flavours.md](sandbox-flavours.md) | Sandbox rootfs flavours (#78) — the `image-processing` + `data` images, the router-over-flavoured-sandboxes recipe, ephemeral vs persistent, and deferred hardening (#116) |
+| [sandbox-flavours.md](sandbox-flavours.md) | Sandbox rootfs flavours (#78) — the `image-processing` + `data` + `office` images, the router-over-flavoured-sandboxes recipe, ephemeral vs persistent, and deferred hardening (#116) |
 | [sandbox/README.md](sandbox/README.md) | Sandbox debugging — identify/inspect/reap containers, `/work` durable-workspace layout, `.harness-logs` jq recipes |
+| [deploy/azure-vm.md](deploy/azure-vm.md) | Single-VM deployment runbook (Azure VM or any VPS): compose hardening (loopback binds), UI as systemd host service, Caddy TLS, env reference, ops |
 
 **Key config files:**
 - `docker-compose.yaml` — service orchestration
@@ -90,7 +102,7 @@ Scripts: `scripts/export-neo4j.sh` · `scripts/import-neo4j.sh` · `scripts/rese
 | `EMBEDDINGS_PROVIDER` | Data Stash embedding provider: `local` (default) or `openrouter` (see [DATA_STASH.md](DATA_STASH.md)) |
 | `EMBEDDINGS_LOCAL_URL` / `EMBEDDINGS_LOCAL_MODEL` | Override the local embedder URL (`http://localhost:8090/v1`) / model (`Qwen3-Embedding-0.6B`) |
 | `OPENAI_API_KEY` | OpenAI models (GPT-5, GPT-5 Mini, GPT-5 Nano) |
-| `ANTHROPIC_API_KEY` | Anthropic models (Opus 4, Sonnet 4, Haiku) |
+| `ANTHROPIC_API_KEY` | Anthropic models (Sonnet 5, Sonnet 4.6, Haiku 4.5) — the default chains; **required** |
 | `VITE_STACK_PROJECT_ID` | Stack Auth project |
 | `VITE_STACK_PUBLISHABLE_CLIENT_KEY` | Stack Auth client key |
 | `STACK_SECRET_SERVER_KEY` | Stack Auth server key (used by `lib/auth/session.ts` to resolve users on the server) |
@@ -111,10 +123,18 @@ kg-agent/
 │   ├── AGENT_TRIGGER.md         # POST /api/agents/:id async trigger → actions
 │   ├── DOCKER_COMPOSE.md        # Docker setup
 │   ├── MCP_GATEWAY.md           # MCP Gateway reference
+│   ├── sandbox-flavours.md      # Rootfs flavours (#78): image-processing/data/office
+│   ├── plan/                    # Forward-looking design docs
+│   │   ├── ROADMAP.md           # Multi-user architecture + phased MoSCoW roadmap
+│   │   └── sandbox.md           # Sandbox design (core shipped; Swarm/Firecracker = plan)
+│   ├── deploy/
+│   │   └── azure-vm.md          # Single-VM deployment runbook
+│   ├── sandbox/
+│   │   └── README.md            # Sandbox operational debugging
 │   └── harness-patterns/        # Harness patterns documentation
 │       ├── README.md            # Overview
 │       ├── api.md               # API reference
-│       ├── examples.md          # Example agents
+│       ├── examples.md          # Example agents (7)
 │       ├── frontend.md          # Frontend integration
 │       ├── parallel.md          # Parallel pattern design
 │       └── with-references.md   # withReferences meta-pattern design (#30)

--- a/docs/UI_ARCHITECTURE.md
+++ b/docs/UI_ARCHITECTURE.md
@@ -830,7 +830,6 @@ ui/
 │       │   └── patterns/
 │       │       ├── simpleLoop.server.ts   # ReAct loop + callId on tool events
 │       │       ├── actorCritic.server.ts  # Generate-evaluate + callId
-│       │       ├── withApproval.server.ts # Approval gate + pattern_enter/exit
 │       │       ├── parallel.server.ts     # Concurrent branches + pattern_enter/exit
 │       │       ├── guardrail.server.ts    # Rail validation + pattern_enter/exit
 │       │       ├── hook.server.ts         # Lifecycle hook + pattern_enter/exit

--- a/docs/data-flow.md
+++ b/docs/data-flow.md
@@ -1,7 +1,7 @@
 # Data Flow — Data Stash & Sandbox
 
 Visual companion to [`DATA_STASH.md`](DATA_STASH.md) (the store → chunk → embed →
-search pipeline) and the sandbox docs [`sandbox-plan.md`](sandbox-plan.md) /
+search pipeline) and the sandbox docs [`plan/sandbox.md`](plan/sandbox.md) /
 [`sandbox/README.md`](sandbox/README.md). Those cover the *what* and *why* in
 prose; this doc is the *how data moves* at a glance — four Mermaid diagrams
 covering the two subsystems and the bridge between them.

--- a/docs/deploy/azure-vm.md
+++ b/docs/deploy/azure-vm.md
@@ -1,0 +1,258 @@
+# Deploying to a single Azure VM (or any VPS)
+
+Lift-and-shift runbook for the current architecture. It maps 1:1 to what the
+app needs at runtime, so it works on a plain VPS or an Azure VM identically —
+"push to Azure" here just means "an Azure Linux VM running this stack."
+
+> Not yet suitable for multi-replica / autoscale. The app keeps per-session run
+> state, the sandbox `AttachmentTable`, and background jobs **in process memory**,
+> so it runs as a **single long-lived instance**. Scaling out first needs the
+> state externalized (#105) and the sandbox made remote (#78).
+
+---
+
+## Topology (one VM)
+
+```
+                         Internet
+                            │  443 / 80
+                    ┌───────▼────────┐
+                    │     Caddy      │  TLS termination (auto Let's Encrypt)
+                    └───────┬────────┘
+                            │  127.0.0.1:3000
+        ┌───────────────────▼───────────────────┐
+        │  UI (SolidStart)  — systemd, on host   │  `pnpm start` (vinxi start)
+        │  • shells `docker run` for sandboxes    │  needs docker CLI + node-pty
+        │  • node-pty for the Shell terminal      │  cwd = ui/  (resolves ../configs)
+        └───┬───────────┬──────────┬─────────┬────┘
+   localhost│           │          │         │ /var/run/docker.sock
+      5432  │      7687 │     8811 │    8090 │ (sandbox + gateway spawn containers)
+   ┌────────▼──┐ ┌──────▼───┐ ┌────▼─────┐ ┌─▼──────────┐
+   │ postgres  │ │  neo4j   │ │ mcp-     │ │ embeddings │   ← `docker compose`,
+   │  :5432    │ │  :7687   │ │ gateway  │ │ (optional) │     ports bound to
+   │ (convos)  │ │(apoc+n10s)│ │ :8811    │ │  :8090     │     127.0.0.1 only
+   └───────────┘ └──────────┘ └────┬─────┘ └────────────┘
+   redis-stack :6379 (DataStash)   │ mounts docker.sock, spawns 1 container/MCP-server
+```
+
+**Why the UI runs on the host, not in a container:** it shells out to
+`docker run -d --rm …` for compute sandboxes (`docker-backend.server.ts:291`) and
+uses `node-pty` for the Shell terminal. There is **no UI Dockerfile** today (only
+`rootfs/Dockerfile`, which is the sandbox image). Running the UI as a host
+`systemd` service gives it a native `docker` CLI and native `node-pty` with the
+least friction. Containerizing it later is possible but needs a socket mount +
+`docker` CLI in the image + native rebuild.
+
+---
+
+## 1. Provision the VM
+
+- **Architecture: x86 / amd64.** This sidesteps the redis-stack arm64 SIGILL bug
+  (see `docker-compose.override.yml`); on x86 the native image just works, delete
+  that override.
+- **Size:** start around **4 vCPU / 16 GB** (e.g. Azure `Standard_D4s_v5`). Neo4j
+  (+apoc+n10s), redis-stack, Postgres, the Node server, *and* N concurrent sandbox
+  containers all share this box. Bump RAM if you raise the sandbox cap.
+- **OS:** Ubuntu 22.04 / 24.04 LTS.
+- **Disk:** Premium SSD, 64 GB+ (Docker images + the three data volumes).
+- **Network security group — open only:**
+  - `22` (SSH) — ideally restricted to your IP.
+  - `80` + `443` (Caddy).
+  - **Nothing else.** Postgres/Redis/Neo4j/gateway stay on `127.0.0.1` (step 4).
+
+## 2. Install prerequisites
+
+```bash
+# Docker Engine + compose plugin
+curl -fsSL https://get.docker.com | sh
+sudo usermod -aG docker "$USER"   # log out/in so the UI service user can use docker
+
+# Node 22 + pnpm (via corepack)
+curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
+sudo apt-get install -y nodejs
+sudo corepack enable && corepack prepare pnpm@latest --activate
+
+# Caddy (reverse proxy + auto-TLS)
+sudo apt-get install -y debian-keyring debian-archive-keyring apt-transport-https
+# ...add Caddy's apt repo, then:
+sudo apt-get install -y caddy
+```
+
+## 3. Code + configs
+
+```bash
+sudo git clone <repo> /opt/kg-agent && cd /opt/kg-agent
+```
+
+Keep the repo layout intact — **`ui/` and `configs/` must stay siblings**: the
+server resolves the MCP catalog via `path.resolve(process.cwd(), '..', 'configs', …)`
+with cwd = `ui/` (`server-catalog.server.ts:42`).
+
+Create the git-ignored config files with **real** values:
+- **`configs/mcp-config.yaml`** — the enabled-servers list + secrets (GitHub PAT,
+  neo4j password, …). Per #88, scope the GitHub token to **public/read-only** and
+  pre-provision statically; there is no runtime secret-setting on a Linux host.
+- **`docker-config.json`** — Docker registry auth so the gateway can pull MCP
+  server images (mounted read-only into the gateway).
+- **`ui/.env`** — see the env table in step 9.
+
+## 4. Harden the compose stack for a public host ⚠️
+
+The committed `docker-compose.yaml` publishes Postgres, Redis, Neo4j, and the
+gateway on `0.0.0.0`. **On a public VM that is an internet-exposed database.**
+Add a server-side `docker-compose.override.yml` (git-ignored) binding every
+published port to loopback, and change the default passwords:
+
+```yaml
+# /opt/kg-agent/docker-compose.override.yml  (production)
+services:
+  postgres:
+    ports: ["127.0.0.1:5432:5432"]
+    environment: ["POSTGRES_PASSWORD=<STRONG_PW>"]
+  neo4j:
+    ports: ["127.0.0.1:7474:7474", "127.0.0.1:7687:7687"]
+    environment: ["NEO4J_AUTH=neo4j/<STRONG_PW>"]
+  redis:
+    ports: ["127.0.0.1:6379:6379"]
+  mcp-gateway:
+    ports: ["127.0.0.1:8811:8811"]
+  # (drop the arm64 `platform: linux/amd64` override — you're on x86 now)
+```
+
+The UI reaches all of these over `localhost`, so loopback binding is transparent
+to the app and closes the exposure.
+
+## 5. Bring up the backing tier
+
+```bash
+cd /opt/kg-agent
+docker compose up -d                 # neo4j, postgres, redis-stack, mcp-gateway (+ n8n if wanted)
+docker compose ps                    # all healthy?
+
+# Build the sandbox base image — the compute sandbox needs it or every run fails
+docker build -t kg-sandbox:base rootfs/     # matches SANDBOX_IMAGE default
+```
+
+## 6. Build + run the UI (systemd)
+
+```bash
+cd /opt/kg-agent/ui
+pnpm install --frozen-lockfile      # builds node-pty natively for node 22
+pnpm baml-generate                  # generate baml_client/ (also run by build)
+pnpm build                          # vinxi build → .output/
+```
+
+`/etc/systemd/system/kg-agent.service`:
+
+```ini
+[Unit]
+Description=kg-agent UI (SolidStart)
+After=network-online.target docker.service
+Requires=docker.service
+
+[Service]
+Type=simple
+User=kgagent                        # a user in the `docker` group
+WorkingDirectory=/opt/kg-agent/ui   # cwd must be ui/ so ../configs resolves
+EnvironmentFile=/opt/kg-agent/ui/.env
+Environment=PORT=3000
+Environment=HOST=127.0.0.1
+ExecStart=/usr/bin/pnpm start       # vinxi start — serves .output/
+Restart=on-failure
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```bash
+sudo systemctl daemon-reload && sudo systemctl enable --now kg-agent
+journalctl -u kg-agent -f
+```
+
+## 7. Embeddings backend (only if you use DataStash / retriever search)
+
+The Data Stash pipeline needs an embedder. Two options:
+- **Self-host** a `llama-server --embedding` on `:8090` (needs the GGUF model on
+  disk) as its own systemd unit, and set `EMBEDDINGS_PROVIDER=local` +
+  `EMBEDDINGS_LOCAL_URL=http://127.0.0.1:8090`.
+- **Hosted provider** — set `EMBEDDINGS_PROVIDER` to a remote provider instead.
+
+If you don't use DataStash search, you can skip this.
+
+## 8. Reverse proxy + TLS
+
+`/etc/caddy/Caddyfile`:
+
+```
+your.domain.com {
+    reverse_proxy 127.0.0.1:3000
+}
+```
+
+```bash
+sudo systemctl reload caddy    # auto-provisions a Let's Encrypt cert
+```
+
+## 9. Environment reference (`ui/.env`)
+
+Every var the server reads (`grep process.env src/`), with its localhost default:
+
+| Var | Purpose | Default / note |
+|---|---|---|
+| `ANTHROPIC_API_KEY` | **Required** — all default BAML chains | — |
+| `USE_MIXED_CHAINS` | `1` to use mixed-provider chains | unset = Anthropic-only |
+| `OPENROUTER_API_KEY` | mixed chains + possibly embeddings | needed iff `USE_MIXED_CHAINS=1` |
+| `DATABASE_URL` | Postgres (conversations) | `postgresql://postgres:password@localhost:5432/kgagent` — **override the password** |
+| `MCP_GATEWAY_URL` | MCP gateway endpoint | `http://localhost:8811/mcp` |
+| `NEO4J_USER` / `NEO4J_PASSWORD` | direct Neo4j driver | resolves to `bolt://localhost:7687` on host (`config/endpoints.ts:37`) |
+| `COMPUTE_BACKEND` | sandbox backend | `docker` (firecracker `#78` not implemented) |
+| `SANDBOX_IMAGE` | sandbox container image | `kg-sandbox:base` (built in step 5) |
+| `DOCKER_BIN` | docker CLI path | `docker` |
+| `EMBEDDINGS_PROVIDER` / `EMBEDDINGS_LOCAL_URL` / `EMBEDDINGS_LOCAL_MODEL` | DataStash embedder | see step 7 |
+| `STACK_SECRET_SERVER_KEY` | auth (Stack Auth) | configure a real project; **do not** ship `DEV_BYPASS_AUTH=true` to prod |
+
+> Redis is **not** a direct env connection — all Redis access is via the gateway's
+> redis MCP server, so there's no `REDIS_URL` to set.
+
+## 10. Operations
+
+**Update / redeploy:**
+```bash
+cd /opt/kg-agent && git pull
+cd ui && pnpm install --frozen-lockfile && pnpm build
+sudo systemctl restart kg-agent
+docker compose pull && docker compose up -d   # only if the gateway image moved
+```
+
+**Logs:** `journalctl -u kg-agent` (UI) · `docker compose logs -f mcp-gateway` (gateway).
+
+**Backups:** snapshot the three named volumes — `neo4j_data`, `postgres_data`,
+`redis_data` — on a schedule (Azure Disk snapshots, or `pg_dump` + `neo4j-admin
+dump` + Redis RDB). These hold all conversations, the graph, and the Data Stash.
+
+**Sandbox hygiene:** the startup reaper (#97) force-removes orphaned
+`kg-sandbox=1` containers on boot; check with
+`docker ps --filter label=kg-sandbox=1`. Manual reap:
+`docker ps -aq --filter label=kg-sandbox=1 | xargs -r docker rm -f`.
+
+## 11. Known gaps before this is "real prod"
+
+- **Single instance, no HA.** In-memory run/sandbox state means no horizontal
+  scale and a restart orphans in-flight runs. Externalizing that is #105 (+ a
+  durable-run worker) and #78 (remote sandbox).
+- **Secrets are file-based.** Upgrade path: Azure Key Vault → an
+  `EnvironmentFile` populated at boot (VM managed identity), instead of a
+  plaintext `ui/.env` + `configs/mcp-config.yaml`.
+- **Auth.** Confirm a real Stack Auth project (or the email allow-list) is wired
+  and `DEV_BYPASS_AUTH` is off.
+- **No UI Dockerfile.** If you later want everything under compose, add one
+  (socket mount + docker CLI in-image + native `node-pty` rebuild).
+
+## 12. Azure niceties (optional)
+
+- **Key Vault** for `ANTHROPIC_API_KEY` / DB passwords / the GitHub PAT, fetched
+  into the systemd `EnvironmentFile` via the VM's managed identity.
+- **Azure Backup** on the data disk instead of hand-rolled volume dumps.
+- **cloud-init / setup script** to make the box reproducible (steps 2–8 as a
+  provisioning script) — worth doing once you've validated the manual path.

--- a/docs/harness-patterns/README.md
+++ b/docs/harness-patterns/README.md
@@ -35,7 +35,6 @@ MCP Tools ───────┘
 | `router` | Intent-based dispatch | Multi-capability agents |
 | `synthesizer` | Response generation | Human-readable output |
 | `compactIntent` | Rewrite latest message → self-contained `data.intent` | Router-less multi-turn agents ([#83](https://github.com/mknw/harness-playground/issues/83)) |
-| `withApproval` | User approval gate | Write operations |
 | `withReferences` | LLM-curated prior-result attachment at pattern ingress | Cross-pattern data flow ([#30](with-references.md)) |
 | `parallel` | Concurrent execution | Multi-source search |
 | `judge` | Quality ranking | Best-of-N selection |

--- a/docs/harness-patterns/api.md
+++ b/docs/harness-patterns/api.md
@@ -171,25 +171,6 @@ interface ActorCriticConfig extends PatternConfig {
 }
 ```
 
-### withApproval
-
-Wrap pattern to pause for user approval.
-
-```typescript
-function withApproval<T>(
-  pattern: ConfiguredPattern<T>,
-  predicate: ApprovalPredicate,
-  config?: PatternConfig
-): ConfiguredPattern<T>
-
-type ApprovalPredicate = (action: ControllerAction) => boolean
-
-// Built-in predicates
-approvalPredicates.writes     // tool_name includes 'write'
-approvalPredicates.deletes    // tool_name includes 'delete'
-approvalPredicates.mutations  // write, delete, create, update, insert, remove
-```
-
 ### withReferences
 
 Wrap a pattern so that on entry, an LLM-driven selector picks relevant prior `tool_result` events and attaches them to the inner pattern's `priorResults` channel via `scope.data.attachedRefs`. See [`with-references.md`](with-references.md) for full design + selection cases.
@@ -604,7 +585,6 @@ interface ViewConfig {
 | compactIntent | `'intent_compacted'` | `'always'` |
 | router | `false` | `'always'` |
 | chain | `false` | `'always'` |
-| withApproval | `false` | `'on-success'` |
 
 ---
 

--- a/docs/harness-patterns/examples.md
+++ b/docs/harness-patterns/examples.md
@@ -1,6 +1,6 @@
 # Harness Pattern Examples
 
-Catalog of 6 pre-built agents demonstrating pattern compositions.
+Catalog of 7 pre-built agents demonstrating pattern compositions.
 
 > **Full Code:** See [`ui/src/lib/harness-client/examples/`](../../ui/src/lib/harness-client/examples/) for complete implementations.
 
@@ -16,8 +16,9 @@ All agents are registered in `registry.server.ts` and available via `getAgentLis
 | `code-mode` | Code Mode Agent | router → actorCritic → synthesizer | all (via code-mode factory) |
 | `multi-source-research` | Multi-Source Research | parallel → judge → synthesizer | web_search, github, context7 |
 | `conversational-memory` | Conversational Memory | sessionTracker → router → memoryWriter → synthesizer | memory, neo4j, web_search, redis |
-| `kg-builder` | Knowledge Graph Builder | simpleLoop → simpleLoop → withApproval(simpleLoop) → synthesizer | web_search, memory, neo4j |
 | `sandbox-session` | Sandbox · Session | compactIntent → withSandbox(actorCritic) → synthesizer | none (in-VM sandbox tools) |
+| `retriever` | Retriever Agent | router → { retriever \| neo4j \| web_search } → synthesizer | neo4j, web_search, fetch (+ Data Stash via Redis retriever) |
+| `flavoured-sandbox` | Sandbox · Flavoured (router) | router → withSandbox(actorCritic) per flavour (base / image-processing / data) → synthesizer | none (in-VM sandbox tools per flavour) |
 
 ---
 
@@ -40,7 +41,7 @@ router({ neo4j: '...', web_search: '...' })
 - Web search via DuckDuckGo (`search`, `fetch`, `fetch_content`)
 - Cross-turn data flow: `withReferences` selector attaches relevant prior refs at each route's ingress; the controller can use `expandPreviousResult` or pass `ref:<id>` in tool args to inline-expand the full data
 
-For JS-orchestration workflows that span multiple servers, see [Agent 5 — Code Mode](#5-code-mode-agent).
+For JS-orchestration workflows that span multiple servers, see [Agent 4 — Code Mode](#4-code-mode-agent).
 
 ---
 
@@ -76,22 +77,7 @@ synthesizer
 
 ---
 
-## 4. Knowledge Graph Builder
-
-**File:** `kg-builder.server.ts`
-
-Research → Extract → Persist pipeline.
-
-```
-simpleLoop(WebSearchController)  → research topic
-simpleLoop(MemoryController)     → extract entities/relations
-withApproval(simpleLoop(Neo4jController)) → persist to graph
-synthesizer
-```
-
----
-
-## 5. Code Mode Agent
+## 4. Code Mode Agent
 
 **File:** `code-mode.server.ts`
 
@@ -165,4 +151,4 @@ registerAgent(myAgent)
 
 ---
 
-**Last Updated:** 2026-02-12
+**Last Updated:** 2026-07-23

--- a/docs/harness-patterns/frontend.md
+++ b/docs/harness-patterns/frontend.md
@@ -314,13 +314,10 @@ async function createPatterns(): Promise<ConfiguredPattern<SessionData>[]> {
   const neo4jController = createNeo4jController(tools.neo4j ?? [])
   const webController = createWebSearchController(tools.web ?? [])
 
-  const neo4jPattern = withApproval(
-    simpleLoop(neo4jController, tools.neo4j ?? [], {
-      patternId: 'neo4j-query',
-      schema
-    }),
-    approvalPredicates.writes
-  )
+  const neo4jPattern = simpleLoop(neo4jController, tools.neo4j ?? [], {
+    patternId: 'neo4j-query',
+    schema
+  })
 
   const webPattern = simpleLoop(webController, tools.web ?? [], {
     patternId: 'web-search'

--- a/docs/plan/ROADMAP.md
+++ b/docs/plan/ROADMAP.md
@@ -1,0 +1,134 @@
+# Roadmap — multi-user aspirational shape
+
+> **Status: active plan.** Converged 2026-07-14/16. Live tracking on the
+> [GitHub project board](https://github.com/users/mknw/projects/5) (the `MSCW`
+> field mirrors the Must/Should/Could/Won't ratings below); this file holds the
+> *shape* — phases, dependencies, and the architecture the phases build toward.
+> Update both together.
+
+## Target architecture
+
+Two reframes drive everything:
+
+1. **The MCP gateway is the *shared/org-identity* tool boundary — not the
+   one-shop for all tools.** Anything needing *per-user* identity is an
+   **app-side tool template**: the server resolves the user's token/secret from
+   the authenticated `userId` at call time (the generalized `neo4j-driver`
+   shape). The tool schema exposed to the model has **no token field**; secrets
+   never enter prompt/context/event log (#107 principle 1).
+2. **Isolation is physical, never LLM self-scoping.** The LLM writes arbitrary
+   Cypher/queries, so scoping binds to the *connection* (per-user database,
+   user-keyed prefix, Entra-delegated token) — not to query text (#107
+   principle 2).
+
+```
+ User (browser / iOS shortcut)
+        │  Entra SSO (OIDC)  ←──────────── #119: THE foundation
+        ▼
+┌──────────────────────────────────────────────────────────────┐
+│  App server — SolidStart, single VM (compose + Caddy)          │
+│  authenticated userId → runWithUserId(...)                     │
+│                                                                │
+│  ┌──────────────────────────────────────────────────────────┐│
+│  │ Server-side credential resolver — never a tool arg         ││
+│  │  Pattern A (#108)      Pattern C (#110)     Pattern B (#109)││
+│  │  org identity          Entra OBO            per-user vault  ││
+│  │                                              [deferred]     ││
+│  └───┬──────────────────────┬─────────────────────────────────┘│
+│      ▼                       ▼                                  │
+│  ┌─────────┐        ┌──────────────────┐                       │
+│  │  MCP    │        │ App-side tool     │                       │
+│  │ gateway │        │ templates         │                       │
+│  │ (shared │        │ MS Graph via OBO  │                       │
+│  │ org id) │        │ (mailbox/calendar)│                       │
+│  └────┬────┘        └──────────────────┘                       │
+│   fetch/web/context7/fs/playwright/redis/github(App token)/…   │
+│  ┌──────────────────────────────────────────────────────────┐ │
+│  │ Data layer — per-user scoped                               │ │
+│  │  Neo4j/DozerDB db-per-user (#121) · Postgres · Redis       │ │
+│  │  (user-keyed) · encrypted MSAL refresh cache ── Key Vault  │ │
+│  └──────────────────────────────────────────────────────────┘ │
+└──────────────────────────────────────────────────────────────┘
+```
+
+Deployment stays **single VM + `docker compose up -d` + Caddy** for this whole
+cycle (see [`../deploy/azure-vm.md`](../deploy/azure-vm.md)); the app keeps
+per-session state in process memory, so multi-replica is out of scope until
+that state is externalized.
+
+## Critical-path spine
+
+```
+                        ┌─ Pattern A RBAC (#108) ──┬─ per-user Neo4j / DozerDB (#121)
+Entra SSO (#119) ──────►├─ #106 live smoke test     ├─ per-user Redis objects
+(external lead time:    ├─ per-user data everywhere
+ tenant owner)          └─ Pattern C OBO (#110) ◄── MSAL refresh cache on Key Vault
+
+auth-independent, start now: gateway client pool (#120) · prompt caching (#122)
+                             multi-session (#105) · sandbox sweep+cap (#82)
+```
+
+**#119 (Entra SSO) gates five workstreams and carries external lead time**
+(tenant owner: app registration + admin consent). Start that conversation
+first; everything in Phase 0 proceeds in parallel meanwhile.
+
+## Phases
+
+### Phase 0 — concurrency floor + quick wins *(auth-independent, in parallel)*
+
+| MSCW | Item | Why now |
+|---|---|---|
+| **Must** | #120 gateway client pool + connection-scoped reconnect | One user's transport reconnect currently tears down every other user's in-flight gateway call (`mcp-client.server.ts` singleton). Correctness floor for #105 and multi-user. |
+| **Must** | #105 PR 1 — reattach live view on switch-back + sidebar spinner | The "interrupted conversation" complaint; backend continuity already exists. |
+| **Should** | #122 Anthropic prompt caching (BAML `cache_control`) | Router→Controller→Critic→Synth chains re-send stable prefixes within seconds; textbook cache shape. |
+| **Should** | #82 sandbox timer-driven sweep + LRU cap | Last open sandbox-lifecycle gap (#97 closed). |
+| **Could** | #105 PR 2 — multi-active cap ("max N reached — wait for a session to stop") | Policy layer over PR 1's plumbing. |
+
+### Phase 1 — identity foundation *(the gate)*
+
+| MSCW | Item | Notes |
+|---|---|---|
+| **Must** | #119 Entra SSO (replace/federate Stack Auth) | Company is on M365 → Entra is the IdP; also the prerequisite for OBO (#110). |
+| **Must** | Thread real `userId` through the gaps | `configs/action-tokens.yaml` → Entra ids (**#106 live smoke test**), per-user Redis keys (Local/Global objects), session scoping. |
+
+### Phase 2 — data isolation + shared tools (Pattern A)
+
+| MSCW | Item | Notes |
+|---|---|---|
+| **Must** | #108 Pattern A: GitHub App installation token, app-side RBAC, server-side data scoping | Properly closes #88's GitHub-token task. |
+| **Should** | #121 per-user Neo4j via DozerDB | Physical db-per-user; agentic path routed app-side (gateway can stop holding the Neo4j secret). Cross-user analytics = app-side fan-out (DozerDB has no Fabric/composite yet). |
+
+### Phase 3 — Microsoft per-user identity *(narrowed by the MS-only decision)*
+
+| MSCW | Item | Notes |
+|---|---|---|
+| **Must** | OBO MS Graph tool template + encrypted MSAL refresh cache (Azure Key Vault) | The one tool template needed this cycle; the refresh cache also serves async agent-trigger runs (no live user session). Closes #88's secrets posture. |
+| **Must** | #110 Pattern C: Entra OBO for M365 mailbox / calendar / personal Graph | Entra enforces per-user scope (delegated) — no hand-rolled scoping guard. |
+| **Should** | M365 SharePoint / org reference data via Graph **application** token + server-side scoping | Pattern A flavor of Graph. |
+
+### Phase 4 — scale headroom
+
+| MSCW | Item | Notes |
+|---|---|---|
+| **Should** | Tiered credential-profile gateway replicas (standard vs privileged) | The #107 "gateway concurrency" axis beyond the client pool. |
+| **Should** | #105 PR 3 — real mid-run cancellation (abort token through the harness) | Only if wait-at-cap proves insufficient; same primitive a durable-run worker needs. |
+| **Should** | #116 sandbox flavour guardrails / hardening | Open-sandbox tool surface, egress. |
+| **Could** | Horizontal gateway replicas | |
+
+### Won't-have *(this cycle — explicit)*
+
+| Item | Why deferred |
+|---|---|
+| #109 Pattern B per-user vault (Google/Slack/personal GitHub) | **MS-only decision 2026-07-14**; re-promote when a concrete non-MS per-user connector need appears. |
+| #78 Firecracker microVM substrate | Flavours shipped (#117); compose-on-VM deploy needs no docker-daemon externalization now. |
+| #87 MCP catalog hot-swap | Superseded in spirit by #88/#107 static-provisioning posture. |
+| #76 / #77 GenUI, #73 / #75 Ontology agents | Net-new bets off the multi-user critical path; deserve their own planning conversation. |
+| AKS / multi-replica app tier | Blocked on state externalization regardless; single VM suffices at 30 users. |
+
+## Standing decisions this plan encodes
+
+- **~30 users forecast**; single-instance, persistent Node server.
+- **Deploy = Azure VM (or any VPS) + compose + Caddy** — [`../deploy/azure-vm.md`](../deploy/azure-vm.md).
+- **MS-only per-user identity this cycle**; org-wide tokens + app-side RBAC where org scope is acceptable (#108); Entra OBO where personal scope is required (#110).
+- **Per-user graph = DozerDB db-per-user** (#121) — free, drop-in on Neo4j 5.26; accepts no-RBAC + no-Fabric limits at this scale.
+- **Sandbox**: Docker backend with `base`/`image-processing`/`data`/`office` flavours (shipped #117); Firecracker deferred — see [`sandbox.md`](sandbox.md).

--- a/docs/plan/sandbox.md
+++ b/docs/plan/sandbox.md
@@ -1,12 +1,12 @@
 # Sandbox Compute Infrastructure (Plan)
 
-> **Status: plan, not yet implemented.** This documents the intended shape. Several primitives it composes with (`parallel`, `parallelMap`, `withApproval`, `judge`) are untested or unbuilt — see caveats inline. Once `withSandbox` ships, the durable API description moves to [`ui/src/lib/harness-patterns/README.md`](../ui/src/lib/harness-patterns/README.md); this file stays the project-scoped plan.
+> **Status: core shipped; forward-looking sections remain the plan.** `withSandbox` + DockerBackend shipped in PR #81 (#79); durable `/work` ⇄ DataStash workspaces in PR #95 (#89); lifecycle hardening (startup reaper, health-check on reuse, Shell-hydrate) in PRs #103/#104 (#97); rootfs flavours (`image-processing`/`data`/`office`) + the router-over-flavours recipe in PR #117 (#78). The durable API lives in [`ui/src/lib/harness-patterns/README.md`](../../ui/src/lib/harness-patterns/README.md); operational debugging in [`../sandbox/README.md`](../sandbox/README.md); flavours in [`../sandbox-flavours.md`](../sandbox-flavours.md). Still plan-only: **Swarm** (parallel strategies), **Firecracker substrate** (#78), **ephemeral one-shot mode**, timer-driven sweep + LRU cap (#82), and the "Deferred / v1+" section.
 
 Reference design for `withSandbox` — a harness wrapper that attaches a stateful, isolated microVM to a controller pattern, exposing filesystem / shell / Python tools to the actor via MCP servers running *inside* the VM. See [#79](https://github.com/mknw/harness-playground/issues/79) for the implementation story and [#78](https://github.com/mknw/harness-playground/issues/78) for the capability vision (Polars over user-uploaded files, document extraction, NER pipelines, …).
 
 This document is the infrastructure design — wrapper API, attachment model, MCP-in-VM architecture, backend interface, substrate options, lifecycle, failure modes. It does **not** cover:
 - Why we want this (see #78)
-- Rootfs flavor catalog beyond the v0 minimum (see #78 → "Rootfs flavors"; the first `image-processing` + `data` flavours are specced in [`sandbox-flavours.md`](sandbox-flavours.md))
+- Rootfs flavor catalog beyond the v0 minimum (see #78 → "Rootfs flavors"; the first `image-processing` + `data` flavours are specced in [`sandbox-flavours.md`](../sandbox-flavours.md))
 - `backgroundSession` (a v2 primitive, orthogonal to `withSandbox`; outlined under "Deferred / v1+")
 
 > **Design-conversation note.** An earlier draft of this doc was scaffolded too early, before the load-bearing architectural choices were probed. The current shape was reached by sampling the option space first and converging with the user before writing. Keep that ordering. See CLAUDE.md → "Design Decisions" → "Probe before scaffolding."
@@ -15,7 +15,7 @@ This document is the infrastructure design — wrapper API, attachment model, MC
 
 ## What `withSandbox` is
 
-A wrapper, not a leaf pattern. It composes like `withReferences` and `withApproval`:
+A wrapper, not a leaf pattern. It composes like `withReferences`:
 
 ```typescript
 withSandbox({
@@ -33,14 +33,14 @@ The wrapped pattern's controller (e.g., `actorCritic`, `simpleLoop`) gains the s
 
 **Canonical use case:** in-chat data analysis. Agent is asked to operate on a spreadsheet or document, runs Python inside the sandbox, answers in chat. Same shape for format conversion, extraction, profiling — the conversation changes, the wrapper doesn't.
 
-The wrapper composes orthogonally with everything already in the harness — `chain(withSandbox(actorCritic), synthesizer)`, `withSandbox(chain(simpleLoop, synthesizer, actorCritic))`, `router → routes({…: withSandbox(coder)})`, `withReferences(withSandbox(actorCritic))`. Wrapper patterns (`chain`, `router`, `routes`, `withReferences`, `withApproval`) and individual agents need **no** changes — the sandbox handle propagates to nested tool-calling controllers automatically (see [How tools reach the controller](#how-tools-reach-the-controller)). The only code that becomes sandbox-aware is the two controllers that actually dispatch tools.
+The wrapper composes orthogonally with everything already in the harness — `chain(withSandbox(actorCritic), synthesizer)`, `withSandbox(chain(simpleLoop, synthesizer, actorCritic))`, `router → routes({…: withSandbox(coder)})`, `withReferences(withSandbox(actorCritic))`. Wrapper patterns (`chain`, `router`, `routes`, `withReferences`) and individual agents need **no** changes — the sandbox handle propagates to nested tool-calling controllers automatically (see [How tools reach the controller](#how-tools-reach-the-controller)). The only code that becomes sandbox-aware is the two controllers that actually dispatch tools.
 
 It composes with `parallel` / `parallelMap` too, with semantics that depend on **which side** of the parallel the wrapper sits:
 
 - **Wrapper inside the branches** — `parallel(withSandbox(chainA), chainB)` or `parallelMap(items, i => withSandbox(chain(...)))`. Each wrapped branch gets its own sandbox via auto-attachment; unwrapped branches (e.g. `chainB`) run normally with no sandbox — not every branch needs one. No state collision. This is the useful direction — see "Swarm" below.
 - **Wrapper outside the parallel** — `withSandbox(parallel(branchA, branchB))`. All branches share one sandbox and state can collide. No compelling use case identified, so not a focus.
 
-**Caveat — these rest on untested or unbuilt primitives.** `parallel` has never been exercised, `parallelMap` does not exist yet, and `withApproval` / `judge` are likewise untested. The compositions here are structurally sound but depend on primitives that need building and hardening first. Treat them as design intent, not shipping capability.
+**Caveat — these rest on untested or unbuilt primitives.** `parallel` has never been exercised, `parallelMap` does not exist yet, and `judge` is untested; `withApproval` was removed outright (#125 — it never actually paused) with the supervision redesign tracked in #123. The compositions here are structurally sound but depend on primitives that need building and hardening first. Treat them as design intent, not shipping capability.
 
 ---
 
@@ -93,7 +93,7 @@ HOST  (Linux + KVM in production; macOS via Docker fallback)
 
 - **No session-routing in the gateway.** Each VM is a self-contained MCP endpoint. "Which sandbox?" is implicit in the connection. The host gateway stays a static, host-level service for shared infra (Neo4j, web, GitHub).
 - **No second deployable.** The "code at the project root" is `rootfs/` — image definition + init scripts, same shape as `docker-compose.yml`. There is no separate `vmPoolManager` daemon to build or supervise.
-- **Reuse existing MCP server images.** [`rust-mcp-filesystem`](../configs/custom-catalog.yaml) gives us read/write/edit/list/search out of the box; a JS shell-exec MCP gives us `bash`. We don't author MCP servers for v0.
+- **Reuse existing MCP server images.** [`rust-mcp-filesystem`](../../configs/custom-catalog.yaml) gives us read/write/edit/list/search out of the box; a JS shell-exec MCP gives us `bash`. We don't author MCP servers for v0.
 
 **Alternatives explicitly considered and rejected:**
 
@@ -129,7 +129,7 @@ The two controllers, the `callTool` dispatch layer, and the BAML adapters are ch
 
 **What this buys composition:**
 
-- `chain`, `router`, `routes`, `withReferences`, `withApproval` are **unchanged** — they don't dispatch tools, and ALS propagates through their `await`s.
+- `chain`, `router`, `routes`, `withReferences` are **unchanged** — they don't dispatch tools, and ALS propagates through their `await`s.
 - `withSandbox(chain(simpleLoop, synthesizer, actorCritic))` shares **one** sandbox across all of the chain's children for free: `simpleLoop` and `actorCritic` both read the same handle from ALS (a file one writes to `/work` is visible to the other); `synthesizer` simply never touches the scope. No `sandbox` parameter is threaded through `chain`.
 - **Placement is the design lever.** Wrapping the whole chain → shared workspace across children. Wrapping a single child (`chain(withSandbox(actorCritic), synthesizer)`) → only that child sees the sandbox, and it's torn down before the synthesizer runs.
 
@@ -282,7 +282,7 @@ A container is disposable; the workspace shouldn't be. The 5-minute-class idle w
 
 - **Hydrate** — on first boot only (tracked by `Attachment.isFirstBoot`), `listDocuments(sessionId)` → write each into `/work/in`. Reused live attachments skip this, so a multi-turn session doesn't re-hydrate every turn.
 - **Promote** — snapshot `/work/out` (in-VM `sha256sum`) at turn entry, diff at exit, and `storeDocument` each new/changed file. Runs in a `finally`, so deliverables are saved even if the turn throws. Deletions are ignored (promotion never removes stored docs).
-- **Binary-faithful** — text files store verbatim; everything else (xlsx, pdf, images) moves as base64 staged through a `.b64` text file (the in-VM filesystem MCP is text-only) and is stored with `encoding: 'base64'`. See [DATA_STASH.md → Storage model](DATA_STASH.md#storage-model-redis).
+- **Binary-faithful** — text files store verbatim; everything else (xlsx, pdf, images) moves as base64 staged through a `.b64` text file (the in-VM filesystem MCP is text-only) and is stored with `encoding: 'base64'`. See [DATA_STASH.md → Storage model](../DATA_STASH.md#storage-model-redis).
 
 **Boundaries.** Only the `{ id }` path syncs; anonymous (`withSandbox({})`) and one-shot (`{ fresh: true }`) sandboxes have no session identity and are untouched. Sync requires the MCP gateway (the DataStash lives in Redis). The window in which a *live* container is reused before falling back to hydrate-from-store is the warm-cache horizon — see `idleEvictMs` in [Settings](#settings).
 
@@ -290,10 +290,10 @@ A container is disposable; the workspace shouldn't be. The 5-minute-class idle w
 
 ## Swarm: parallel strategies, pick a winner (forward-looking)
 
-A composition the wrapper enables, but which depends on primitives that don't exist or aren't tested yet (`parallelMap`, `withApproval`, `judge`):
+A composition the wrapper enables, but which depends on primitives that don't exist yet (`parallelMap`, `judge`, and the #123 supervision gate — the removed `withApproval` predecessor):
 
 ```typescript
-withApproval(                              // user picks the winner — UNTESTED
+superviseGate(                             // user picks the winner — #123, NOT BUILT
   parallelMap(strategies, (strategy) =>    // N branches, one sandbox each — DOESN'T EXIST YET
     withSandbox(
       chain(actorCritic, synthesizer)      // a full agentic loop per strategy
@@ -483,4 +483,4 @@ Open problems `backgroundSession` surfaces (all genuinely v2):
 - [GitHub Project — "Harness Playground tasks"](https://github.com/users/mknw/projects/5) — where this fits in the broader plan
 - [#79](https://github.com/mknw/harness-playground/issues/79) — implementation story
 - [#78](https://github.com/mknw/harness-playground/issues/78) — capability vision + rootfs flavor catalog
-- [`ui/src/lib/harness-patterns/README.md`](../ui/src/lib/harness-patterns/README.md) — pattern framework overview (`withReferences`, `withApproval` are the analogous wrappers)
+- [`ui/src/lib/harness-patterns/README.md`](../../ui/src/lib/harness-patterns/README.md) — pattern framework overview (`withReferences` is the analogous wrapper)

--- a/docs/sandbox-flavours.md
+++ b/docs/sandbox-flavours.md
@@ -4,7 +4,7 @@
 > ship in this PR; the hardening/ergonomics items are tracked in
 > [#116](https://github.com/mknw/harness-playground/issues/116). Tracks
 > [#78](https://github.com/mknw/harness-playground/issues/78). Companion to
-> [`sandbox-plan.md`](sandbox-plan.md) and [`data-flow.md`](data-flow.md)
+> [`plan/sandbox.md`](plan/sandbox.md) and [`data-flow.md`](data-flow.md)
 > (attachment lifecycle + `/work` ⇄ Data Stash).
 
 ## Problem

--- a/docs/sandbox/README.md
+++ b/docs/sandbox/README.md
@@ -3,7 +3,7 @@
 Quick reference for observing what's happening inside the compute sandbox
 ([#79](https://github.com/mknw/harness-playground/issues/79)) at runtime:
 what containers exist, what's running inside them, how to peek, and how to
-clean up. Pairs with the design spec at [`docs/sandbox-plan.md`](../sandbox-plan.md).
+clean up. Pairs with the design spec at [`docs/plan/sandbox.md`](../plan/sandbox.md).
 
 For the runtime data flow — attachment lifecycle, `/work` ⇄ Data Stash sync, and
 tool dispatch / topology — see the Mermaid diagrams in
@@ -183,7 +183,7 @@ jq -r '.events[] | select(.type=="error") | .data.error' "$LOG"
 
 ## Related docs
 
-- [`docs/sandbox-plan.md`](../sandbox-plan.md) — full design spec (process
+- [`docs/plan/sandbox.md`](../plan/sandbox.md) — full design spec (process
   topology, attachment model, MCP-in-VM architecture, ALS dispatch, backend
   interface, build order).
 - [`rootfs/README.md`](../../rootfs/README.md) — how the `kg-sandbox:base`

--- a/rootfs/README.md
+++ b/rootfs/README.md
@@ -1,6 +1,6 @@
 # Sandbox rootfs (`base` flavor, v0)
 
-The image definition for sandbox VMs. See [`docs/sandbox-plan.md`](../docs/sandbox-plan.md)
+The image definition for sandbox VMs. See [`docs/plan/sandbox.md`](../docs/plan/sandbox.md)
 → "Rootfs composition (v0)" for the design. This is the only "code at the
 project root" the sandbox needs — there is no separate pool-manager daemon.
 

--- a/ui/README.md
+++ b/ui/README.md
@@ -43,7 +43,7 @@ src/
 │   ├── embeddings.server.ts     # Data Stash: provider-pluggable embeddings (#8)
 │   ├── document-ingest.server.ts # Data Stash: chunk→embed→HNSW index + KNN search
 │   ├── stash/                   # Data Stash upload HTTP helpers (parse + auth). See docs/DATA_STASH.md
-│   ├── sandbox/                 # Compute sandbox: withSandbox, Docker backend, warm pool, durable /work⇄DataStash sync (#89). See docs/sandbox-plan.md
+│   ├── sandbox/                 # Compute sandbox: withSandbox, Docker backend, warm pool, durable /work⇄DataStash sync (#89). See docs/plan/sandbox.md
 │   ├── settings.ts            # HarnessSettings type, defaults, MODEL_CONTEXT_WINDOWS
 │   ├── settings-store.ts      # Client-side reactive store (localStorage persistence)
 │   ├── settings-context.server.ts # Request-scoped settings via AsyncLocalStorage

--- a/ui/src/__tests__/lib/harness-patterns/baml-adapters.test.ts
+++ b/ui/src/__tests__/lib/harness-patterns/baml-adapters.test.ts
@@ -1036,7 +1036,7 @@ describe('extractFailureLLMCallData', () => {
 // Build-order step 3: when a `withSandbox` wrapper is active, the adapters
 // prepend the sandbox's in-VM tool descriptions to the `tools` arg passed to
 // the BAML function, so the actor sees them in its first-turn prompt without
-// the caller threading them through `toolNames`. See docs/sandbox-plan.md →
+// the caller threading them through `toolNames`. See docs/plan/sandbox.md →
 // "How tools reach the controller".
 describe('sandbox tool descriptions in prompt', () => {
   function fakeTransport() {

--- a/ui/src/__tests__/lib/harness-patterns/mcp-client.test.ts
+++ b/ui/src/__tests__/lib/harness-patterns/mcp-client.test.ts
@@ -378,7 +378,7 @@ describe('mcp-client', () => {
 
   // Build-order step 3: callTool dispatches sandbox-owned tool names to the
   // active `withSandbox` scope's in-VM transport, not the host gateway. See
-  // docs/sandbox-plan.md → "How tools reach the controller".
+  // docs/plan/sandbox.md → "How tools reach the controller".
   describe('callTool sandbox dispatch', () => {
     it('routes sandbox-owned tool names to the in-VM transport, not the gateway', async () => {
       const { callTool } = await import('../../../lib/harness-patterns/mcp-client.server')

--- a/ui/src/__tests__/lib/sandbox/end-to-end.test.ts
+++ b/ui/src/__tests__/lib/sandbox/end-to-end.test.ts
@@ -1,7 +1,7 @@
 /**
  * End-to-end integration test — `withSandbox(actorCritic(...))`.
  *
- * Build-order step 4 (see docs/sandbox-plan.md → "v0 build order"). Proves the
+ * Build-order step 4 (see docs/plan/sandbox.md → "v0 build order"). Proves the
  * full chain composes: a real `actorCritic` driven by the real BAML adapters,
  * wrapped in `withSandbox`, dispatching through real `callTool` and the real
  * ALS scope, to a real `DockerBackend` whose Docker engine and MCP SDK have

--- a/ui/src/__tests__/lib/sandbox/scope.test.ts
+++ b/ui/src/__tests__/lib/sandbox/scope.test.ts
@@ -2,7 +2,7 @@
  * Sandbox ALS scope unit tests.
  *
  * Covers `runWithSandbox` / `getActiveSandbox` propagation invariants — the
- * load-bearing primitive for build-order step 3 (see docs/sandbox-plan.md →
+ * load-bearing primitive for build-order step 3 (see docs/plan/sandbox.md →
  * "How tools reach the controller").
  */
 import { describe, it, expect, vi } from 'vitest'

--- a/ui/src/lib/harness-client/examples/README.md
+++ b/ui/src/lib/harness-client/examples/README.md
@@ -369,7 +369,7 @@ the workspace is **durable across sessions**, not just turns: stored documents
 are restored into `/work/in` on first boot and `/work/out` deliverables are
 promoted to the DataStash each turn — so an uploaded spreadsheet survives idle
 eviction, restart, and next-day reconnects. The layout contract + mechanism
-live in [`docs/sandbox-plan.md → Durable workspaces`](../../../../docs/sandbox-plan.md#durable-workspaces-89).
+live in [`docs/plan/sandbox.md → Durable workspaces`](../../../../docs/plan/sandbox.md#durable-workspaces-89).
 
 Composes any actor-style pattern with id-addressable attachment. Because this
 agent is **router-less**, `compactIntent` runs first ([#83](https://github.com/mknw/harness-playground/issues/83)

--- a/ui/src/lib/harness-patterns/baml-adapters.server.ts
+++ b/ui/src/lib/harness-patterns/baml-adapters.server.ts
@@ -345,7 +345,7 @@ async function filterToolDescriptions(
 
 /** When a `withSandbox` wrapper is active, return its in-VM tool descriptions
  *  in the adapter's `ToolDescription` shape. Outside any sandbox scope, returns
- *  `[]`. See docs/sandbox-plan.md → "How tools reach the controller". The
+ *  `[]`. See docs/plan/sandbox.md → "How tools reach the controller". The
  *  transport caches its tool list internally, so this is cheap per call. */
 async function getActiveSandboxToolDescriptions(): Promise<ToolDescription[]> {
   const sandbox = getActiveSandbox()

--- a/ui/src/lib/harness-patterns/mcp-client.server.ts
+++ b/ui/src/lib/harness-patterns/mcp-client.server.ts
@@ -101,7 +101,7 @@ export async function callTool(
   name: string,
   args: Record<string, unknown>
 ): Promise<ToolCallResult> {
-  // Sandbox dispatch (see docs/sandbox-plan.md → "How tools reach the
+  // Sandbox dispatch (see docs/plan/sandbox.md → "How tools reach the
   // controller"). When a `withSandbox` wrapper is active and the tool name
   // is owned by its in-VM transport, route there instead of the host
   // gateway. Tools not owned by the sandbox fall through to the gateway path

--- a/ui/src/lib/harness-patterns/patterns/actorCritic.server.ts
+++ b/ui/src/lib/harness-patterns/patterns/actorCritic.server.ts
@@ -80,7 +80,9 @@ export function actorCritic<T extends ActorCriticData>(
     // 1 = every turn, the original behavior). Clamped to >= 1 so a stray 0 /
     // negative value can't disable the critic — the loop's only exit authority.
     // See `ActorCriticConfig.criticCadence` and the cadence gate below.
-    const criticCadence = Math.max(1, Math.floor(config?.criticCadence ?? 1))
+    const criticCadence = Number.isFinite(config?.criticCadence)
+      ? Math.max(1, Math.floor(config!.criticCadence!))
+      : 1
     let successfulTurns = 0
     const previousAttempts: ScriptExecutionEvent[] = []
     let errorMessage: string | undefined
@@ -150,7 +152,7 @@ export function actorCritic<T extends ActorCriticData>(
           : []
         // A third augmentation: an active `withSandbox` scope's tool surface.
         // Sandbox-owned (`sandbox_*`) names pass without being listed in
-        // `tools` or `dynamicToolAllowlist` (see docs/sandbox-plan.md → "How
+        // `tools` or `dynamicToolAllowlist` (see docs/plan/sandbox.md → "How
         // tools reach the controller"). Outside any sandbox scope this is
         // a no-op.
         const sandbox = getActiveSandbox()

--- a/ui/src/lib/harness-patterns/patterns/simpleLoop.server.ts
+++ b/ui/src/lib/harness-patterns/patterns/simpleLoop.server.ts
@@ -379,7 +379,7 @@ export function simpleLoop<T extends SimpleLoopData>(
 
         // Validate tool. The static allowlist is augmented by an active
         // `withSandbox` scope's tool surface — `sandbox_*` names pass without
-        // being listed in `tools` (see docs/sandbox-plan.md → "How tools reach
+        // being listed in `tools` (see docs/plan/sandbox.md → "How tools reach
         // the controller"). Outside any sandbox scope, `getActiveSandbox()`
         // returns undefined and this collapses to the original check.
         const sandbox = getActiveSandbox()

--- a/ui/src/lib/sandbox/attachment-table.server.ts
+++ b/ui/src/lib/sandbox/attachment-table.server.ts
@@ -177,6 +177,10 @@ export class AttachmentTable {
    * entry to make room. If every entry is still in use, the cap overflows
    * rather than kill a live session — the scheduler's `globalCap` remains the
    * in-flight backstop. No-op when `maxAttachments` is unset.
+   *
+   * Soft by design under concurrency too: two boots of *different* ids can both
+   * pass this check before either inserts, transiently reaching cap+1. Not a
+   * bug — the cap bounds steady-state accumulation, not a momentary race.
    */
   private async enforceCap(): Promise<void> {
     const max = this.config.maxAttachments

--- a/ui/src/lib/sandbox/docker-backend.server.ts
+++ b/ui/src/lib/sandbox/docker-backend.server.ts
@@ -1,7 +1,7 @@
 /**
  * DockerBackend — `ComputeBackend` over the local Docker engine.
  *
- * v0 substrate (see docs/sandbox-plan.md → "Backend interface" / "macOS
+ * v0 substrate (see docs/plan/sandbox.md → "Backend interface" / "macOS
  * development"). Works on macOS dev hosts; same MCP-in-VM architecture and
  * tool surface as the future FirecrackerBackend — only boot latency and reset
  * semantics differ.

--- a/ui/src/lib/sandbox/index.server.ts
+++ b/ui/src/lib/sandbox/index.server.ts
@@ -3,7 +3,7 @@
  *
  * `withSandbox` and the (future) sandbox manager import `getComputeBackend()`
  * here rather than constructing a backend directly, so substrate choice stays
- * a single operational decision (see docs/sandbox-plan.md → "macOS
+ * a single operational decision (see docs/plan/sandbox.md → "macOS
  * development" / "Substrate options").
  */
 

--- a/ui/src/lib/sandbox/scheduler.server.ts
+++ b/ui/src/lib/sandbox/scheduler.server.ts
@@ -13,7 +13,7 @@
  * Orthogonal to `WarmPool`: the scheduler decides *whether* a sandbox may
  * exist right now, not where it comes from. `withSandbox` does
  * `scheduler.allocate(...)` first (blocks on cap), then `pool.acquire(...)`
- * (cold-boot vs. pool hit). See docs/sandbox-plan.md → "Scheduler".
+ * (cold-boot vs. pool hit). See docs/plan/sandbox.md → "Scheduler".
  *
  * Queue fairness: FIFO with skip-on-session-cap. A waiter whose session is
  * still over its per-session cap is passed over so later waiters in *other*

--- a/ui/src/lib/sandbox/scope.server.ts
+++ b/ui/src/lib/sandbox/scope.server.ts
@@ -3,7 +3,7 @@
  *
  * `withSandbox` acquires a sandbox (boot + connectMcp) and runs the wrapped
  * pattern inside an ALS scope carrying the resulting `McpTransport`. Three
- * downstream readers consult it (see docs/sandbox-plan.md → "How tools reach
+ * downstream readers consult it (see docs/plan/sandbox.md → "How tools reach
  * the controller"):
  *
  *   1. `mcp-client.callTool` — routes sandbox-owned tool names to the in-VM

--- a/ui/src/lib/sandbox/types.ts
+++ b/ui/src/lib/sandbox/types.ts
@@ -4,7 +4,7 @@
  * The `ComputeBackend` trait abstracts the substrate (Docker today,
  * Firecracker later) behind a single interface so substrate choice is
  * operational config, not application code. See
- * docs/sandbox-plan.md → "Backend interface".
+ * docs/plan/sandbox.md → "Backend interface".
  *
  * Pure types only — safe to import from anywhere. The actual backend
  * implementations live in `*.server.ts` files (server-only).
@@ -157,7 +157,7 @@ export interface InVmMcpServer {
 
 /**
  * v0 in-VM server registry — the six tools from
- * docs/sandbox-plan.md → "Tools available in v0".
+ * docs/plan/sandbox.md → "Tools available in v0".
  *
  * `launch` argv targets `/opt/mcp/init.sh serve <name>`, the stable launch
  * path baked into the rootfs (see rootfs/init.sh).

--- a/ui/src/lib/sandbox/warm-pool.server.ts
+++ b/ui/src/lib/sandbox/warm-pool.server.ts
@@ -4,7 +4,7 @@
  * Acquisition is O(ms) on a hit (return a parked VM); cold-boot via the
  * backend otherwise. Release calls `backend.reset(vm)` and parks the VM if
  * the pool has capacity; otherwise (cap reached or reset failed) destroys
- * it. See docs/sandbox-plan.md → "Warm pool".
+ * it. See docs/plan/sandbox.md → "Warm pool".
  *
  * Pool is keyed by rootfs flavor only — v0 sandboxes use settings-driven
  * defaults, so all parked VMs share a runtime fingerprint. If a future

--- a/ui/src/lib/sandbox/with-sandbox.server.ts
+++ b/ui/src/lib/sandbox/with-sandbox.server.ts
@@ -1,6 +1,6 @@
 /**
  * `withSandbox` — outer wrapper that attaches a sandbox VM to a controller
- * pattern for its lifetime. See docs/sandbox-plan.md → "What withSandbox is".
+ * pattern for its lifetime. See docs/plan/sandbox.md → "What withSandbox is".
  *
  * Four acquire paths, picked by `id` and `fresh`:
  *
@@ -83,7 +83,7 @@ const SANDBOX_SWEEP_INTERVAL_MS = 60_000
 // Process-shared singletons, lazily constructed from DEFAULT_SETTINGS. Cap
 // values are read once at first use; the settings panel can't reshape an
 // already-built scheduler/pool/table at runtime (those caps are process-
-// scoped, not per-request — see docs/sandbox-plan.md → "Settings").
+// scoped, not per-request — see docs/plan/sandbox.md → "Settings").
 let defaultBackend: ComputeBackend | null = null
 let defaultPool: WarmPool | null = null
 let defaultScheduler: SandboxScheduler | null = null

--- a/ui/src/lib/settings.ts
+++ b/ui/src/lib/settings.ts
@@ -5,7 +5,7 @@
  */
 
 /**
- * Sandbox compute settings. See docs/sandbox-plan.md → "Settings".
+ * Sandbox compute settings. See docs/plan/sandbox.md → "Settings".
  *
  * Process-scoped values (`globalCap`, `perSessionCap`, `warmPool`, `idleEvictMs`)
  * are read once when the harness lazily constructs its singleton scheduler


### PR DESCRIPTION
## What

1. **`docs/plan/` subfolder** — `sandbox-plan.md` → `plan/sandbox.md` (status header now separates shipped #79/#89/#97/#117 from still-plan Swarm/Firecracker), plus the new **`plan/ROADMAP.md`**: multi-user target architecture + phased MoSCoW roadmap (Entra SSO #119 as the gate; kept in sync with the project board's MSCW field). All 28 cross-references updated (docs links + source comments).
2. **`docs/deploy/azure-vm.md`** — single-VM deployment runbook (compose loopback hardening, systemd UI, Caddy, env reference).
3. **Post-#125 sweep** — removes the dangling `withApproval`/`kg-builder` references #125 left in repo-level docs: `examples.md` (7 agents, renumbered, anchors fixed), `api.md`, `frontend.md`, `UI_ARCHITECTURE.md`, `harness-patterns/README.md`, `plan/sandbox.md` (now past-tense with #123 pointers).
4. **Review follow-ups from #124/#126**: `criticCadence` NaN-guard (a non-finite value could silently disable the modulo backstop) + `enforceCap` transient-race doc note.
5. Freshness: INDEX (Planning section, deploy entry, current Anthropic model names, file tree), CLAUDE.md docs table, `.gitignore` for the machine-specific `docker-compose.override.yml`.

## Verify
- 908 tests pass / 1 skipped (baseline after #124+#125+#126). tsc: 19 pre-existing errors, none added.
- TS changes beyond the two hardening items are comment-only (verified with `git diff -U0 | grep -v '^[+-]\s*(//|\*)'`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DUSeozx2rQEaC8S9u94RDw