### PR TITLE
feat(auth): Pattern C — per-user Microsoft Graph access (#110)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,5 +193,6 @@ Custom tokens: `dark-bg-{primary,secondary,tertiary}`, `dark-text-{primary,secon
 | [`docs/UI_ARCHITECTURE.md`](docs/UI_ARCHITECTURE.md) | Component structure, data flow, Chat-Graph linking |
 | [`docs/DATA_STASH.md`](docs/DATA_STASH.md) | Data Stash pipeline: upload → chunk → embed → search (#6/#9/#8), API routes, Redis storage, redis-stack + local-embedder requirements |
 | [`docs/AGENT_TRIGGER.md`](docs/AGENT_TRIGGER.md) | `POST /api/agents/:id` async agent trigger → action rows: contract, fire-and-forget model, `kind`/`source`/`status` columns, token auth (`configs/action-tokens.yaml`), recording playback via Data Stash, promotion gate |
+| [`docs/MICROSOFT_GRAPH.md`](docs/MICROSOFT_GRAPH.md) | Per-user Microsoft Graph (Pattern C, #110): the Microsoft 365 agent's tools, the app-side tool transport (third transport beside gateway + sandbox), cross-user isolation, encrypted per-user token lifecycle, adding a connector. Tenant setup: [`docs/deploy/entra-setup.md`](docs/deploy/entra-setup.md) |
 | [`ui/README.md`](ui/README.md) | UI quick start and file index |
 | [`ui/src/lib/harness-patterns/README.md`](ui/src/lib/harness-patterns/README.md) | Harness patterns full API |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -66,7 +66,8 @@ Source-level index: see [ui/README.md](../ui/README.md#documentation-index).
 
 | Document | Description |
 |----------|-------------|
-| [deploy/entra-setup.md](deploy/entra-setup.md) | **Microsoft Entra ID SSO** (#119): tenant-owner provisioning checklist (app registration, redirect URIs, delegated Graph scopes, client secret), app env vars, the `oid`-based identity model, and the server-side OIDC sign-in flow. The auth architecture itself is in [UI_ARCHITECTURE.md §3](UI_ARCHITECTURE.md) |
+| [deploy/entra-setup.md](deploy/entra-setup.md) | **Entra tenant setup** (#119): provisioning checklist (app registration, redirect URIs, client secret), the delegated Graph scope set + consent ordering trap, app env vars and key rotation, the `oid`-based identity model. Operator-facing — in-app architecture is below and in [UI_ARCHITECTURE.md §3](UI_ARCHITECTURE.md) |
+| [MICROSOFT_GRAPH.md](MICROSOFT_GRAPH.md) | **Per-user Graph access** (Pattern C, #110): what the Microsoft 365 agent can do, the app-side tool transport + dispatch order, cross-user isolation guarantees, the encrypted per-user token lifecycle, and how to add a connector |
 
 ---
 

--- a/docs/MICROSOFT_GRAPH.md
+++ b/docs/MICROSOFT_GRAPH.md
@@ -1,0 +1,211 @@
+# Per-user Microsoft Graph access (Pattern C)
+
+How the app calls Microsoft Graph **as the signed-in user**, so Entra enforces
+each request's scope instead of an org token guarded by app code. This is
+Pattern C of the identity model in #107; issue #110.
+
+For tenant setup (app registration, scopes, consent, env vars) see
+[`deploy/entra-setup.md`](deploy/entra-setup.md). For the sign-in/session
+machinery see [UI_ARCHITECTURE.md §3](UI_ARCHITECTURE.md).
+
+---
+
+## What it can do today
+
+The **Microsoft 365** agent (`lib/harness-client/examples/microsoft-365.server.ts`)
+exposes three **read-only** tools:
+
+| Tool | Reads | Scope used |
+|------|-------|-----------|
+| `graph_me` | own profile (name, UPN, job title, office) | `User.Read` |
+| `graph_calendar_today` | own calendar for a given day (`day_offset`) | `Calendars.ReadWrite` |
+| `graph_mail_recent` | own inbox, newest first, optional `unread_only` | `Mail.Read` |
+
+Enough for "what does my day look like?" — the agent's loop calls several tools
+in one turn and the synthesizer writes the briefing.
+
+**Consented scopes exceed implemented tools.** The sign-in request also carries
+`Mail.Send`, `Files.Read.All` and `Sites.Read.All` (see the setup doc for why
+consent is taken up front). No tool exposes them, so the model cannot use them:
+a granted scope is not a capability — capability comes from a registered tool.
+
+**Writes.** None yet. Adding one is the same shape as a read tool, but it should
+carry a confirmation gate: creating an event emails real invitations, and
+`Mail.Send` sends real mail. The ready-made `withApproval` pattern was removed
+in #125, so a write tool wires its own pause using the surviving primitives
+(`pauseContext()` → `status='paused'`, `resumeHarness()`, and the
+`approveAction`/`rejectAction` server actions already bound to the UI).
+
+---
+
+## Architecture
+
+A tool is a plain in-process function; everything security-relevant lives in the
+layers beneath it, so the tool body only knows a Graph path.
+
+```
+model emits tool_call graph_calendar_today {day_offset: 0}
+        │
+callTool(name, args)                    ← harness-patterns/mcp-client.server.ts
+   ├─ sandbox owns it?  → in-VM transport
+   ├─ hasAppTool(name)? → runAppTool     ← THIS path
+   └─ else              → MCP gateway
+        │
+runAppTool                              ← app-tools/registry.server.ts
+   ├─ userId = getRequestUserId()        ← AsyncLocalStorage, not args
+   └─ def.execute(args, {userId}) → {success, data} | {success:false, error}
+        │
+tool definition                          ← app-tools/graph.server.ts
+   └─ graphFetch(userId, '/me/calendarView?…', {scopes, headers})
+        │
+graphFetch                               ← auth/graph-token.server.ts
+   ├─ getUserGraphToken(userId, scopes)
+   │     ├─ loadUserTokenCache(userId)   ← user_tokens, AES-256-GCM
+   │     ├─ cache.deserialize → acquireTokenSilent
+   │     └─ saveUserTokenCache (refresh-token rotation)
+   └─ fetch(GRAPH_BASE + path, Authorization: Bearer …)
+```
+
+| Module | Sole responsibility |
+|--------|--------------------|
+| `harness-patterns/mcp-client.server.ts` | dispatch: which transport owns this tool name |
+| `lib/app-tools/registry.server.ts` | resolve identity, execute, never throw |
+| `lib/app-tools/graph.server.ts` | Graph paths, `$select`, response shaping |
+| `lib/auth/graph-token.server.ts` | token acquisition, rotation, attach credential |
+| `lib/auth/user-tokens.server.ts` | encrypted per-user cache, keyed by `oid` |
+| `lib/auth/secret-crypto.server.ts` | AES-256-GCM envelope for stored secrets |
+
+### Why in-process rather than an MCP server
+
+The MCP gateway is a single shared-identity credential boundary: every user's
+calls execute as one principal, and the static-secret model cannot inject
+per-user credentials (#107). Routing Graph through it would forfeit delegated
+per-user scope — the entire point of Pattern C. So app tools are a **third
+transport** beside the gateway and the sandbox, dispatched in `callTool` after
+the sandbox branch and before the gateway.
+
+### Why `acquireTokenSilent`, not the On-Behalf-Of grant
+
+Despite "OBO" in the issue title, the OBO grant is not what this uses. OBO
+serves a **middle-tier API**: a separate client signs in, receives a token
+scoped to *our* API, calls us, and we exchange that user assertion downstream.
+Since #119 this app is itself the confidential OIDC client — the browser holds
+an opaque session cookie, not a token — so there is no assertion to exchange,
+and we already hold the user's refresh token from sign-in. `acquireTokenSilent`
+produces the same delegated per-user token with less machinery, and needs no
+`api://…/access_as_user` scope or "Expose an API" configuration.
+
+`acquireTokenOnBehalfOf` becomes necessary only if a distinct client
+authenticates to Entra itself and then calls our API — e.g. giving the iOS
+Shortcut its own client id instead of the shared bearer secret it uses today
+(see [AGENT_TRIGGER.md](AGENT_TRIGGER.md)). The token-cache plumbing here is the
+seam for that.
+
+### Advertisement
+
+`listTools()` appends `appToolDescriptions()` to the gateway's list, and
+`inferServer()` reads each tool's declared `namespace`, so they group as
+`tools.graph`. Consequences:
+
+- The `microsoft-365` agent picks up new graph tools with **no agent change**.
+- App tools stay available when the **gateway is down** — they run in-process.
+
+---
+
+## Identity and isolation
+
+Two invariants shape the design:
+
+1. **Tokens resolve from the request, never from arguments.** No advertised
+   schema has a user or token field, so the model cannot ask for another
+   person's data — a caller-supplied `userId` argument is ignored in favour of
+   `getRequestUserId()`.
+2. **The credential is attached inside `graphFetch`** and never returned, so no
+   tool body, log line, tool result or event can carry it.
+
+Four mechanisms keep concurrent users apart:
+
+| Layer | Mechanism |
+|-------|-----------|
+| Identity | `getRequestUserId()` reads AsyncLocalStorage — per-request context |
+| MSAL client | constructed per call; only that user's cache is deserialized into it |
+| Token store | `user_tokens.user_id` is the primary key; every query is `WHERE user_id = $1` |
+| Provenance | no server action accepts a `userId`; all derive it from `requireUser()` → session cookie |
+
+`__tests__/lib/app-tools/{user,token}-isolation.test.ts` assert this under
+deliberately interleaved concurrent calls, and were mutation-checked: hoisting
+the MSAL client to a module-level singleton fails them.
+
+**Fail-closed:** a tool called outside any `runWithUserId` scope is refused
+rather than guessing an identity. Both entry points establish the scope —
+`runTurn` (interactive) and `runAgentInBackground` (async).
+
+**Accepted limit:** one encryption key protects every stored cache. Users cannot
+reach each other's tokens, but a leaked key plus database access would expose
+all of them — which is why the key belongs in a secret store in production.
+
+---
+
+## Token lifecycle
+
+| | |
+|---|---|
+| Store | `user_tokens`, keyed by the Entra `oid` |
+| Contents | MSAL's serialized cache — **includes the refresh token** |
+| At rest | AES-256-GCM, versioned envelope (`v1.<iv>.<tag>.<ciphertext>`) |
+| Lifetime | survives logout and session expiry, deliberately |
+| Rotation | re-written after every silent acquisition (Entra rotates refresh tokens) |
+
+**Why per-user and not per-session:** background runs
+(`POST /api/agents/:id` → `runAgentInBackground`) have no live session, only a
+`userId`. A session-scoped cache — which is what #119 originally shipped — would
+leave those runs with no credential at all.
+
+**When it can't produce a token** (no stored cache, unusable refresh token, an
+unconsented scope, or Graph answering 401/403) the layer raises
+`GraphAuthRequiredError`, which surfaces as a "sign in again" tool result rather
+than failing the run.
+
+> Schema note: databases created by #119 may still carry a plaintext
+> `auth_sessions.token_cache` column. It is no longer written; dropping it is
+> post-merge cleanup, deliberately not done from a feature branch because code
+> deployed from `main` still writes it.
+
+---
+
+## Adding a read connector
+
+1. Ensure the delegated scope is consented **and** in the sign-in request — see
+   [`deploy/entra-setup.md`](deploy/entra-setup.md). No re-consent is needed for
+   a scope already in that set.
+2. Register the tool:
+
+```ts
+registerAppTool({
+  name: "graph_files_recent",
+  namespace: "graph",
+  description: "…acts as the current user; no user or token argument.",
+  inputSchema: { type: "object", properties: { … }, additionalProperties: false },
+  execute: async (args, { userId }) =>
+    shape(await graphFetch(userId, "/me/drive/recent?$top=10", {
+      scopes: ["Files.Read.All"],
+    })),
+});
+```
+
+That's the whole change — no auth, dispatch or agent wiring to touch. Guidelines
+that keep turns small and safe:
+
+- Always `$select` explicit fields; never hand a raw Graph payload to the model.
+- Shape and truncate (e.g. mail previews are capped at 300 chars).
+- Pass the **narrowest** scope the call needs, not the whole consented set.
+- Keep the schema free of any user/credential field.
+
+### Calendar time zones
+
+Event times come back in the zone named by the `Prefer: outlook.timezone`
+header, defaulting to the server's own zone (override with `GRAPH_TIMEZONE`).
+Day windows are therefore built as **naive local** ISO strings: sending UTC
+instants would shift the day boundary and silently drop early or late meetings.
+`graph_calendar_today` also uses `/me/calendarView` rather than `/me/events` so
+recurring series expand into the day's occurrences.

--- a/docs/UI_ARCHITECTURE.md
+++ b/docs/UI_ARCHITECTURE.md
@@ -138,9 +138,13 @@ dev-bypass stays a zero-config path.
 ### Session store
 **File:** `ui/src/lib/auth/session-store.server.ts` — Postgres `auth_sessions`
 (opaque cookie id → row: `user_id` = Entra `oid`, email, display name,
-`home_account_id`, serialized MSAL token cache for #110, 8h expiry). Every
-sign-in also upserts `users` (`ui/src/lib/auth/users.server.ts`: oid, email,
-display name, tenant, first/last login) — the app's own activity record.
+`home_account_id`, 8h expiry). Every sign-in also upserts `users`
+(`ui/src/lib/auth/users.server.ts`: oid, email, display name, tenant, first/last
+login) — the app's own activity record.
+
+The user's **MSAL token cache is not stored on the session**: it lives encrypted
+and per-user in `user_tokens` so runs without a live session can still act for
+the user. See [MICROSOFT_GRAPH.md](MICROSOFT_GRAPH.md).
 
 ### Server Validation
 **File:** `ui/src/lib/auth/server.ts`

--- a/docs/deploy/entra-setup.md
+++ b/docs/deploy/entra-setup.md
@@ -67,10 +67,19 @@ AZURE_TENANT_ID=<tenant (directory) GUID>
 AZURE_CLIENT_ID=<app registration client id>
 AZURE_CLIENT_SECRET=<from Certificates & secrets>
 AUTH_SESSION_SECRET=<openssl rand -base64 32>   # signs auth cookies
+# Encrypts the stored per-user token cache (#110). Strongly recommended in
+# production so it can rotate independently of the cookie-signing key; when
+# unset, the key is HKDF-derived from AUTH_SESSION_SECRET.
+TOKEN_ENCRYPTION_KEY=<openssl rand -base64 32>
 # Optional overrides (defaults target dev):
 # AUTH_REDIRECT_URI=http://localhost:3444/api/auth/callback
 # AUTH_POST_LOGOUT_REDIRECT_URI=http://localhost:3444/auth/signin
 ```
+
+⚠️ Rotating `TOKEN_ENCRYPTION_KEY` (or `AUTH_SESSION_SECRET` when no dedicated
+key is set) makes existing stored token caches undecryptable. That is handled
+gracefully — affected users are simply asked to sign in again — but it does mean
+background runs for those users fail until they do.
 
 Access is still gated by the email allow-list (`VITE_ALLOWED_EMAILS`); a
 signed-in account whose email isn't listed lands on `/auth/access-denied` and
@@ -79,6 +88,67 @@ gets no session.
 **Dev without a tenant:** `VITE_DEV_BYPASS_AUTH=true` (dev builds only) signs in
 as the mock `dev-bypass-user` — no Entra round-trip. This is the default for
 local iteration.
+
+---
+
+## Calling Microsoft Graph as the user (Pattern C, #110)
+
+Once signed in, the app can call Graph **as that user** — Entra enforces the
+delegated scope, so there is no over-privileged org token and no app-side
+scoping guard to get wrong.
+
+### Why `acquireTokenSilent`, not the OBO grant
+
+The On-Behalf-Of grant is for a **middle-tier API**: a separate client (SPA or
+mobile) signs in, receives a token scoped to *our* API, calls us, and we exchange
+that user assertion for a downstream token. This app is itself the confidential
+OIDC client — the browser holds an opaque session cookie, not a token — so there
+is no assertion to exchange, and we already hold the user's refresh token from
+sign-in. `acquireTokenSilent` yields the same delegated per-user token with less
+machinery: **no `api://…/access_as_user` scope and nothing to configure under
+"Expose an API"**.
+
+OBO proper (`acquireTokenOnBehalfOf`) becomes necessary only if a distinct client
+authenticates to Entra itself and then calls our API — e.g. giving the iOS
+Shortcut its own client id instead of a shared bearer secret. The token-cache
+plumbing is the seam for that.
+
+### Where the tokens live
+
+| | |
+|---|---|
+| Store | `user_tokens` table, keyed by the Entra `oid` |
+| Contents | MSAL's serialized cache (**includes the refresh token**) |
+| At rest | AES-256-GCM encrypted (`TOKEN_ENCRYPTION_KEY`) |
+| Lifetime | Survives logout and session expiry — deliberately |
+| Rotation | Re-written after every silent acquisition (Entra rotates refresh tokens) |
+
+It is **per-user, not per-session**, because background runs
+(`POST /api/agents/:id` → `runAgentInBackground`) have no live session — only a
+`userId`. A session-scoped cache would leave those runs with no credential.
+
+### Adding a connector (mail, files, calendar)
+
+1. Add the delegated scope in **API permissions** and grant admin consent.
+2. Add it to the sign-in request (`scopes` in `lib/auth/entra-config.server.ts`)
+   so one consent covers it and the refresh token can mint it silently. Requesting
+   scopes at sign-in — rather than incrementally — is what makes background runs
+   possible at all: there is no user present to consent mid-run.
+3. Register a tool in `lib/app-tools/graph.server.ts` using `graphFetch(userId,
+   path, { scopes })`. It appears in `tools.graph` automatically, so the
+   `microsoft-365` agent picks it up with no change.
+
+Existing users must sign in again after new scopes are added, so their stored
+refresh token covers them.
+
+### Security invariants (#107 principle 1)
+
+- Tool schemas shown to the model contain **no** token or user field; the user id
+  comes from `getRequestUserId()`, so the model cannot choose whose data to read.
+- Tokens are attached inside `graphFetch` and never returned to callers, logged,
+  or placed in the prompt/event stream.
+- These tools run **in-process**, not through the MCP gateway — the gateway is a
+  single shared-identity boundary and cannot express per-user identity.
 
 ---
 

--- a/docs/deploy/entra-setup.md
+++ b/docs/deploy/entra-setup.md
@@ -50,6 +50,7 @@ set a rotation reminder. (Rotate out any secret previously shared with Stack.)
 |------------|---------------|
 | `openid`, `profile`, `email`, `offline_access` | not required (user consent) |
 | `User.Read` | grant tenant-wide admin consent |
+| `Mail.Read`, `Mail.Send`, `Calendars.ReadWrite`, `Files.Read.All`, `Sites.Read.All` | add + grant admin consent before enabling the connectors — see "Scopes are requested up front" below |
 
 `offline_access` is what yields the refresh token the app persists for the
 future OBO exchange (#110). Additional Graph scopes for #110 (e.g. `Mail.Read`,
@@ -127,19 +128,42 @@ It is **per-user, not per-session**, because background runs
 (`POST /api/agents/:id` → `runAgentInBackground`) have no live session — only a
 `userId`. A session-scoped cache would leave those runs with no credential.
 
-### Adding a connector (mail, files, calendar)
+### Scopes are requested up front — all of them
 
-1. Add the delegated scope in **API permissions** and grant admin consent.
-2. Add it to the sign-in request (`scopes` in `lib/auth/entra-config.server.ts`)
-   so one consent covers it and the refresh token can mint it silently. Requesting
-   scopes at sign-in — rather than incrementally — is what makes background runs
-   possible at all: there is no user present to consent mid-run.
-3. Register a tool in `lib/app-tools/graph.server.ts` using `graphFetch(userId,
-   path, { scopes })`. It appears in `tools.graph` automatically, so the
-   `microsoft-365` agent picks it up with no change.
+`DEFAULT_GRAPH_SCOPES` in `lib/auth/entra-config.server.ts` requests the whole
+connector set at sign-in:
 
-Existing users must sign in again after new scopes are added, so their stored
-refresh token covers them.
+| Scope | For | Kind |
+|---|---|---|
+| `User.Read`, `email` | own profile | read |
+| `Mail.Read` | mailbox search / summarise | read |
+| `Mail.Send` | send as the user | **write** |
+| `Calendars.ReadWrite` | availability + scheduling | **write** |
+| `Files.Read.All` | OneDrive + SharePoint files the user can access | read |
+| `Sites.Read.All` | SharePoint sites the user can access | read |
+
+Why up front rather than incrementally: **adding a scope later forces every user
+to sign in again** (their stored refresh token must cover it), and background runs
+have no user present to consent mid-run. One consent, done.
+
+A granted scope is not a capability. The model can only do what a *registered
+tool* exposes, and today that is the read-only `graph_me`. Any future write tool
+should carry its own confirmation gate.
+
+> ⚠️ **Order matters.** Every scope in the request must exist under **API
+> permissions** with consent granted *before* anyone signs in. A scope that is
+> requested but not consented fails **the whole sign-in** — not just that
+> connector ("Need admin approval"). If that happens, trim the list via the
+> `AZURE_GRAPH_SCOPES` env var (space- or comma-separated) and restart — no code
+> change or redeploy needed. Reserved scopes (`openid`/`profile`/
+> `offline_access`) are stripped automatically; MSAL supplies them.
+
+### Adding a connector tool
+
+Register it in `lib/app-tools/graph.server.ts` using `graphFetch(userId, path,
+{ scopes })`. It appears in `tools.graph` automatically, so the `microsoft-365`
+agent picks it up with no change. No re-consent is needed as long as the scope is
+already in the set above.
 
 ### Security invariants (#107 principle 1)
 

--- a/docs/deploy/entra-setup.md
+++ b/docs/deploy/entra-setup.md
@@ -92,41 +92,18 @@ local iteration.
 
 ---
 
-## Calling Microsoft Graph as the user (Pattern C, #110)
+## Graph scopes and consent (Pattern C, #110)
 
 Once signed in, the app can call Graph **as that user** — Entra enforces the
 delegated scope, so there is no over-privileged org token and no app-side
-scoping guard to get wrong.
+scoping guard to get wrong. How that works internally, and how to add a
+connector, is [MICROSOFT_GRAPH.md](../MICROSOFT_GRAPH.md); this section covers
+only what the tenant needs.
 
-### Why `acquireTokenSilent`, not the OBO grant
-
-The On-Behalf-Of grant is for a **middle-tier API**: a separate client (SPA or
-mobile) signs in, receives a token scoped to *our* API, calls us, and we exchange
-that user assertion for a downstream token. This app is itself the confidential
-OIDC client — the browser holds an opaque session cookie, not a token — so there
-is no assertion to exchange, and we already hold the user's refresh token from
-sign-in. `acquireTokenSilent` yields the same delegated per-user token with less
-machinery: **no `api://…/access_as_user` scope and nothing to configure under
-"Expose an API"**.
-
-OBO proper (`acquireTokenOnBehalfOf`) becomes necessary only if a distinct client
-authenticates to Entra itself and then calls our API — e.g. giving the iOS
-Shortcut its own client id instead of a shared bearer secret. The token-cache
-plumbing is the seam for that.
-
-### Where the tokens live
-
-| | |
-|---|---|
-| Store | `user_tokens` table, keyed by the Entra `oid` |
-| Contents | MSAL's serialized cache (**includes the refresh token**) |
-| At rest | AES-256-GCM encrypted (`TOKEN_ENCRYPTION_KEY`) |
-| Lifetime | Survives logout and session expiry — deliberately |
-| Rotation | Re-written after every silent acquisition (Entra rotates refresh tokens) |
-
-It is **per-user, not per-session**, because background runs
-(`POST /api/agents/:id` → `runAgentInBackground`) have no live session — only a
-`userId`. A session-scoped cache would leave those runs with no credential.
+One consequence is worth noting here because it saves portal work: the app is
+itself the OIDC client, so it uses `acquireTokenSilent` rather than the
+On-Behalf-Of grant — which means **nothing needs configuring under "Expose an
+API"** and there is no `api://…/access_as_user` scope. Leave that blade empty.
 
 ### Scopes are requested up front — all of them
 
@@ -158,21 +135,13 @@ should carry its own confirmation gate.
 > change or redeploy needed. Reserved scopes (`openid`/`profile`/
 > `offline_access`) are stripped automatically; MSAL supplies them.
 
-### Adding a connector tool
+### Adding a scope later
 
-Register it in `lib/app-tools/graph.server.ts` using `graphFetch(userId, path,
-{ scopes })`. It appears in `tools.graph` automatically, so the `microsoft-365`
-agent picks it up with no change. No re-consent is needed as long as the scope is
-already in the set above.
-
-### Security invariants (#107 principle 1)
-
-- Tool schemas shown to the model contain **no** token or user field; the user id
-  comes from `getRequestUserId()`, so the model cannot choose whose data to read.
-- Tokens are attached inside `graphFetch` and never returned to callers, logged,
-  or placed in the prompt/event stream.
-- These tools run **in-process**, not through the MCP gateway — the gateway is a
-  single shared-identity boundary and cannot express per-user identity.
+Adding a scope to the sign-in request **forces every user to sign in again**
+(their stored refresh token must cover it), which is the reason the full set is
+taken up front. Grant it in the portal first, then extend
+`DEFAULT_GRAPH_SCOPES`. Writing the tool that uses it is
+[MICROSOFT_GRAPH.md](../MICROSOFT_GRAPH.md).
 
 ---
 

--- a/ui/.env.example
+++ b/ui/.env.example
@@ -20,6 +20,13 @@ AUTH_SESSION_SECRET=''
 # only means affected users sign in again.
 # TOKEN_ENCRYPTION_KEY=''
 
+# Escape hatch for the delegated Graph scopes requested at sign-in (#110).
+# Defaults to the full connector set (profile + mail + calendar + files); every
+# scope must be consented under API permissions FIRST, or sign-in fails
+# outright. Set a trimmed space/comma-separated list here to drop a problem
+# scope without a code change. See docs/deploy/entra-setup.md.
+# AZURE_GRAPH_SCOPES='User.Read email Mail.Read'
+
 # OIDC redirect / post-logout URIs. Defaults target dev (port 3444); the
 # redirect MUST match a Redirect URI registered on the app (Web platform).
 # AUTH_REDIRECT_URI='http://localhost:3444/api/auth/callback'

--- a/ui/.env.example
+++ b/ui/.env.example
@@ -13,6 +13,13 @@ AZURE_CLIENT_SECRET=''      # from the app's "Certificates & secrets"
 # HMAC key that signs the auth cookies. Generate: `openssl rand -base64 32`.
 AUTH_SESSION_SECRET=''
 
+# Encrypts the per-user Microsoft token cache at rest (#110 — that cache holds
+# refresh tokens). Generate: `openssl rand -base64 32`. When unset, the key is
+# HKDF-derived from AUTH_SESSION_SECRET; set it explicitly in production so the
+# two can rotate independently. Rotating it invalidates stored caches, which
+# only means affected users sign in again.
+# TOKEN_ENCRYPTION_KEY=''
+
 # OIDC redirect / post-logout URIs. Defaults target dev (port 3444); the
 # redirect MUST match a Redirect URI registered on the app (Web platform).
 # AUTH_REDIRECT_URI='http://localhost:3444/api/auth/callback'

--- a/ui/.env.example
+++ b/ui/.env.example
@@ -27,6 +27,10 @@ AUTH_SESSION_SECRET=''
 # scope without a code change. See docs/deploy/entra-setup.md.
 # AZURE_GRAPH_SCOPES='User.Read email Mail.Read'
 
+# IANA timezone Graph renders calendar times in (default: the server's own zone).
+# Set when the app and its users don't share a timezone.
+# GRAPH_TIMEZONE='Europe/Brussels'
+
 # OIDC redirect / post-logout URIs. Defaults target dev (port 3444); the
 # redirect MUST match a Redirect URI registered on the app (Web platform).
 # AUTH_REDIRECT_URI='http://localhost:3444/api/auth/callback'

--- a/ui/src/__tests__/lib/app-tools/graph-connectors.test.ts
+++ b/ui/src/__tests__/lib/app-tools/graph-connectors.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Calendar + mail connector tools (#110).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../../../lib/harness-patterns/assert.server", () => ({
+  assertServerOnImport: vi.fn(),
+  assertServer: vi.fn(),
+  ServerOnlyError: class ServerOnlyError extends Error {},
+}));
+
+const getRequestUserId = vi.fn<() => string | null>(() => "oid-1");
+vi.mock("../../../lib/harness-client/request-user.server", () => ({
+  getRequestUserId: () => getRequestUserId(),
+  runWithUserId: (_u: string, fn: () => Promise<unknown>) => fn(),
+}));
+
+const graphFetch = vi.fn();
+vi.mock("../../../lib/auth/graph-token.server", () => ({
+  graphFetch: (...a: unknown[]) => graphFetch(...a),
+  GRAPH_BASE: "https://graph.microsoft.com/v1.0",
+  DEFAULT_GRAPH_SCOPES: ["User.Read"],
+}));
+
+import { runAppTool, appToolDescriptions } from "../../../lib/app-tools/index.server";
+import {
+  shapeEvents,
+  shapeMessages,
+  localDayBounds,
+} from "../../../lib/app-tools/graph.server";
+
+/** Last graphFetch call as [userId, path, init]. */
+function lastCall() {
+  return graphFetch.mock.calls.at(-1) as [
+    string,
+    string,
+    { scopes?: string[]; headers?: Record<string, string> },
+  ];
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getRequestUserId.mockReturnValue("oid-1");
+  graphFetch.mockResolvedValue({ value: [] });
+});
+
+describe("tool advertisement", () => {
+  it("registers both connectors with no credential field", () => {
+    const names = appToolDescriptions().map((t) => t.name);
+    expect(names).toContain("graph_calendar_today");
+    expect(names).toContain("graph_mail_recent");
+
+    for (const t of appToolDescriptions()) {
+      const schema = JSON.stringify(t.inputSchema).toLowerCase();
+      for (const bad of ["token", "credential", "secret", "userid", "user_id"]) {
+        expect(schema, `${t.name} leaks ${bad}`).not.toContain(bad);
+      }
+    }
+  });
+});
+
+describe("localDayBounds", () => {
+  it("returns naive local ISO bounds for the day (no Z — Graph applies Prefer tz)", () => {
+    const { start, end } = localDayBounds(new Date(2026, 6, 27, 15, 30));
+    expect(start).toBe("2026-07-27T00:00:00");
+    expect(end).toBe("2026-07-27T23:59:59");
+    expect(start.endsWith("Z")).toBe(false);
+  });
+
+  it("applies a day offset, crossing month boundaries", () => {
+    expect(localDayBounds(new Date(2026, 6, 31, 12, 0), 1).start).toBe("2026-08-01T00:00:00");
+    expect(localDayBounds(new Date(2026, 7, 1, 12, 0), -1).start).toBe("2026-07-31T00:00:00");
+  });
+});
+
+describe("graph_calendar_today", () => {
+  it("queries calendarView for today with an ordered window + timezone header", async () => {
+    const res = await runAppTool("graph_calendar_today", {});
+    expect(res.success).toBe(true);
+
+    const [userId, path, init] = lastCall();
+    expect(userId).toBe("oid-1");
+    expect(path).toContain("/me/calendarView"); // expands recurring series
+    expect(path).toContain("startDateTime=");
+    expect(path).toContain("$orderby=start/dateTime");
+    expect(init.scopes).toEqual(["Calendars.ReadWrite"]);
+    expect(init.headers?.Prefer).toMatch(/^outlook\.timezone="/);
+  });
+
+  it("honours day_offset and reports the day it queried", async () => {
+    const today = (await runAppTool("graph_calendar_today", {})).data as { day: string };
+    const tomorrow = (await runAppTool("graph_calendar_today", { day_offset: 1 }))
+      .data as { day: string };
+    expect(tomorrow.day).not.toBe(today.day);
+  });
+
+  it("ignores a non-numeric day_offset instead of building a broken query", async () => {
+    const res = await runAppTool("graph_calendar_today", { day_offset: "junk" });
+    expect(res.success).toBe(true);
+    expect(lastCall()[1]).not.toContain("NaN");
+  });
+
+  it("flattens Graph's nested event shape", () => {
+    const events = shapeEvents({
+      value: [
+        {
+          subject: "Standup",
+          start: { dateTime: "2026-07-27T09:00:00.0000000", timeZone: "Europe/Brussels" },
+          end: { dateTime: "2026-07-27T09:15:00.0000000" },
+          isAllDay: false,
+          location: { displayName: "Teams" },
+          organizer: { emailAddress: { name: "Ada", address: "ada@corp.com" } },
+          onlineMeetingUrl: "https://teams/x",
+        },
+      ],
+    });
+    expect(events).toEqual([
+      {
+        subject: "Standup",
+        start: "2026-07-27T09:00:00.0000000",
+        end: "2026-07-27T09:15:00.0000000",
+        isAllDay: false,
+        location: "Teams",
+        organizer: "Ada",
+        onlineMeetingUrl: "https://teams/x",
+      },
+    ]);
+  });
+
+  it("shapeEvents tolerates missing/garbage payloads", () => {
+    expect(shapeEvents(null)).toEqual([]);
+    expect(shapeEvents({})).toEqual([]);
+    expect(shapeEvents({ value: [{}] })[0]).toMatchObject({
+      subject: null,
+      start: null,
+      isAllDay: false,
+      organizer: null,
+    });
+  });
+});
+
+describe("graph_mail_recent", () => {
+  it("reads the inbox newest-first with Mail.Read", async () => {
+    await runAppTool("graph_mail_recent", {});
+    const [, path, init] = lastCall();
+    expect(path).toContain("/me/mailFolders/inbox/messages");
+    expect(path).toContain("$orderby=receivedDateTime desc");
+    expect(path).toContain("$top=10");
+    expect(path).not.toContain("$filter");
+    expect(init.scopes).toEqual(["Mail.Read"]);
+  });
+
+  it("filters to unread when asked", async () => {
+    await runAppTool("graph_mail_recent", { unread_only: true });
+    expect(lastCall()[1]).toContain("$filter=isRead eq false");
+  });
+
+  it("clamps limit into 1..25", async () => {
+    await runAppTool("graph_mail_recent", { limit: 999 });
+    expect(lastCall()[1]).toContain("$top=25");
+    await runAppTool("graph_mail_recent", { limit: 0 });
+    expect(lastCall()[1]).toContain("$top=10"); // 0 is falsy → default
+    await runAppTool("graph_mail_recent", { limit: -5 });
+    expect(lastCall()[1]).toContain("$top=1");
+  });
+
+  it("compacts messages and truncates the preview", () => {
+    const [msg] = shapeMessages({
+      value: [
+        {
+          subject: "Invoice",
+          from: { emailAddress: { name: "Bob", address: "bob@x.com" } },
+          receivedDateTime: "2026-07-27T08:00:00Z",
+          isRead: false,
+          hasAttachments: true,
+          bodyPreview: "x".repeat(1000),
+          webLink: "https://outlook/1",
+        },
+      ],
+    });
+    expect(msg).toMatchObject({
+      subject: "Invoice",
+      from: "Bob",
+      isRead: false,
+      hasAttachments: true,
+      webLink: "https://outlook/1",
+    });
+    expect(msg.preview).toHaveLength(300);
+  });
+
+  it("falls back to the sender address when no display name exists", () => {
+    const [msg] = shapeMessages({
+      value: [{ from: { emailAddress: { address: "no-name@x.com" } } }],
+    });
+    expect(msg.from).toBe("no-name@x.com");
+  });
+
+  it("shapeMessages tolerates garbage", () => {
+    expect(shapeMessages(null)).toEqual([]);
+    expect(shapeMessages({ value: "nope" })).toEqual([]);
+  });
+});

--- a/ui/src/__tests__/lib/app-tools/registry.test.ts
+++ b/ui/src/__tests__/lib/app-tools/registry.test.ts
@@ -1,0 +1,143 @@
+/**
+ * App-side tool registry + the graph_me tool (#110).
+ *
+ * Asserts the security invariants from #107: the advertised schema carries no
+ * credential field, the user id comes from request scope (never args), and a
+ * call outside any user scope is refused.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../../../lib/harness-patterns/assert.server", () => ({
+  assertServerOnImport: vi.fn(),
+  assertServer: vi.fn(),
+  ServerOnlyError: class ServerOnlyError extends Error {},
+}));
+
+const getRequestUserId = vi.fn<() => string | null>(() => "oid-1");
+vi.mock("../../../lib/harness-client/request-user.server", () => ({
+  getRequestUserId: () => getRequestUserId(),
+  runWithUserId: (_u: string, fn: () => Promise<unknown>) => fn(),
+}));
+
+const graphFetch = vi.fn();
+vi.mock("../../../lib/auth/graph-token.server", () => ({
+  graphFetch: (...a: unknown[]) => graphFetch(...a),
+  GRAPH_BASE: "https://graph.microsoft.com/v1.0",
+  DEFAULT_GRAPH_SCOPES: ["User.Read"],
+}));
+
+// Importing the barrel registers the built-in tools as a side effect.
+import {
+  hasAppTool,
+  runAppTool,
+  appToolDescriptions,
+  appToolNamespace,
+  registerAppTool,
+} from "../../../lib/app-tools/index.server";
+import { shapeMe } from "../../../lib/app-tools/graph.server";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getRequestUserId.mockReturnValue("oid-1");
+});
+
+describe("registry wiring", () => {
+  it("registers graph_me under the graph namespace", () => {
+    expect(hasAppTool("graph_me")).toBe(true);
+    expect(appToolNamespace("graph_me")).toBe("graph");
+    expect(hasAppTool("read_neo4j_cypher")).toBe(false);
+    expect(appToolNamespace("read_neo4j_cypher")).toBeNull();
+  });
+
+  it("advertises graph_me with NO credential/user field (#107 principle 1)", () => {
+    const def = appToolDescriptions().find((t) => t.name === "graph_me");
+    expect(def).toBeDefined();
+    const schema = JSON.stringify(def!.inputSchema).toLowerCase();
+    for (const forbidden of ["token", "credential", "secret", "userid", "user_id", "access"]) {
+      expect(schema).not.toContain(forbidden);
+    }
+    expect(def!.inputSchema).toMatchObject({ type: "object", properties: {} });
+  });
+});
+
+describe("runAppTool", () => {
+  it("passes the request-scoped userId to the executor (not from args)", async () => {
+    graphFetch.mockResolvedValue({ displayName: "Ada" });
+    const res = await runAppTool("graph_me", { userId: "attacker-oid" });
+    expect(res.success).toBe(true);
+    // graphFetch receives the SCOPED user, ignoring the arg entirely.
+    expect(graphFetch.mock.calls[0][0]).toBe("oid-1");
+  });
+
+  it("refuses when no user is in scope", async () => {
+    getRequestUserId.mockReturnValue(null);
+    const res = await runAppTool("graph_me", {});
+    expect(res.success).toBe(false);
+    expect(res.error).toMatch(/authenticated user/i);
+    expect(graphFetch).not.toHaveBeenCalled();
+  });
+
+  it("returns a failed result (not a throw) when the tool errors", async () => {
+    graphFetch.mockRejectedValue(new Error("sign in to connect Microsoft 365"));
+    const res = await runAppTool("graph_me", {});
+    expect(res.success).toBe(false);
+    expect(res.error).toMatch(/sign in/i);
+    expect(res.data).toBeNull();
+  });
+
+  it("reports unknown tool names", async () => {
+    const res = await runAppTool("nope_not_here", {});
+    expect(res.success).toBe(false);
+    expect(res.error).toMatch(/unknown app tool/i);
+  });
+
+  it("supports registering additional tools (e.g. #109 vault tools)", async () => {
+    registerAppTool({
+      name: "test_echo",
+      namespace: "test",
+      description: "echo",
+      inputSchema: { type: "object", properties: {} },
+      execute: async (args, ctx) => ({ args, user: ctx.userId }),
+    });
+    const res = await runAppTool("test_echo", { a: 1 });
+    expect(res.success).toBe(true);
+    expect(res.data).toEqual({ args: { a: 1 }, user: "oid-1" });
+  });
+});
+
+describe("graph_me result shaping", () => {
+  it("selects only the advertised fields and null-normalizes", async () => {
+    graphFetch.mockResolvedValue({
+      displayName: "Ada Lovelace",
+      mail: "ada@corp.com",
+      jobTitle: "   ",
+      id: "should-not-surface",
+      "@odata.context": "should-not-surface",
+    });
+    const res = await runAppTool("graph_me", {});
+    expect(res.data).toEqual({
+      displayName: "Ada Lovelace",
+      givenName: null,
+      surname: null,
+      userPrincipalName: null,
+      mail: "ada@corp.com",
+      jobTitle: null, // whitespace-only → null
+      officeLocation: null,
+      preferredLanguage: null,
+    });
+  });
+
+  it("requests /me with an explicit $select and the User.Read scope", async () => {
+    graphFetch.mockResolvedValue({});
+    await runAppTool("graph_me", {});
+    const [, path, init] = graphFetch.mock.calls[0] as [string, string, { scopes: string[] }];
+    expect(path).toContain("/me?$select=");
+    expect(path).toContain("displayName");
+    expect(init.scopes).toEqual(["User.Read"]);
+  });
+
+  it("shapeMe tolerates null/garbage payloads", () => {
+    expect(shapeMe(null).displayName).toBeNull();
+    expect(shapeMe({ displayName: 42 }).displayName).toBeNull();
+  });
+});

--- a/ui/src/__tests__/lib/app-tools/token-isolation.test.ts
+++ b/ui/src/__tests__/lib/app-tools/token-isolation.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Token-cache isolation between concurrent users (#110 / #107).
+ *
+ * Uses the REAL `getUserGraphToken` with a fake MSAL whose token is derived
+ * from whichever cache was deserialized into that client instance. Deliberate
+ * awaits inside deserialize/acquire create a window in which a shared client
+ * would cross wires — so if these ever pass tokens between users, the test
+ * fails rather than the tenant finding out.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("../../../lib/harness-patterns/assert.server", () => ({
+  assertServerOnImport: vi.fn(),
+  assertServer: vi.fn(),
+  ServerOnlyError: class ServerOnlyError extends Error {},
+}));
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+vi.mock("@azure/msal-node", () => ({
+  InteractionRequiredAuthError: class extends Error {},
+  ConfidentialClientApplication: class {
+    private loaded: string | null = null;
+    getTokenCache() {
+      return {
+        deserialize: async (s: string) => {
+          await sleep(5); // window for another user's call to interfere
+          this.loaded = s;
+        },
+        serialize: () => this.loaded ?? "",
+        hasChanged: () => true,
+        getAccountByHomeId: async () => ({ homeAccountId: `acct-${this.loaded}` }),
+        getAllAccounts: async () => [{ homeAccountId: `acct-${this.loaded}` }],
+      };
+    }
+    acquireTokenSilent = async () => {
+      await sleep(5);
+      return {
+        accessToken: `token-from-${this.loaded}`,
+        account: { homeAccountId: `acct-${this.loaded}` },
+      };
+    };
+  },
+}));
+
+vi.mock("../../../lib/auth/entra-config.server", () => ({
+  buildEntraConfig: () => ({
+    tenantId: "t",
+    clientId: "c",
+    clientSecret: "s",
+    authority: "https://login.microsoftonline.com/t",
+    redirectUri: "r",
+    postLogoutRedirectUri: "p",
+    scopes: ["User.Read"],
+  }),
+  msalConfiguration: () => ({ auth: { clientId: "c" } }),
+}));
+
+const saved: Array<[string, string]> = [];
+vi.mock("../../../lib/auth/user-tokens.server", () => ({
+  loadUserTokenCache: async (userId: string) => {
+    await sleep(3);
+    return {
+      homeAccountId: `acct-cache-of-${userId}`,
+      tokenCache: `cache-of-${userId}`,
+      updatedAt: new Date(0),
+    };
+  },
+  saveUserTokenCache: async (userId: string, cache: string) => {
+    saved.push([userId, cache]);
+  },
+}));
+
+import { getUserGraphToken } from "../../../lib/auth/graph-token.server";
+
+describe("token-cache isolation under concurrency", () => {
+  beforeEach(() => {
+    saved.length = 0;
+  });
+
+  it("gives each concurrent user a token derived from their OWN cache", async () => {
+    const users = ["u1", "u2", "u3", "u4", "u5"];
+    const tokens = await Promise.all(users.map((u) => getUserGraphToken(u)));
+
+    // A shared MSAL client would hand two users the same token.
+    users.forEach((u, i) => expect(tokens[i]).toBe(`token-from-cache-of-${u}`));
+    expect(new Set(tokens).size).toBe(users.length);
+  });
+
+  it("writes each rotated cache back under the right user", async () => {
+    const users = ["a1", "a2", "a3"];
+    await Promise.all(users.map((u) => getUserGraphToken(u)));
+
+    expect(saved).toHaveLength(3);
+    for (const [userId, cache] of saved) {
+      // Never persist one user's cache under another's id.
+      expect(cache).toBe(`cache-of-${userId}`);
+    }
+  });
+
+  it("repeated interleaved calls for the same two users never cross", async () => {
+    const pairs = await Promise.all(
+      Array.from({ length: 10 }, (_, i) =>
+        getUserGraphToken(i % 2 === 0 ? "even-user" : "odd-user"),
+      ),
+    );
+    pairs.forEach((tok, i) => {
+      expect(tok).toBe(`token-from-cache-of-${i % 2 === 0 ? "even-user" : "odd-user"}`);
+    });
+  });
+});

--- a/ui/src/__tests__/lib/app-tools/user-isolation.test.ts
+++ b/ui/src/__tests__/lib/app-tools/user-isolation.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Cross-user isolation (#110 / #107).
+ *
+ * These tests use the REAL AsyncLocalStorage scope (`runWithUserId`) and a real
+ * per-call MSAL client, with deliberately interleaved awaits, so they fail if
+ * concurrent users could ever observe each other's identity or tokens.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../../../lib/harness-patterns/assert.server", () => ({
+  assertServerOnImport: vi.fn(),
+  assertServer: vi.fn(),
+  ServerOnlyError: class ServerOnlyError extends Error {},
+}));
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+// Graph itself is stubbed; it echoes back whichever userId reached it, after a
+// delay, so any context bleed between concurrent calls shows up as a mismatch.
+vi.mock("../../../lib/auth/graph-token.server", () => ({
+  GRAPH_BASE: "https://graph.microsoft.com/v1.0",
+  DEFAULT_GRAPH_SCOPES: ["User.Read"],
+  graphFetch: async (userId: string) => {
+    await sleep(userId === "user-A" ? 30 : 5); // A is slow, B/C overtake it
+    return { userPrincipalName: userId };
+  },
+}));
+
+import { runWithUserId } from "../../../lib/harness-client/request-user.server";
+import { runAppTool } from "../../../lib/app-tools/index.server";
+
+describe("request-scoped identity under concurrency", () => {
+  it("keeps each user's identity separate across interleaved calls", async () => {
+    const call = (u: string) =>
+      runWithUserId(u, async () => {
+        // Yield before and after, so the scopes are genuinely interleaved.
+        await sleep(1);
+        const res = await runAppTool("graph_me", {});
+        await sleep(1);
+        return res;
+      });
+
+    const [a, b, c] = await Promise.all([call("user-A"), call("user-B"), call("user-C")]);
+
+    // Each call must see ONLY its own user — the slow one included.
+    expect((a.data as { userPrincipalName: string }).userPrincipalName).toBe("user-A");
+    expect((b.data as { userPrincipalName: string }).userPrincipalName).toBe("user-B");
+    expect((c.data as { userPrincipalName: string }).userPrincipalName).toBe("user-C");
+  });
+
+  it("nested scopes do not leak outward", async () => {
+    const result = await runWithUserId("outer-user", async () => {
+      const inner = await runWithUserId("inner-user", () => runAppTool("graph_me", {}));
+      const outer = await runAppTool("graph_me", {});
+      return { inner, outer };
+    });
+
+    expect((result.inner.data as { userPrincipalName: string }).userPrincipalName).toBe(
+      "inner-user",
+    );
+    // After the nested scope closes, the outer identity is intact.
+    expect((result.outer.data as { userPrincipalName: string }).userPrincipalName).toBe(
+      "outer-user",
+    );
+  });
+
+  it("refuses outside any scope, even while other users are mid-call", async () => {
+    const [scoped, unscoped] = await Promise.all([
+      runWithUserId("user-A", () => runAppTool("graph_me", {})),
+      runAppTool("graph_me", {}), // no runWithUserId around this one
+    ]);
+
+    expect(scoped.success).toBe(true);
+    expect(unscoped.success).toBe(false);
+    expect(unscoped.error).toMatch(/authenticated user/i);
+  });
+});
+
+// Token-cache isolation lives in token-isolation.test.ts — it needs the REAL
+// graph-token module, which this file mocks.

--- a/ui/src/__tests__/lib/auth/entra-config.test.ts
+++ b/ui/src/__tests__/lib/auth/entra-config.test.ts
@@ -16,6 +16,7 @@ import {
   isEntraConfigured,
   msalConfiguration,
   AAD_HOST,
+  DEFAULT_GRAPH_SCOPES,
 } from "../../../lib/auth/entra-config.server";
 
 const full = {
@@ -39,7 +40,43 @@ describe("buildEntraConfig", () => {
     expect(cfg.authority).toBe(`${AAD_HOST}/tid`);
     expect(cfg.redirectUri).toBe("http://localhost:3444/api/auth/callback");
     expect(cfg.postLogoutRedirectUri).toBe("http://localhost:3444/auth/signin");
-    expect(cfg.scopes).toEqual(["User.Read", "email"]);
+    expect(cfg.scopes).toEqual([...DEFAULT_GRAPH_SCOPES]);
+  });
+
+  it("requests the full connector scope set at sign-in (#110)", () => {
+    const cfg = buildEntraConfig(full);
+    // One consent must cover every connector: background runs have no user
+    // present to consent later.
+    for (const s of ["User.Read", "Mail.Read", "Files.Read.All", "Calendars.ReadWrite"]) {
+      expect(cfg.scopes).toContain(s);
+    }
+  });
+
+  it("AZURE_GRAPH_SCOPES trims the set without a code change", () => {
+    const cfg = buildEntraConfig({ ...full, AZURE_GRAPH_SCOPES: "User.Read, Mail.Read" });
+    expect(cfg.scopes).toEqual(["User.Read", "Mail.Read"]);
+  });
+
+  it("accepts whitespace-separated overrides and ignores blanks", () => {
+    const cfg = buildEntraConfig({ ...full, AZURE_GRAPH_SCOPES: "  User.Read   Mail.Read  " });
+    expect(cfg.scopes).toEqual(["User.Read", "Mail.Read"]);
+  });
+
+  it("falls back to the default set for a blank/empty override", () => {
+    expect(buildEntraConfig({ ...full, AZURE_GRAPH_SCOPES: "   " }).scopes).toEqual([
+      ...DEFAULT_GRAPH_SCOPES,
+    ]);
+    expect(buildEntraConfig({ ...full, AZURE_GRAPH_SCOPES: " , , " }).scopes).toEqual([
+      ...DEFAULT_GRAPH_SCOPES,
+    ]);
+  });
+
+  it("strips reserved OIDC scopes from an override (MSAL would throw)", () => {
+    const cfg = buildEntraConfig({
+      ...full,
+      AZURE_GRAPH_SCOPES: "openid profile offline_access User.Read",
+    });
+    expect(cfg.scopes).toEqual(["User.Read"]);
   });
 
   it("does NOT list reserved OIDC scopes (MSAL adds them)", () => {

--- a/ui/src/__tests__/lib/auth/graph-token.test.ts
+++ b/ui/src/__tests__/lib/auth/graph-token.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Per-user Graph token acquisition (#110) — MSAL, config and store are mocked,
+ * so this runs with no tenant, no network and no database.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../../../lib/harness-patterns/assert.server", () => ({
+  assertServerOnImport: vi.fn(),
+  assertServer: vi.fn(),
+  ServerOnlyError: class ServerOnlyError extends Error {},
+}));
+
+// ---- MSAL double ------------------------------------------------------------
+// The class must be hoisted with the mock factory: vi.mock is lifted above
+// normal declarations, so a plain `class` here would still be in its TDZ when
+// the factory runs.
+const { FakeInteractionRequiredAuthError } = vi.hoisted(() => ({
+  FakeInteractionRequiredAuthError: class extends Error {},
+}));
+
+const acquireTokenSilent = vi.fn();
+const cacheState = {
+  deserialize: vi.fn(),
+  serialize: vi.fn(() => '{"cache":"rotated"}'),
+  hasChanged: vi.fn(() => true),
+  getAccountByHomeId: vi.fn(async () => ({ homeAccountId: "hai-1" })),
+  getAllAccounts: vi.fn(async () => [{ homeAccountId: "hai-1" }]),
+};
+
+vi.mock("@azure/msal-node", () => ({
+  ConfidentialClientApplication: class {
+    getTokenCache() {
+      return cacheState;
+    }
+    acquireTokenSilent = acquireTokenSilent;
+  },
+  InteractionRequiredAuthError: FakeInteractionRequiredAuthError,
+}));
+
+vi.mock("../../../lib/auth/entra-config.server", () => ({
+  buildEntraConfig: () => ({
+    tenantId: "t",
+    clientId: "c",
+    clientSecret: "s",
+    authority: "https://login.microsoftonline.com/t",
+    redirectUri: "http://localhost:3444/api/auth/callback",
+    postLogoutRedirectUri: "http://localhost:3444/auth/signin",
+    scopes: ["User.Read"],
+  }),
+  msalConfiguration: () => ({ auth: { clientId: "c" } }),
+}));
+
+const loadUserTokenCache = vi.fn();
+const saveUserTokenCache = vi.fn(async () => {});
+vi.mock("../../../lib/auth/user-tokens.server", () => ({
+  loadUserTokenCache: (...a: unknown[]) => loadUserTokenCache(...a),
+  saveUserTokenCache: (...a: unknown[]) => saveUserTokenCache(...a),
+}));
+
+import {
+  getUserGraphToken,
+  graphFetch,
+  GraphAuthRequiredError,
+  GRAPH_BASE,
+} from "../../../lib/auth/graph-token.server";
+
+const USER = "oid-123";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  cacheState.hasChanged.mockReturnValue(true);
+  cacheState.serialize.mockReturnValue('{"cache":"rotated"}');
+  cacheState.getAccountByHomeId.mockResolvedValue({ homeAccountId: "hai-1" });
+  cacheState.getAllAccounts.mockResolvedValue([{ homeAccountId: "hai-1" }]);
+  loadUserTokenCache.mockResolvedValue({
+    homeAccountId: "hai-1",
+    tokenCache: '{"cache":"stored"}',
+    updatedAt: new Date(0),
+  });
+  acquireTokenSilent.mockResolvedValue({ accessToken: "tok-abc" });
+});
+
+describe("getUserGraphToken", () => {
+  it("returns a delegated token and rehydrates the user's cache", async () => {
+    await expect(getUserGraphToken(USER)).resolves.toBe("tok-abc");
+    expect(cacheState.deserialize).toHaveBeenCalledWith('{"cache":"stored"}');
+    expect(acquireTokenSilent).toHaveBeenCalledWith(
+      expect.objectContaining({ scopes: ["User.Read"] }),
+    );
+  });
+
+  it("persists the rotated cache when MSAL mutated it", async () => {
+    await getUserGraphToken(USER);
+    expect(saveUserTokenCache).toHaveBeenCalledWith(USER, '{"cache":"rotated"}', "hai-1");
+  });
+
+  it("skips the write-back when the cache is unchanged", async () => {
+    cacheState.hasChanged.mockReturnValue(false);
+    await getUserGraphToken(USER);
+    expect(saveUserTokenCache).not.toHaveBeenCalled();
+  });
+
+  it("still returns the token when the write-back fails", async () => {
+    saveUserTokenCache.mockRejectedValueOnce(new Error("db down"));
+    await expect(getUserGraphToken(USER)).resolves.toBe("tok-abc");
+  });
+
+  it("passes through custom scopes", async () => {
+    await getUserGraphToken(USER, ["Mail.Read"]);
+    expect(acquireTokenSilent).toHaveBeenCalledWith(
+      expect.objectContaining({ scopes: ["Mail.Read"] }),
+    );
+  });
+
+  it("throws GraphAuthRequiredError when the user has no stored cache", async () => {
+    loadUserTokenCache.mockResolvedValue(null);
+    await expect(getUserGraphToken(USER)).rejects.toBeInstanceOf(GraphAuthRequiredError);
+    expect(acquireTokenSilent).not.toHaveBeenCalled();
+  });
+
+  it("throws GraphAuthRequiredError when no account resolves", async () => {
+    cacheState.getAccountByHomeId.mockResolvedValue(null);
+    cacheState.getAllAccounts.mockResolvedValue([]);
+    await expect(getUserGraphToken(USER)).rejects.toBeInstanceOf(GraphAuthRequiredError);
+  });
+
+  it("falls back to the sole cached account when the recorded id misses", async () => {
+    cacheState.getAccountByHomeId.mockResolvedValue(null);
+    cacheState.getAllAccounts.mockResolvedValue([{ homeAccountId: "hai-2" }]);
+    await expect(getUserGraphToken(USER)).resolves.toBe("tok-abc");
+  });
+
+  it("maps InteractionRequiredAuthError → GraphAuthRequiredError", async () => {
+    acquireTokenSilent.mockRejectedValue(new FakeInteractionRequiredAuthError("consent"));
+    await expect(getUserGraphToken(USER)).rejects.toBeInstanceOf(GraphAuthRequiredError);
+  });
+
+  it("propagates unexpected errors unchanged", async () => {
+    acquireTokenSilent.mockRejectedValue(new Error("network boom"));
+    await expect(getUserGraphToken(USER)).rejects.toThrow("network boom");
+  });
+});
+
+describe("graphFetch", () => {
+  it("attaches the bearer token and returns parsed JSON", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ displayName: "U" }),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(graphFetch(USER, "/me")).resolves.toEqual({ displayName: "U" });
+
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe(`${GRAPH_BASE}/me`);
+    expect((init.headers as Record<string, string>).Authorization).toBe("Bearer tok-abc");
+  });
+
+  it("accepts an absolute URL (nextLink pagination)", async () => {
+    const fetchMock = vi.fn(async () => ({ ok: true, status: 200, json: async () => ({}) }));
+    vi.stubGlobal("fetch", fetchMock);
+    await graphFetch(USER, "https://graph.microsoft.com/v1.0/me/messages?$skip=10");
+    expect((fetchMock.mock.calls[0] as unknown as [string])[0]).toContain("$skip=10");
+  });
+
+  it("maps 401/403 to GraphAuthRequiredError", async () => {
+    for (const status of [401, 403]) {
+      vi.stubGlobal("fetch", vi.fn(async () => ({ ok: false, status, statusText: "no" })));
+      await expect(graphFetch(USER, "/me")).rejects.toBeInstanceOf(GraphAuthRequiredError);
+    }
+  });
+
+  it("throws a plain error on other failures", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: false, status: 500, statusText: "Server Error" })),
+    );
+    await expect(graphFetch(USER, "/me")).rejects.toThrow(/500/);
+  });
+
+  it("returns null for 204 No Content", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ({ ok: true, status: 204 })));
+    await expect(graphFetch(USER, "/me")).resolves.toBeNull();
+  });
+});

--- a/ui/src/__tests__/lib/auth/graph-token.test.ts
+++ b/ui/src/__tests__/lib/auth/graph-token.test.ts
@@ -18,13 +18,19 @@ const { FakeInteractionRequiredAuthError } = vi.hoisted(() => ({
   FakeInteractionRequiredAuthError: class extends Error {},
 }));
 
+type FakeAccount = { homeAccountId: string };
+
 const acquireTokenSilent = vi.fn();
 const cacheState = {
   deserialize: vi.fn(),
   serialize: vi.fn(() => '{"cache":"rotated"}'),
   hasChanged: vi.fn(() => true),
-  getAccountByHomeId: vi.fn(async () => ({ homeAccountId: "hai-1" })),
-  getAllAccounts: vi.fn(async () => [{ homeAccountId: "hai-1" }]),
+  getAccountByHomeId: vi.fn<(id: string) => Promise<FakeAccount | null>>(async () => ({
+    homeAccountId: "hai-1",
+  })),
+  getAllAccounts: vi.fn<() => Promise<FakeAccount[]>>(async () => [
+    { homeAccountId: "hai-1" },
+  ]),
 };
 
 vi.mock("@azure/msal-node", () => ({
@@ -50,11 +56,14 @@ vi.mock("../../../lib/auth/entra-config.server", () => ({
   msalConfiguration: () => ({ auth: { clientId: "c" } }),
 }));
 
-const loadUserTokenCache = vi.fn();
-const saveUserTokenCache = vi.fn(async () => {});
+const loadUserTokenCache = vi.fn<(userId: string) => Promise<unknown>>();
+const saveUserTokenCache = vi.fn<
+  (userId: string, cache: string, homeAccountId: string | null) => Promise<void>
+>(async () => {});
 vi.mock("../../../lib/auth/user-tokens.server", () => ({
-  loadUserTokenCache: (...a: unknown[]) => loadUserTokenCache(...a),
-  saveUserTokenCache: (...a: unknown[]) => saveUserTokenCache(...a),
+  loadUserTokenCache: (userId: string) => loadUserTokenCache(userId),
+  saveUserTokenCache: (userId: string, cache: string, hai: string | null) =>
+    saveUserTokenCache(userId, cache, hai),
 }));
 
 import {

--- a/ui/src/__tests__/lib/auth/secret-crypto.test.ts
+++ b/ui/src/__tests__/lib/auth/secret-crypto.test.ts
@@ -1,0 +1,84 @@
+/**
+ * At-rest secret encryption (#110). Keys are injectable so no env is touched.
+ */
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("../../../lib/harness-patterns/assert.server", () => ({
+  assertServerOnImport: vi.fn(),
+  assertServer: vi.fn(),
+  ServerOnlyError: class ServerOnlyError extends Error {},
+}));
+
+import {
+  encryptSecret,
+  decryptSecret,
+  generateEncryptionKey,
+} from "../../../lib/auth/secret-crypto.server";
+import { hkdfSync, randomBytes } from "node:crypto";
+
+const KEY = Buffer.from(randomBytes(32));
+const OTHER_KEY = Buffer.from(randomBytes(32));
+
+describe("encryptSecret / decryptSecret", () => {
+  it("round-trips a payload", () => {
+    const plain = JSON.stringify({ RefreshToken: { secret: "r1" } });
+    const env = encryptSecret(plain, KEY);
+    expect(decryptSecret(env, KEY)).toBe(plain);
+  });
+
+  it("does not leak plaintext into the envelope", () => {
+    const env = encryptSecret("super-secret-refresh-token", KEY);
+    expect(env).not.toContain("super-secret-refresh-token");
+    expect(env.startsWith("v1.")).toBe(true);
+    expect(env.split(".")).toHaveLength(4);
+  });
+
+  it("is non-deterministic (fresh IV per call)", () => {
+    expect(encryptSecret("same", KEY)).not.toBe(encryptSecret("same", KEY));
+  });
+
+  it("returns null for a wrong key (GCM auth failure)", () => {
+    expect(decryptSecret(encryptSecret("x", KEY), OTHER_KEY)).toBeNull();
+  });
+
+  it("returns null for tampered ciphertext", () => {
+    const parts = encryptSecret("x", KEY).split(".");
+    const flipped = Buffer.from(parts[3], "base64url");
+    flipped[0] ^= 0xff;
+    parts[3] = flipped.toString("base64url");
+    expect(decryptSecret(parts.join("."), KEY)).toBeNull();
+  });
+
+  it("returns null for malformed / empty / unknown-version input", () => {
+    expect(decryptSecret(null, KEY)).toBeNull();
+    expect(decryptSecret(undefined, KEY)).toBeNull();
+    expect(decryptSecret("", KEY)).toBeNull();
+    expect(decryptSecret("not-an-envelope", KEY)).toBeNull();
+    expect(decryptSecret("v9.a.b.c", KEY)).toBeNull();
+    expect(decryptSecret("v1.a.b", KEY)).toBeNull();
+  });
+
+  it("handles unicode and large payloads", () => {
+    const big = "é🔐".repeat(5000);
+    expect(decryptSecret(encryptSecret(big, KEY), KEY)).toBe(big);
+  });
+});
+
+describe("key handling", () => {
+  it("generateEncryptionKey returns 32 bytes of base64", () => {
+    const k = generateEncryptionKey();
+    expect(Buffer.from(k, "base64")).toHaveLength(32);
+  });
+
+  it("derives the same key from the same env secret (HKDF is deterministic)", () => {
+    const derive = (s: string) =>
+      Buffer.from(hkdfSync("sha256", Buffer.from(s), Buffer.alloc(0), "kg-agent:secret-crypto:v1", 32));
+    const a = derive("secret-a");
+    const b = derive("secret-a");
+    expect(a.equals(b)).toBe(true);
+    // …and a different secret yields a different key (domain separation holds).
+    expect(a.equals(derive("secret-b"))).toBe(false);
+    // Round-trip through the derived key works.
+    expect(decryptSecret(encryptSecret("v", a), b)).toBe("v");
+  });
+});

--- a/ui/src/__tests__/lib/auth/session-store.test.ts
+++ b/ui/src/__tests__/lib/auth/session-store.test.ts
@@ -17,7 +17,6 @@ import {
   createSession,
   getSession,
   deleteSession,
-  getSessionTokenCache,
 } from "../../../lib/auth/session-store.server";
 import { closePool, query } from "../../../lib/db/client.server";
 
@@ -40,17 +39,14 @@ afterAll(async () => {
 });
 
 describe("auth session store", () => {
-  it("round-trips a session with its token cache", async () => {
+  it("round-trips a session (token cache now lives per-user, see #110)", async () => {
     if (!dbAvailable) return;
-    const id = await createSession(
-      {
-        userId: TEST_USER,
-        email: "u@corp.com",
-        displayName: "U",
-        homeAccountId: "hai-1",
-      },
-      { tokenCache: '{"cache":1}' },
-    );
+    const id = await createSession({
+      userId: TEST_USER,
+      email: "u@corp.com",
+      displayName: "U",
+      homeAccountId: "hai-1",
+    });
 
     const s = await getSession(id);
     expect(s).not.toBeNull();
@@ -58,7 +54,6 @@ describe("auth session store", () => {
     expect(s!.email).toBe("u@corp.com");
     expect(s!.displayName).toBe("U");
     expect(s!.homeAccountId).toBe("hai-1");
-    expect(await getSessionTokenCache(id)).toBe('{"cache":1}');
 
     await deleteSession(id);
     expect(await getSession(id)).toBeNull();

--- a/ui/src/__tests__/lib/auth/user-tokens.test.ts
+++ b/ui/src/__tests__/lib/auth/user-tokens.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Per-user encrypted MSAL token cache (#110).
+ *
+ * Hits the live Postgres container (mirrors session-store.test.ts); skips
+ * gracefully when Postgres isn't reachable.
+ */
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+
+vi.mock("../../../lib/harness-patterns/assert.server", () => ({
+  assertServerOnImport: vi.fn(),
+  assertServer: vi.fn(),
+  ServerOnlyError: class ServerOnlyError extends Error {},
+}));
+
+// The store encrypts with a key derived from AUTH_SESSION_SECRET when no
+// dedicated TOKEN_ENCRYPTION_KEY is set. Pin one so the test is self-contained.
+process.env.TOKEN_ENCRYPTION_KEY ||= "unit-test-token-encryption-key";
+
+import {
+  saveUserTokenCache,
+  loadUserTokenCache,
+  hasUserTokenCache,
+  deleteUserTokenCache,
+} from "../../../lib/auth/user-tokens.server";
+import { closePool, query } from "../../../lib/db/client.server";
+
+const TEST_OID = `test-oid-${Math.random().toString(36).slice(2, 10)}`;
+const CACHE = JSON.stringify({ RefreshToken: { "x-y": { secret: "r3fr3sh" } } });
+let dbAvailable = true;
+
+beforeAll(async () => {
+  try {
+    await query("SELECT 1");
+  } catch (err) {
+    dbAvailable = false;
+    console.warn("[user-tokens.test] Postgres unreachable, skipping:", err);
+  }
+});
+
+afterAll(async () => {
+  if (!dbAvailable) return;
+  await query("DELETE FROM user_tokens WHERE user_id = $1", [TEST_OID]);
+  await closePool();
+});
+
+describe("per-user token cache", () => {
+  it("round-trips a cache and reports existence", async () => {
+    if (!dbAvailable) return;
+    expect(await hasUserTokenCache(TEST_OID)).toBe(false);
+
+    await saveUserTokenCache(TEST_OID, CACHE, "home-acct-1");
+
+    const loaded = await loadUserTokenCache(TEST_OID);
+    expect(loaded).not.toBeNull();
+    expect(loaded!.tokenCache).toBe(CACHE);
+    expect(loaded!.homeAccountId).toBe("home-acct-1");
+    expect(await hasUserTokenCache(TEST_OID)).toBe(true);
+  });
+
+  it("stores the cache ENCRYPTED at rest (no plaintext secret in the row)", async () => {
+    if (!dbAvailable) return;
+    const { rows } = await query<{ token_cache: string }>(
+      "SELECT token_cache FROM user_tokens WHERE user_id = $1",
+      [TEST_OID],
+    );
+    expect(rows[0].token_cache).not.toContain("r3fr3sh");
+    expect(rows[0].token_cache).not.toContain("RefreshToken");
+    expect(rows[0].token_cache.startsWith("v1.")).toBe(true);
+  });
+
+  it("upsert replaces the cache (refresh-token rotation) and bumps updated_at", async () => {
+    if (!dbAvailable) return;
+    const before = await loadUserTokenCache(TEST_OID);
+    await new Promise((r) => setTimeout(r, 25));
+
+    const rotated = JSON.stringify({ RefreshToken: { "x-y": { secret: "rotated" } } });
+    await saveUserTokenCache(TEST_OID, rotated, "home-acct-2");
+
+    const after = await loadUserTokenCache(TEST_OID);
+    expect(after!.tokenCache).toBe(rotated);
+    expect(after!.homeAccountId).toBe("home-acct-2");
+    expect(after!.updatedAt.getTime()).toBeGreaterThan(before!.updatedAt.getTime());
+  });
+
+  it("treats an undecryptable row as absent (re-auth required)", async () => {
+    if (!dbAvailable) return;
+    await query("UPDATE user_tokens SET token_cache = $2 WHERE user_id = $1", [
+      TEST_OID,
+      "v1.aaaa.bbbb.cccc", // well-formed shape, bogus contents
+    ]);
+    expect(await loadUserTokenCache(TEST_OID)).toBeNull();
+    // …but existence is still true: the row is there, just unusable.
+    expect(await hasUserTokenCache(TEST_OID)).toBe(true);
+  });
+
+  it("delete is idempotent and clears the cache", async () => {
+    if (!dbAvailable) return;
+    await deleteUserTokenCache(TEST_OID);
+    expect(await loadUserTokenCache(TEST_OID)).toBeNull();
+    expect(await hasUserTokenCache(TEST_OID)).toBe(false);
+    await deleteUserTokenCache(TEST_OID); // no throw
+  });
+
+  it("returns null for a user who never signed in", async () => {
+    if (!dbAvailable) return;
+    expect(await loadUserTokenCache("never-signed-in-oid")).toBeNull();
+  });
+});

--- a/ui/src/__tests__/lib/harness-patterns/mcp-client.test.ts
+++ b/ui/src/__tests__/lib/harness-patterns/mcp-client.test.ts
@@ -303,24 +303,35 @@ describe('mcp-client', () => {
       expect(typeof listTools).toBe('function')
     })
 
-    it('should return list of tool descriptions', async () => {
+    it('should return gateway tool descriptions', async () => {
       const { listTools } = await import('../../../lib/harness-patterns/mcp-client.server')
 
       const tools = await listTools()
 
-      expect(tools).toHaveLength(1)
-      expect(tools[0].name).toBe('test_tool')
-      expect(tools[0].description).toBe('A test tool')
+      const gateway = tools.find((t) => t.name === 'test_tool')
+      expect(gateway).toBeDefined()
+      expect(gateway!.description).toBe('A test tool')
     })
 
-    it('should return empty array on error', async () => {
+    it('should append in-process app tools to the gateway list (#110)', async () => {
+      const { listTools } = await import('../../../lib/harness-patterns/mcp-client.server')
+
+      const tools = await listTools()
+
+      // App-side tools (per-user Graph) are advertised alongside gateway tools.
+      expect(tools.map((t) => t.name)).toContain('graph_me')
+    })
+
+    it('should still offer app tools when the gateway fails', async () => {
       mockListTools.mockRejectedValue(new Error('Failed'))
 
       const { listTools } = await import('../../../lib/harness-patterns/mcp-client.server')
 
       const tools = await listTools()
 
-      expect(tools).toEqual([])
+      // No gateway tools, but app tools run in-process so they survive.
+      expect(tools.every((t) => t.name !== 'test_tool')).toBe(true)
+      expect(tools.map((t) => t.name)).toContain('graph_me')
     })
   })
 

--- a/ui/src/global.d.ts
+++ b/ui/src/global.d.ts
@@ -15,6 +15,9 @@ declare namespace NodeJS {
     /** Encrypts the per-user MSAL token cache at rest (#110). Falls back to
      *  an HKDF derivation from AUTH_SESSION_SECRET when unset. */
     TOKEN_ENCRYPTION_KEY: string;
+    /** Override the delegated Graph scopes requested at sign-in (space- or
+     *  comma-separated). Escape hatch when a scope isn't consented (#110). */
+    AZURE_GRAPH_SCOPES: string;
     /** OIDC redirect URI; must match a registered Redirect URI. */
     AUTH_REDIRECT_URI: string;
     /** Post-sign-out landing URI. */

--- a/ui/src/global.d.ts
+++ b/ui/src/global.d.ts
@@ -12,6 +12,9 @@ declare namespace NodeJS {
     AZURE_CLIENT_SECRET: string;
     /** HMAC key for signed auth cookies (`openssl rand -base64 32`). */
     AUTH_SESSION_SECRET: string;
+    /** Encrypts the per-user MSAL token cache at rest (#110). Falls back to
+     *  an HKDF derivation from AUTH_SESSION_SECRET when unset. */
+    TOKEN_ENCRYPTION_KEY: string;
     /** OIDC redirect URI; must match a registered Redirect URI. */
     AUTH_REDIRECT_URI: string;
     /** Post-sign-out landing URI. */

--- a/ui/src/global.d.ts
+++ b/ui/src/global.d.ts
@@ -18,6 +18,9 @@ declare namespace NodeJS {
     /** Override the delegated Graph scopes requested at sign-in (space- or
      *  comma-separated). Escape hatch when a scope isn't consented (#110). */
     AZURE_GRAPH_SCOPES: string;
+    /** IANA timezone Graph renders calendar times in (#110). Defaults to the
+     *  server's own zone. */
+    GRAPH_TIMEZONE: string;
     /** OIDC redirect URI; must match a registered Redirect URI. */
     AUTH_REDIRECT_URI: string;
     /** Post-sign-out landing URI. */

--- a/ui/src/lib/app-tools/graph.server.ts
+++ b/ui/src/lib/app-tools/graph.server.ts
@@ -1,0 +1,72 @@
+/**
+ * Microsoft Graph app-side tools (Pattern C, #110) — Server Only.
+ *
+ * Each tool calls Graph **as the signed-in user** via `graphFetch`, which
+ * resolves that user's delegated token server-side. Entra enforces the scope,
+ * so we don't write a scoping guard and the model never sees a credential.
+ *
+ * First slice is deliberately `User.Read`-only — the scope already has tenant
+ * admin consent, so the whole per-user token path is provable end-to-end with
+ * no new tenant configuration. Mail/Files/Calendar tools slot in here once
+ * their scopes are consented and added to the sign-in request
+ * (`entra-config.server.ts`).
+ */
+import { assertServerOnImport } from "../harness-patterns/assert.server";
+import { graphFetch } from "../auth/graph-token.server";
+import { registerAppTool } from "./registry.server";
+
+assertServerOnImport();
+
+/** Fields we surface from `/me`. Explicit so we never dump the whole payload
+ *  (which can include tenant metadata) into the model's context. */
+const ME_FIELDS = [
+  "displayName",
+  "givenName",
+  "surname",
+  "userPrincipalName",
+  "mail",
+  "jobTitle",
+  "officeLocation",
+  "preferredLanguage",
+] as const;
+
+export interface GraphMeResult {
+  displayName: string | null;
+  givenName: string | null;
+  surname: string | null;
+  userPrincipalName: string | null;
+  mail: string | null;
+  jobTitle: string | null;
+  officeLocation: string | null;
+  preferredLanguage: string | null;
+}
+
+/** Pick + null-normalize the fields we advertise. */
+export function shapeMe(raw: unknown): GraphMeResult {
+  const src = (raw ?? {}) as Record<string, unknown>;
+  const out = {} as Record<string, string | null>;
+  for (const f of ME_FIELDS) {
+    const v = src[f];
+    out[f] = typeof v === "string" && v.trim() ? v : null;
+  }
+  return out as unknown as GraphMeResult;
+}
+
+registerAppTool({
+  name: "graph_me",
+  namespace: "graph",
+  description:
+    "Get the signed-in user's own Microsoft 365 profile (name, work email/UPN, " +
+    "job title, office, language). Acts as the current user — no user or token " +
+    "argument is accepted or needed.",
+  // No parameters at all: the identity is the request's authenticated user.
+  inputSchema: { type: "object", properties: {}, additionalProperties: false },
+  execute: async (_args, { userId }) => {
+    const raw = await graphFetch(
+      userId,
+      `/me?$select=${ME_FIELDS.join(",")}`,
+      { scopes: ["User.Read"] },
+    );
+    return shapeMe(raw);
+  },
+});

--- a/ui/src/lib/app-tools/graph.server.ts
+++ b/ui/src/lib/app-tools/graph.server.ts
@@ -52,6 +52,182 @@ export function shapeMe(raw: unknown): GraphMeResult {
   return out as unknown as GraphMeResult;
 }
 
+// ============================================================================
+// Calendar
+// ============================================================================
+
+/** IANA timezone Graph should render event times in. Defaults to the server's
+ *  own zone, which is right for a single-tenant deployment; override with
+ *  `GRAPH_TIMEZONE` if the app and its users don't share one. */
+function graphTimeZone(): string {
+  return (
+    process.env.GRAPH_TIMEZONE?.trim() ||
+    Intl.DateTimeFormat().resolvedOptions().timeZone ||
+    "UTC"
+  );
+}
+
+/**
+ * Local-day bounds as naive ISO strings (no `Z`). Graph interprets these in the
+ * timezone from the `Prefer: outlook.timezone` header, so we must NOT send UTC
+ * instants here — that would shift the day boundary.
+ */
+export function localDayBounds(now: Date, dayOffset = 0): { start: string; end: string } {
+  const d = new Date(now);
+  d.setDate(d.getDate() + dayOffset);
+  const pad = (n: number) => String(n).padStart(2, "0");
+  const day = `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+  return { start: `${day}T00:00:00`, end: `${day}T23:59:59` };
+}
+
+export interface CalendarEvent {
+  subject: string | null;
+  start: string | null;
+  end: string | null;
+  isAllDay: boolean;
+  location: string | null;
+  organizer: string | null;
+  onlineMeetingUrl: string | null;
+}
+
+/** Flatten Graph's nested event shape into something compact for the model. */
+export function shapeEvents(raw: unknown): CalendarEvent[] {
+  const items = (raw as { value?: unknown[] })?.value;
+  if (!Array.isArray(items)) return [];
+  return items.map((it) => {
+    const e = (it ?? {}) as Record<string, unknown>;
+    const str = (v: unknown) => (typeof v === "string" && v.trim() ? v : null);
+    return {
+      subject: str(e.subject),
+      start: str((e.start as { dateTime?: unknown })?.dateTime),
+      end: str((e.end as { dateTime?: unknown })?.dateTime),
+      isAllDay: e.isAllDay === true,
+      location: str((e.location as { displayName?: unknown })?.displayName),
+      organizer: str(
+        ((e.organizer as { emailAddress?: Record<string, unknown> })?.emailAddress
+          ?.name ??
+          (e.organizer as { emailAddress?: Record<string, unknown> })?.emailAddress
+            ?.address) as unknown,
+      ),
+      onlineMeetingUrl: str(e.onlineMeetingUrl),
+    };
+  });
+}
+
+registerAppTool({
+  name: "graph_calendar_today",
+  namespace: "graph",
+  description:
+    "List the signed-in user's own calendar events for today (or another day via " +
+    "day_offset: 0=today, 1=tomorrow, -1=yesterday). Returns subject, start/end, " +
+    "location and organizer. Expands recurring meetings. Acts as the current user.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      day_offset: {
+        type: "integer",
+        description: "Days from today. 0=today (default), 1=tomorrow, -1=yesterday.",
+      },
+    },
+    additionalProperties: false,
+  },
+  execute: async (args, { userId }) => {
+    const offset = Number.isFinite(Number(args.day_offset))
+      ? Number(args.day_offset)
+      : 0;
+    const tz = graphTimeZone();
+    const { start, end } = localDayBounds(new Date(), offset);
+
+    // calendarView (not /events) so recurring series are expanded into
+    // occurrences within the window.
+    const raw = await graphFetch(
+      userId,
+      `/me/calendarView?startDateTime=${start}&endDateTime=${end}` +
+        `&$select=subject,start,end,isAllDay,location,organizer,onlineMeetingUrl` +
+        `&$orderby=start/dateTime&$top=50`,
+      {
+        scopes: ["Calendars.ReadWrite"],
+        headers: { Prefer: `outlook.timezone="${tz}"` },
+      },
+    );
+    return { timeZone: tz, day: start.slice(0, 10), events: shapeEvents(raw) };
+  },
+});
+
+// ============================================================================
+// Mail
+// ============================================================================
+
+export interface MailMessage {
+  subject: string | null;
+  from: string | null;
+  received: string | null;
+  isRead: boolean;
+  hasAttachments: boolean;
+  preview: string | null;
+  webLink: string | null;
+}
+
+/** Compact Graph's message shape; `bodyPreview` is truncated to keep turns small. */
+export function shapeMessages(raw: unknown): MailMessage[] {
+  const items = (raw as { value?: unknown[] })?.value;
+  if (!Array.isArray(items)) return [];
+  return items.map((it) => {
+    const m = (it ?? {}) as Record<string, unknown>;
+    const str = (v: unknown) => (typeof v === "string" && v.trim() ? v : null);
+    const sender = (m.from as { emailAddress?: Record<string, unknown> })?.emailAddress;
+    const preview = str(m.bodyPreview);
+    return {
+      subject: str(m.subject),
+      from: str((sender?.name ?? sender?.address) as unknown),
+      received: str(m.receivedDateTime),
+      isRead: m.isRead === true,
+      hasAttachments: m.hasAttachments === true,
+      preview: preview ? preview.slice(0, 300) : null,
+      webLink: str(m.webLink),
+    };
+  });
+}
+
+registerAppTool({
+  name: "graph_mail_recent",
+  namespace: "graph",
+  description:
+    "List recent messages from the signed-in user's inbox, newest first. Set " +
+    "unread_only=true for just unread mail. Returns sender, subject, received " +
+    "time and a short preview — not full bodies. Acts as the current user.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      unread_only: {
+        type: "boolean",
+        description: "Only unread messages (default false).",
+      },
+      limit: {
+        type: "integer",
+        description: "How many messages to return, 1-25 (default 10).",
+      },
+    },
+    additionalProperties: false,
+  },
+  execute: async (args, { userId }) => {
+    const limit = Math.min(Math.max(Number(args.limit) || 10, 1), 25);
+    const unreadOnly = args.unread_only === true;
+
+    // Inbox specifically (not all folders), so Sent/Archive don't pollute
+    // "recent mail". $filter + $orderby together is supported on messages.
+    const raw = await graphFetch(
+      userId,
+      `/me/mailFolders/inbox/messages?$top=${limit}` +
+        `&$select=subject,from,receivedDateTime,isRead,hasAttachments,bodyPreview,webLink` +
+        `&$orderby=receivedDateTime desc` +
+        (unreadOnly ? `&$filter=isRead eq false` : ""),
+      { scopes: ["Mail.Read"] },
+    );
+    return { unreadOnly, messages: shapeMessages(raw) };
+  },
+});
+
 registerAppTool({
   name: "graph_me",
   namespace: "graph",

--- a/ui/src/lib/app-tools/index.server.ts
+++ b/ui/src/lib/app-tools/index.server.ts
@@ -1,0 +1,22 @@
+/**
+ * App-side tools barrel — Server Only.
+ *
+ * Importing this module registers every built-in app tool as a side effect,
+ * then re-exports the registry accessors. `mcp-client.server.ts` and
+ * `tools.server.ts` import from here (never from `registry.server.ts`
+ * directly) so tool registration can't be skipped by import order.
+ *
+ * Add new app-side tool modules to the side-effect import list below —
+ * e.g. Pattern B (#109) per-user vault tools.
+ */
+import "./graph.server";
+
+export {
+  hasAppTool,
+  runAppTool,
+  appToolDescriptions,
+  appToolNamespace,
+  registerAppTool,
+  type AppToolDefinition,
+  type AppToolContext,
+} from "./registry.server";

--- a/ui/src/lib/app-tools/registry.server.ts
+++ b/ui/src/lib/app-tools/registry.server.ts
@@ -1,0 +1,112 @@
+/**
+ * App-side tool registry — Server Only.
+ *
+ * A third tool transport alongside the MCP gateway and the sandbox: tools that
+ * execute **in this process** so a credential can be resolved server-side from
+ * the authenticated user and never leave it.
+ *
+ * ## Why these can't be gateway tools
+ * The MCP gateway is a single shared-identity credential boundary (#107): every
+ * user's calls run as one principal, and the static-secret model can't inject
+ * per-user credentials. Per-user Microsoft Graph access (#110) therefore cannot
+ * go through it without giving up delegated per-user scope — the entire point.
+ *
+ * ## Invariants
+ * - The schema advertised to the model has **no credential field** (#107
+ *   principle 1). The user id comes from `getRequestUserId()` at call time, so
+ *   the model cannot choose whose data to read.
+ * - Executors receive `{ userId }` and resolve tokens themselves; a token must
+ *   never appear in args, results, logs or the event stream.
+ * - Errors become `{ success: false, error }` rather than throwing, so one
+ *   failing tool degrades a turn instead of killing a run.
+ */
+import { assertServerOnImport } from "../harness-patterns/assert.server";
+import type { ToolCallResult, MCPToolDescription } from "../harness-patterns/types";
+import { getRequestUserId } from "../harness-client/request-user.server";
+
+assertServerOnImport();
+
+export interface AppToolContext {
+  /** Authenticated user id (Entra `oid`), resolved server-side. */
+  userId: string;
+}
+
+export interface AppToolDefinition {
+  name: string;
+  description: string;
+  /** JSON Schema shown to the model. MUST NOT contain a token/credential. */
+  inputSchema: Record<string, unknown>;
+  /** Namespace for `ToolSet` grouping (e.g. `graph`), mirrors MCP servers. */
+  namespace: string;
+  execute: (
+    args: Record<string, unknown>,
+    ctx: AppToolContext,
+  ) => Promise<unknown>;
+}
+
+const registry = new Map<string, AppToolDefinition>();
+
+/** Register an app-side tool. Later registration of the same name wins. */
+export function registerAppTool(def: AppToolDefinition): void {
+  registry.set(def.name, def);
+}
+
+/** Is this tool name handled in-process? Used by `callTool` dispatch. */
+export function hasAppTool(name: string): boolean {
+  return registry.has(name);
+}
+
+/** Namespace for a registered app tool, or null when not one of ours. */
+export function appToolNamespace(name: string): string | null {
+  return registry.get(name)?.namespace ?? null;
+}
+
+/** Advertise app tools alongside the gateway's, in the same shape. */
+export function appToolDescriptions(): MCPToolDescription[] {
+  return [...registry.values()].map((t) => ({
+    name: t.name,
+    description: t.description,
+    inputSchema: t.inputSchema,
+  }));
+}
+
+/** Test helper: drop all registrations. */
+export function __resetAppTools(): void {
+  registry.clear();
+}
+
+/**
+ * Execute a registered app tool. Resolves the caller's user id from the
+ * request scope — established by `runWithUserId()` in both the interactive
+ * path (`runTurn`) and background runs (`runAgentInBackground`).
+ */
+export async function runAppTool(
+  name: string,
+  args: Record<string, unknown>,
+): Promise<ToolCallResult> {
+  const def = registry.get(name);
+  if (!def) {
+    return { success: false, data: null, error: `Unknown app tool: ${name}` };
+  }
+
+  const userId = getRequestUserId();
+  if (!userId) {
+    // No user scope — e.g. a background summarization path outside
+    // runWithUserId. Refuse rather than guess an identity.
+    return {
+      success: false,
+      data: null,
+      error: `${name} requires an authenticated user, but no user is in scope for this call.`,
+    };
+  }
+
+  try {
+    return { success: true, data: await def.execute(args, { userId }) };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    // Deliberately no stack/credential detail in the tool result — it flows
+    // into the model's context and the event log.
+    console.error(`[app-tools] ${name} failed:`, message);
+    return { success: false, data: null, error: message };
+  }
+}

--- a/ui/src/lib/auth/entra-config.server.ts
+++ b/ui/src/lib/auth/entra-config.server.ts
@@ -40,6 +40,55 @@ const DEFAULT_REDIRECT_URI = "http://localhost:3444/api/auth/callback";
 const DEFAULT_POST_LOGOUT_REDIRECT_URI = "http://localhost:3444/auth/signin";
 
 /**
+ * Reserved OIDC scopes MSAL adds itself; passing them explicitly makes MSAL
+ * throw. Filtered defensively so an operator-supplied `AZURE_GRAPH_SCOPES`
+ * can't break sign-in by including them.
+ */
+const RESERVED_SCOPES = new Set(["openid", "profile", "offline_access"]);
+
+/**
+ * Delegated Graph scopes requested **at sign-in**, so one consent covers every
+ * connector and the stored refresh token can mint any of them silently. This
+ * matters beyond convenience: background runs (`POST /api/agents/:id`) have no
+ * user present to consent, so a scope missing here can never be obtained later
+ * without dragging the user back through an interactive sign-in.
+ *
+ * Consequence to keep in mind: **adding a scope to this list forces every user
+ * to sign in again**, because their stored refresh token must cover it. Hence
+ * the full set up front.
+ *
+ * Each scope must also exist under the app registration's API permissions with
+ * consent granted — see `docs/deploy/entra-setup.md`. A scope requested here but
+ * not consented fails the whole sign-in (not just that connector), so
+ * `AZURE_GRAPH_SCOPES` exists as an escape hatch: set it to a trimmed,
+ * space- or comma-separated list to drop a problem scope without a code change.
+ *
+ * WRITE scopes are included deliberately (one-and-done consent). Note that a
+ * granted scope is not a capability: the model can only do what a *registered
+ * tool* exposes, and today only the read-only `graph_me` exists. Any future
+ * write tool should carry its own confirmation gate.
+ */
+export const DEFAULT_GRAPH_SCOPES: readonly string[] = [
+  "User.Read", // own profile
+  "email",
+  "Mail.Read", // read mailbox
+  "Mail.Send", // WRITE: send as the user
+  "Calendars.ReadWrite", // WRITE: create/modify events
+  "Files.Read.All", // OneDrive + SharePoint files the user can access
+  "Sites.Read.All", // SharePoint sites the user can access
+];
+
+/** Parse an operator-supplied scope override (comma or whitespace separated). */
+function parseScopes(raw: string | undefined): string[] | null {
+  if (!raw?.trim()) return null;
+  const list = raw
+    .split(/[\s,]+/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0 && !RESERVED_SCOPES.has(s.toLowerCase()));
+  return list.length > 0 ? list : null;
+}
+
+/**
  * True when all three `AZURE_*` secrets are present. `/api/auth/login` checks
  * this and returns a helpful error instead of a raw MSAL crash when the tenant
  * config hasn't been filled in yet (dev-bypass remains the zero-config path).
@@ -74,7 +123,7 @@ export function buildEntraConfig(
     postLogoutRedirectUri:
       env.AUTH_POST_LOGOUT_REDIRECT_URI?.trim() ||
       DEFAULT_POST_LOGOUT_REDIRECT_URI,
-    scopes: ["User.Read", "email"],
+    scopes: parseScopes(env.AZURE_GRAPH_SCOPES) ?? [...DEFAULT_GRAPH_SCOPES],
   };
 }
 

--- a/ui/src/lib/auth/graph-token.server.ts
+++ b/ui/src/lib/auth/graph-token.server.ts
@@ -159,7 +159,14 @@ async function resolveAccount(
 export async function graphFetch(
   userId: string,
   path: string,
-  init: { method?: string; scopes?: readonly string[]; body?: unknown } = {},
+  init: {
+    method?: string;
+    scopes?: readonly string[];
+    body?: unknown;
+    /** Extra request headers, e.g. `Prefer: outlook.timezone="Europe/Brussels"`.
+     *  Cannot override Authorization — the credential is set here, not by callers. */
+    headers?: Record<string, string>;
+  } = {},
 ): Promise<unknown> {
   const token = await getUserGraphToken(userId, init.scopes ?? DEFAULT_GRAPH_SCOPES);
   const url = path.startsWith("http") ? path : `${GRAPH_BASE}${path}`;
@@ -167,6 +174,8 @@ export async function graphFetch(
   const res = await fetch(url, {
     method: init.method ?? "GET",
     headers: {
+      ...init.headers,
+      // Set last so a caller can never replace the credential or content type.
       Authorization: `Bearer ${token}`,
       Accept: "application/json",
       ...(init.body ? { "Content-Type": "application/json" } : {}),

--- a/ui/src/lib/auth/graph-token.server.ts
+++ b/ui/src/lib/auth/graph-token.server.ts
@@ -1,0 +1,192 @@
+/**
+ * Per-user Microsoft Graph tokens — Server Only.
+ *
+ * Pattern C (#110): obtain a short-lived access token that acts **as the
+ * signed-in user**, so Entra enforces the delegated scope and we never rely on
+ * an over-privileged org token guarded only by app code.
+ *
+ * ## Why `acquireTokenSilent` and not the OBO grant
+ * The classic On-Behalf-Of grant is for a *middle-tier API*: a separate client
+ * (SPA/mobile) signs in, receives a token scoped to **our** API, calls us, and
+ * we exchange that user assertion for a downstream token. Since #119 this app
+ * **is** the confidential OIDC client — the browser holds an opaque session
+ * cookie, not a token — so there is no user assertion to exchange. We already
+ * hold the user's refresh token from sign-in, which makes `acquireTokenSilent`
+ * the correct (and simpler) call: same outcome, delegated per-user token from
+ * Entra, no `api://…/access_as_user` scope and no "Expose an API" config.
+ *
+ * `acquireTokenOnBehalfOf` becomes necessary only if a distinct client ever
+ * authenticates to Entra itself and calls our API (e.g. giving the iOS
+ * Shortcut its own client id). The token-cache plumbing here is the seam for
+ * that; see `docs/deploy/entra-setup.md`.
+ *
+ * ## Security posture (#107 principle 1)
+ * Tokens are resolved server-side from the authenticated `userId` and are
+ * never tool arguments, never logged, and never placed in the prompt/context.
+ * Callers should prefer {@link graphFetch}, which attaches the credential
+ * internally so no calling code ever handles a raw token.
+ */
+import {
+  ConfidentialClientApplication,
+  InteractionRequiredAuthError,
+  type AccountInfo,
+} from "@azure/msal-node";
+import { assertServerOnImport } from "../harness-patterns/assert.server";
+import { buildEntraConfig, msalConfiguration } from "./entra-config.server";
+import { loadUserTokenCache, saveUserTokenCache } from "./user-tokens.server";
+
+assertServerOnImport();
+
+/** Graph base URL (v1.0). */
+export const GRAPH_BASE = "https://graph.microsoft.com/v1.0";
+
+/**
+ * Default delegated scope set. `User.Read` is already admin-consented in the
+ * tenant, so the first slice needs no new consent. Additional connector scopes
+ * (Mail.Read, Files.Read.All, …) are requested at **sign-in** so the refresh
+ * token can mint them silently — see `entra-config.server.ts`.
+ */
+export const DEFAULT_GRAPH_SCOPES = ["User.Read"] as const;
+
+/**
+ * Raised when we cannot get a token without user interaction — no stored cache,
+ * an unusable/expired refresh token, or a scope the user hasn't consented to.
+ * Tool wrappers translate this into a "please sign in again" result rather than
+ * failing the whole run.
+ */
+export class GraphAuthRequiredError extends Error {
+  constructor(
+    message: string,
+    readonly userId: string,
+  ) {
+    super(message);
+    this.name = "GraphAuthRequiredError";
+  }
+}
+
+/**
+ * Acquire a delegated Graph access token for `userId`.
+ *
+ * Rehydrates that user's MSAL cache, acquires silently (MSAL uses a cached
+ * access token when still valid, else redeems the refresh token), and persists
+ * the cache back when MSAL mutated it — Entra rotates refresh tokens, so
+ * skipping the write-back would strand the user after the old token expires.
+ */
+export async function getUserGraphToken(
+  userId: string,
+  scopes: readonly string[] = DEFAULT_GRAPH_SCOPES,
+): Promise<string> {
+  const stored = await loadUserTokenCache(userId);
+  if (!stored) {
+    throw new GraphAuthRequiredError(
+      "No Microsoft token cache for this user — sign in to connect Microsoft 365.",
+      userId,
+    );
+  }
+
+  const cfg = buildEntraConfig();
+  const cca = new ConfidentialClientApplication(msalConfiguration(cfg));
+  const cache = cca.getTokenCache();
+  await cache.deserialize(stored.tokenCache);
+
+  const account = await resolveAccount(cache, stored.homeAccountId);
+  if (!account) {
+    throw new GraphAuthRequiredError(
+      "Stored Microsoft token cache has no usable account — sign in again.",
+      userId,
+    );
+  }
+
+  try {
+    const result = await cca.acquireTokenSilent({
+      account,
+      scopes: [...scopes],
+    });
+    if (!result?.accessToken) {
+      throw new GraphAuthRequiredError(
+        "Microsoft returned no access token — sign in again.",
+        userId,
+      );
+    }
+
+    // Persist rotation. `hasChanged` avoids a pointless write when MSAL served
+    // a still-valid cached access token.
+    if (cache.hasChanged()) {
+      await saveUserTokenCache(
+        userId,
+        cache.serialize(),
+        account.homeAccountId ?? stored.homeAccountId,
+      ).catch((err) =>
+        // A failed write-back doesn't invalidate the token we just got; the
+        // next call will simply re-redeem. Log, don't fail the request.
+        console.error("[graph-token] failed to persist rotated cache:", err),
+      );
+    }
+
+    return result.accessToken;
+  } catch (err) {
+    if (err instanceof GraphAuthRequiredError) throw err;
+    if (err instanceof InteractionRequiredAuthError) {
+      throw new GraphAuthRequiredError(
+        "Microsoft requires interactive sign-in (consent or expired credential) — sign in again.",
+        userId,
+      );
+    }
+    throw err;
+  }
+}
+
+/** Prefer the recorded account; fall back to the cache's sole account. */
+async function resolveAccount(
+  cache: ReturnType<ConfidentialClientApplication["getTokenCache"]>,
+  homeAccountId: string | null,
+): Promise<AccountInfo | null> {
+  if (homeAccountId) {
+    const byId = await cache.getAccountByHomeId(homeAccountId);
+    if (byId) return byId;
+  }
+  const all = await cache.getAllAccounts();
+  return all.length === 1 ? all[0] : null;
+}
+
+/**
+ * Call Microsoft Graph as `userId`. The token is attached here and never
+ * returned to callers, so tool implementations cannot leak it.
+ *
+ * @param path Graph path beginning with `/` (e.g. `/me`), or an absolute URL
+ *             (used for `@odata.nextLink` pagination).
+ */
+export async function graphFetch(
+  userId: string,
+  path: string,
+  init: { method?: string; scopes?: readonly string[]; body?: unknown } = {},
+): Promise<unknown> {
+  const token = await getUserGraphToken(userId, init.scopes ?? DEFAULT_GRAPH_SCOPES);
+  const url = path.startsWith("http") ? path : `${GRAPH_BASE}${path}`;
+
+  const res = await fetch(url, {
+    method: init.method ?? "GET",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/json",
+      ...(init.body ? { "Content-Type": "application/json" } : {}),
+    },
+    ...(init.body ? { body: JSON.stringify(init.body) } : {}),
+  });
+
+  if (res.status === 401 || res.status === 403) {
+    // Entra rejected the delegated token — treat as re-auth/consent needed.
+    // The body can echo request detail, so it is deliberately not surfaced.
+    throw new GraphAuthRequiredError(
+      `Microsoft Graph denied the request (${res.status}) — the account may lack consent for this scope.`,
+      userId,
+    );
+  }
+  if (!res.ok) {
+    throw new Error(
+      `[graph] ${init.method ?? "GET"} ${path} failed: ${res.status} ${res.statusText}`,
+    );
+  }
+  if (res.status === 204) return null;
+  return res.json();
+}

--- a/ui/src/lib/auth/secret-crypto.server.ts
+++ b/ui/src/lib/auth/secret-crypto.server.ts
@@ -1,0 +1,104 @@
+/**
+ * At-rest encryption for stored secrets — Server Only.
+ *
+ * AES-256-GCM (authenticated) for secret material we must persist, currently
+ * the per-user MSAL token cache (#110): it holds refresh tokens, so plaintext
+ * at rest is not acceptable (#107 / #110 both specify an *encrypted* cache).
+ *
+ * Key material: a dedicated `TOKEN_ENCRYPTION_KEY` when set, otherwise
+ * HKDF-derived from `AUTH_SESSION_SECRET` with a distinct `info` label. The
+ * derivation keeps encryption and cookie-signing keys cryptographically
+ * separate (domain separation) without forcing a second mandatory env var —
+ * but a dedicated key is preferred in production so the two can rotate
+ * independently.
+ *
+ * Ciphertext format (versioned so the scheme can be rotated):
+ *   `v1.<iv>.<authTag>.<ciphertext>`   — all parts base64url
+ */
+import {
+  createCipheriv,
+  createDecipheriv,
+  randomBytes,
+  hkdfSync,
+} from "node:crypto";
+import { assertServerOnImport } from "../harness-patterns/assert.server";
+
+assertServerOnImport();
+
+const VERSION = "v1";
+const ALGO = "aes-256-gcm";
+const IV_BYTES = 12; // GCM standard nonce length
+const KEY_BYTES = 32;
+const HKDF_INFO = "kg-agent:secret-crypto:v1";
+
+/**
+ * Resolve the 32-byte encryption key. Throws when neither
+ * `TOKEN_ENCRYPTION_KEY` nor `AUTH_SESSION_SECRET` is configured — failing
+ * closed is deliberate: we must never silently fall back to storing plaintext.
+ */
+function encryptionKey(): Buffer {
+  const dedicated = process.env.TOKEN_ENCRYPTION_KEY?.trim();
+  if (dedicated) {
+    // Accept base64 / base64url / hex / raw; normalize to exactly 32 bytes by
+    // HKDF so a short or long value can still be used safely.
+    return Buffer.from(
+      hkdfSync("sha256", Buffer.from(dedicated), Buffer.alloc(0), HKDF_INFO, KEY_BYTES),
+    );
+  }
+  const fallback = process.env.AUTH_SESSION_SECRET?.trim();
+  if (fallback) {
+    return Buffer.from(
+      hkdfSync("sha256", Buffer.from(fallback), Buffer.alloc(0), HKDF_INFO, KEY_BYTES),
+    );
+  }
+  throw new Error(
+    "[secret-crypto] no encryption key: set TOKEN_ENCRYPTION_KEY (preferred) " +
+      "or AUTH_SESSION_SECRET. Refusing to store secrets unencrypted.",
+  );
+}
+
+/** Encrypt a UTF-8 plaintext into the versioned envelope. */
+export function encryptSecret(plaintext: string, key: Buffer = encryptionKey()): string {
+  const iv = randomBytes(IV_BYTES);
+  const cipher = createCipheriv(ALGO, key, iv);
+  const ct = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return [
+    VERSION,
+    iv.toString("base64url"),
+    tag.toString("base64url"),
+    ct.toString("base64url"),
+  ].join(".");
+}
+
+/**
+ * Decrypt an envelope produced by {@link encryptSecret}. Returns `null` on any
+ * malformed input, unknown version, wrong key, or failed authentication —
+ * callers treat that as "no usable cache" and re-authenticate rather than
+ * crashing a request.
+ */
+export function decryptSecret(
+  envelope: string | null | undefined,
+  key: Buffer = encryptionKey(),
+): string | null {
+  if (!envelope) return null;
+  const parts = envelope.split(".");
+  if (parts.length !== 4 || parts[0] !== VERSION) return null;
+  try {
+    const iv = Buffer.from(parts[1], "base64url");
+    const tag = Buffer.from(parts[2], "base64url");
+    const ct = Buffer.from(parts[3], "base64url");
+    if (iv.length !== IV_BYTES || tag.length !== 16) return null;
+    const decipher = createDecipheriv(ALGO, key, iv);
+    decipher.setAuthTag(tag);
+    return Buffer.concat([decipher.update(ct), decipher.final()]).toString("utf8");
+  } catch {
+    // Wrong key or tampered ciphertext — GCM auth failure lands here.
+    return null;
+  }
+}
+
+/** Test/ops helper: generate a fresh key suitable for `TOKEN_ENCRYPTION_KEY`. */
+export function generateEncryptionKey(): string {
+  return randomBytes(KEY_BYTES).toString("base64");
+}

--- a/ui/src/lib/auth/session-store.server.ts
+++ b/ui/src/lib/auth/session-store.server.ts
@@ -55,8 +55,10 @@ const SCHEMA_SQL = `
     home_account_id  TEXT,
     -- NOTE: the MSAL token cache is NOT stored here. It lives encrypted and
     -- per-user in user_tokens (see user-tokens.server.ts, #110) so that runs
-    -- without a live session (agent-trigger) can still act for the user. That
-    -- module also drops this table's legacy plaintext token_cache column.
+    -- without a live session (agent-trigger) can still act for the user. The
+    -- legacy plaintext token_cache column may still exist on databases created
+    -- by #119; it is no longer written, and dropping it is post-merge cleanup
+    -- (doing it here would break main's code, which still writes it).
     created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     expires_at       TIMESTAMPTZ NOT NULL
   );

--- a/ui/src/lib/auth/session-store.server.ts
+++ b/ui/src/lib/auth/session-store.server.ts
@@ -53,10 +53,10 @@ const SCHEMA_SQL = `
     email            TEXT NOT NULL,
     display_name     TEXT,
     home_account_id  TEXT,
-    -- Serialized MSAL token cache for this session's account. Holds the
-    -- refresh/access tokens for the OBO exchange (#110). Nullable: a session
-    -- can exist before a cache is captured, and dev/test paths omit it.
-    token_cache      TEXT,
+    -- NOTE: the MSAL token cache is NOT stored here. It lives encrypted and
+    -- per-user in user_tokens (see user-tokens.server.ts, #110) so that runs
+    -- without a live session (agent-trigger) can still act for the user. That
+    -- module also drops this table's legacy plaintext token_cache column.
     created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     expires_at       TIMESTAMPTZ NOT NULL
   );
@@ -93,27 +93,26 @@ function toRecord(row: DbRow): SessionRecord {
 
 /**
  * Create a session row and return its opaque id (to be set as the cookie).
- * `tokenCache` is MSAL's serialized cache blob — stored for OBO (#110), never
- * sent to the client.
+ * The MSAL token cache is persisted separately, per-user and encrypted, by
+ * `user-tokens.server.ts` (#110) — not on the session row.
  */
 export async function createSession(
   claims: SessionClaims,
-  opts: { tokenCache?: string | null; ttlSeconds?: number } = {},
+  opts: { ttlSeconds?: number } = {},
 ): Promise<string> {
   await ensureSchema();
   const id = newOpaqueId();
   const ttl = opts.ttlSeconds ?? DEFAULT_SESSION_TTL_SECONDS;
   await query(
     `INSERT INTO auth_sessions
-       (id, user_id, email, display_name, home_account_id, token_cache, expires_at)
-     VALUES ($1, $2, $3, $4, $5, $6, NOW() + ($7 || ' seconds')::interval)`,
+       (id, user_id, email, display_name, home_account_id, expires_at)
+     VALUES ($1, $2, $3, $4, $5, NOW() + ($6 || ' seconds')::interval)`,
     [
       id,
       claims.userId,
       claims.email,
       claims.displayName,
       claims.homeAccountId,
-      opts.tokenCache ?? null,
       String(ttl),
     ],
   );
@@ -139,16 +138,6 @@ export async function getSession(id: string | null | undefined): Promise<Session
     return null;
   }
   return toRecord(row);
-}
-
-/** Retrieve the persisted MSAL token cache for a session (for #110/OBO). */
-export async function getSessionTokenCache(id: string): Promise<string | null> {
-  await ensureSchema();
-  const { rows } = await query<{ token_cache: string | null }>(
-    `SELECT token_cache FROM auth_sessions WHERE id = $1`,
-    [id],
-  );
-  return rows[0]?.token_cache ?? null;
 }
 
 /** Delete a session (logout / revocation). Idempotent. */

--- a/ui/src/lib/auth/user-tokens.server.ts
+++ b/ui/src/lib/auth/user-tokens.server.ts
@@ -42,10 +42,12 @@ const SCHEMA_SQL = `
     updated_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()
   );
 
-  -- #110: the session-scoped cache column from #119 is superseded by this
-  -- table. Dropping it removes plaintext refresh tokens from any existing
-  -- database; idempotent, so it is safe on every boot.
-  ALTER TABLE IF EXISTS auth_sessions DROP COLUMN IF EXISTS token_cache;
+  -- NOTE: auth_sessions.token_cache (the plaintext, session-scoped cache from
+  -- #119) is superseded by this table and is no longer written. It is
+  -- deliberately NOT dropped here: this app shares one database with whatever
+  -- code is deployed from main, and main's createSession still INSERTs that
+  -- column — dropping it from a feature branch breaks sign-in for main.
+  -- Dropping the column is post-merge cleanup, tracked in the PR description.
 `;
 
 let _schemaReady: Promise<void> | null = null;

--- a/ui/src/lib/auth/user-tokens.server.ts
+++ b/ui/src/lib/auth/user-tokens.server.ts
@@ -1,0 +1,142 @@
+/**
+ * Per-user MSAL token cache (encrypted, durable) — Server Only.
+ *
+ * Pattern C (#110): calling Microsoft Graph *as the user* needs that user's
+ * tokens available server-side, including for runs with **no live session** —
+ * the agent-trigger endpoint (`runAgentInBackground(runId, userId, …)`) has only
+ * a `userId`. The #119 sign-in stored the MSAL cache on `auth_sessions`, which
+ * has an 8h TTL and is deleted on logout, so it cannot serve that case.
+ *
+ * This store is therefore keyed by the Entra `oid` and outlives sessions. The
+ * blob is MSAL's serialized cache (it contains the refresh token), so it is
+ * encrypted at rest via `secret-crypto.server.ts` — #107/#110 both require an
+ * encrypted cache. Kept in its own table rather than on `users` so secret
+ * material stays separate from profile data (a `listUsers()` admin view can
+ * never accidentally select it) and can be dropped/rotated independently.
+ *
+ * Written on every sign-in and re-written after each silent acquisition
+ * (Entra rotates refresh tokens, so the fresh cache must replace the old one).
+ */
+import { assertServerOnImport } from "../harness-patterns/assert.server";
+import { query } from "../db/client.server";
+import { encryptSecret, decryptSecret } from "./secret-crypto.server";
+
+assertServerOnImport();
+
+export interface UserTokenCache {
+  /** MSAL account key, for `getAccountByHomeId()` during silent acquisition. */
+  homeAccountId: string | null;
+  /** Decrypted, serialized MSAL token cache. */
+  tokenCache: string;
+  updatedAt: Date;
+}
+
+const SCHEMA_SQL = `
+  CREATE TABLE IF NOT EXISTS user_tokens (
+    user_id          TEXT PRIMARY KEY,
+    home_account_id  TEXT,
+    -- AES-256-GCM envelope (see secret-crypto.server.ts) wrapping MSAL's
+    -- serialized cache. NEVER stored or logged in plaintext.
+    token_cache      TEXT NOT NULL,
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()
+  );
+
+  -- #110: the session-scoped cache column from #119 is superseded by this
+  -- table. Dropping it removes plaintext refresh tokens from any existing
+  -- database; idempotent, so it is safe on every boot.
+  ALTER TABLE IF EXISTS auth_sessions DROP COLUMN IF EXISTS token_cache;
+`;
+
+let _schemaReady: Promise<void> | null = null;
+function ensureSchema(): Promise<void> {
+  if (!_schemaReady) {
+    _schemaReady = query(SCHEMA_SQL)
+      .then(() => undefined)
+      .catch((err) => {
+        _schemaReady = null; // allow retry on next call
+        throw err;
+      });
+  }
+  return _schemaReady;
+}
+
+/**
+ * Upsert the user's token cache (encrypting before write). Call after sign-in
+ * and after every silent acquisition that mutates the cache.
+ */
+export async function saveUserTokenCache(
+  userId: string,
+  tokenCache: string,
+  homeAccountId: string | null,
+): Promise<void> {
+  await ensureSchema();
+  await query(
+    `INSERT INTO user_tokens (user_id, home_account_id, token_cache)
+     VALUES ($1, $2, $3)
+     ON CONFLICT (user_id) DO UPDATE SET
+       home_account_id = EXCLUDED.home_account_id,
+       token_cache     = EXCLUDED.token_cache,
+       updated_at      = NOW()`,
+    [userId, homeAccountId, encryptSecret(tokenCache)],
+  );
+}
+
+/**
+ * Load and decrypt the user's cache. Returns `null` when absent **or when
+ * decryption fails** (rotated/incorrect key, tampered row) — the caller treats
+ * that as "this user must sign in again" rather than crashing.
+ */
+export async function loadUserTokenCache(
+  userId: string,
+): Promise<UserTokenCache | null> {
+  await ensureSchema();
+  const { rows } = await query<{
+    home_account_id: string | null;
+    token_cache: string;
+    updated_at: Date;
+  }>(
+    `SELECT home_account_id, token_cache, updated_at
+       FROM user_tokens WHERE user_id = $1`,
+    [userId],
+  );
+  const row = rows[0];
+  if (!row) return null;
+
+  const tokenCache = decryptSecret(row.token_cache);
+  if (!tokenCache) {
+    console.warn(
+      `[user-tokens] could not decrypt token cache for user ${userId} — ` +
+        "treating as absent (re-authentication required).",
+    );
+    return null;
+  }
+  return {
+    homeAccountId: row.home_account_id,
+    tokenCache,
+    updatedAt: row.updated_at,
+  };
+}
+
+/** True when the user has a usable cache (cheap existence check, no decrypt). */
+export async function hasUserTokenCache(userId: string): Promise<boolean> {
+  await ensureSchema();
+  const { rows } = await query<{ one: number }>(
+    `SELECT 1 AS one FROM user_tokens WHERE user_id = $1`,
+    [userId],
+  );
+  return rows.length > 0;
+}
+
+/**
+ * Forget a user's tokens — e.g. an explicit "disconnect Microsoft" action, or
+ * after an unrecoverable auth failure. Idempotent.
+ *
+ * NOTE: deliberately NOT called on logout. Logout ends the browser session;
+ * the durable cache is what lets background runs (#106 agent-trigger) keep
+ * acting for the user afterwards.
+ */
+export async function deleteUserTokenCache(userId: string): Promise<void> {
+  await ensureSchema();
+  await query(`DELETE FROM user_tokens WHERE user_id = $1`, [userId]);
+}

--- a/ui/src/lib/harness-client/examples/microsoft-365.server.ts
+++ b/ui/src/lib/harness-client/examples/microsoft-365.server.ts
@@ -6,9 +6,11 @@
  * delegated per-user token server-side (see `lib/app-tools/graph.server.ts`),
  * so Entra enforces the scope and no credential ever reaches the model.
  *
- * First slice is profile-only (`graph_me`, scope `User.Read` — already
- * admin-consented). Mail/Files/Calendar tools appear in `tools.graph`
- * automatically once registered, so this agent needs no change to pick them up.
+ * Tools available: `graph_me` (profile), `graph_calendar_today` (today's
+ * events), `graph_mail_recent` (inbox, optionally unread-only) — enough for a
+ * "what does my day look like?" briefing. Further graph tools appear in
+ * `tools.graph` automatically once registered, so this agent needs no change to
+ * pick them up.
  */
 "use server";
 
@@ -32,9 +34,11 @@ async function createPatterns(_sessionId: string): Promise<ConfiguredPattern<Ses
     {
       patternId: "microsoft-365",
       liveEvents: true,
-      // Profile lookups are single-shot; no need to replay prior turns.
       rememberPriorTurns: false,
-      maxTurns: 3,
+      // A "what's on today?" briefing needs several calls in one turn
+      // (calendar + mail, sometimes profile), plus room to recover from a
+      // failed call, so this is deliberately higher than a single-shot loop.
+      maxTurns: 8,
     },
   );
 

--- a/ui/src/lib/harness-client/examples/microsoft-365.server.ts
+++ b/ui/src/lib/harness-client/examples/microsoft-365.server.ts
@@ -1,0 +1,60 @@
+/**
+ * Microsoft 365 Agent (Pattern C / #110)
+ *
+ * Answers questions about the signed-in user's own Microsoft 365 data by
+ * calling Graph **as that user**: the app-side `graph` tools resolve a
+ * delegated per-user token server-side (see `lib/app-tools/graph.server.ts`),
+ * so Entra enforces the scope and no credential ever reaches the model.
+ *
+ * First slice is profile-only (`graph_me`, scope `User.Read` — already
+ * admin-consented). Mail/Files/Calendar tools appear in `tools.graph`
+ * automatically once registered, so this agent needs no change to pick them up.
+ */
+"use server";
+
+import {
+  simpleLoop,
+  synthesizer,
+  Tools,
+  createLoopControllerAdapter,
+  type ConfiguredPattern,
+} from "../../harness-patterns";
+import type { SessionData } from "../session.server";
+import type { AgentConfig } from "../registry.server";
+
+async function createPatterns(_sessionId: string): Promise<ConfiguredPattern<SessionData>[]> {
+  const tools = await Tools();
+  const graphTools = tools.graph ?? [];
+
+  const graphPattern = simpleLoop<SessionData>(
+    createLoopControllerAdapter(graphTools),
+    graphTools,
+    {
+      patternId: "microsoft-365",
+      liveEvents: true,
+      // Profile lookups are single-shot; no need to replay prior turns.
+      rememberPriorTurns: false,
+      maxTurns: 3,
+    },
+  );
+
+  const responseSynth = synthesizer<SessionData>({
+    mode: "thread",
+    patternId: "response-synth",
+    liveEvents: true,
+  });
+
+  return [graphPattern, responseSynth];
+}
+
+export const microsoft365Agent: AgentConfig = {
+  id: "microsoft-365",
+  name: "Microsoft 365",
+  description:
+    "Answers from your own Microsoft 365 account (delegated, per-user via Entra)",
+  icon: "🪟",
+  // Not an MCP gateway server: these tools run in-process so the per-user
+  // token stays server-side (#107). Listed for UI display only.
+  servers: ["graph (app-side, per-user)"],
+  createPatterns,
+};

--- a/ui/src/lib/harness-client/registry.server.ts
+++ b/ui/src/lib/harness-client/registry.server.ts
@@ -200,6 +200,7 @@ import { conversationalMemoryAgent } from "./examples/conversational-memory.serv
 import { sandboxSessionAgent } from "./examples/sandbox-session.server";
 import { flavouredSandboxAgent } from "./examples/flavoured-sandbox.server";
 import { retrieverAgent } from "./examples/retriever-agent.server";
+import { microsoft365Agent } from "./examples/microsoft-365.server";
 
 // Register all agents
 registerAgent(defaultAgent);
@@ -209,3 +210,4 @@ registerAgent(conversationalMemoryAgent);
 registerAgent(sandboxSessionAgent);
 registerAgent(flavouredSandboxAgent);
 registerAgent(retrieverAgent);
+registerAgent(microsoft365Agent);

--- a/ui/src/lib/harness-patterns/README.md
+++ b/ui/src/lib/harness-patterns/README.md
@@ -257,8 +257,19 @@ Fetch MCP tools and group by server namespace.
 const tools = await Tools()
 tools.neo4j  // ['read_neo4j_cypher', 'write_neo4j_cypher', 'get_neo4j_schema']
 tools.web    // ['search', 'fetch', 'fetch_content']
+tools.graph  // app-side, per-user (see below)
 tools.all    // all tool names
 ```
+
+**Three transports.** `callTool()` routes a tool name to whichever transport
+owns it: the **sandbox** (in-VM, when a `withSandbox` scope is active), an
+**app-side** in-process tool, or the **MCP gateway** (the default). App-side
+tools exist for calls that carry a per-user credential resolved server-side —
+the gateway executes every user's calls as one shared principal, so it cannot
+express per-user identity. They are registered via `registerAppTool()` in
+`lib/app-tools/` and advertised by `listTools()` alongside gateway tools, so
+patterns and agents treat them identically. See
+[`docs/MICROSOFT_GRAPH.md`](../../../../docs/MICROSOFT_GRAPH.md).
 
 ### `simpleLoop(controller, tools, config?)`
 
@@ -1104,7 +1115,7 @@ harness-patterns/
 ├── tools.server.ts         # Tools() — groups MCP tools by namespace
 ├── harness.server.ts       # harness(), resumeHarness(), continueSession() — all accept onEvent? callback
 ├── routing.server.ts       # BAML router integration (routeMessageOp)
-├── mcp-client.server.ts    # callTool(), listTools(); demotes `"<ToolName> Error:"` text results to `success:false` (issue #50); aggregates multi-text-block results into an array (single block stays scalar) so multi-value tools like Redis `smembers`/`lrange` don't drop all but the first element
+├── mcp-client.server.ts    # callTool(), listTools(); dispatches across THREE tool transports — sandbox (in-VM) → app-side in-process → MCP gateway; demotes `"<ToolName> Error:"` text results to `success:false` (issue #50); aggregates multi-text-block results into an array (single block stays scalar) so multi-value tools like Redis `smembers`/`lrange` don't drop all but the first element
 ├── baml-adapters.server.ts # Adapter factories: createLoopControllerAdapter, createNeo4jController, createActorControllerAdapter, createCriticAdapter, describeToolResultOp, etc.
 ├── summarize.server.ts     # scheduleSummarization() — background tool result summarization via DescribeFallback
 ├── token-budget.server.ts  # trimToFit(), getContextWindow(), estimateTokens() — rolling context window

--- a/ui/src/lib/harness-patterns/mcp-client.server.ts
+++ b/ui/src/lib/harness-patterns/mcp-client.server.ts
@@ -7,6 +7,7 @@
 
 import { assertServerOnImport } from './assert.server';
 import { getActiveSandbox } from '../sandbox/scope.server';
+import { hasAppTool, runAppTool, appToolDescriptions } from '../app-tools/index.server';
 import type { ToolCallResult, MCPToolDescription } from './types';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
@@ -111,6 +112,14 @@ export async function callTool(
     return sandbox.callTool(name, args);
   }
 
+  // App-side dispatch (#110). Tools that must run in THIS process because they
+  // carry a per-user credential resolved server-side — the shared-identity
+  // gateway cannot express per-user identity (#107). Checked after the sandbox
+  // (so an in-VM tool of the same name still wins) and before the gateway.
+  if (hasAppTool(name)) {
+    return runAppTool(name, args);
+  }
+
   try {
     const result = await withReconnect((c) => c.callTool({ name, arguments: args }));
 
@@ -194,13 +203,20 @@ function demoteErrorString(
 }
 
 export async function listTools(): Promise<MCPToolDescription[]> {
+  // App-side tools (#110) are advertised alongside the gateway's. They run
+  // in-process, so they stay available even when the gateway is unreachable —
+  // hence they are appended on both the success and the failure path.
+  const appTools = appToolDescriptions();
   try {
     const { tools } = await withReconnect((c) => c.listTools());
-    return tools.map((t) => ({
-      name: t.name,
-      description: t.description ?? '',
-      inputSchema: (t.inputSchema as Record<string, unknown>) ?? {}
-    }));
+    return [
+      ...tools.map((t) => ({
+        name: t.name,
+        description: t.description ?? '',
+        inputSchema: (t.inputSchema as Record<string, unknown>) ?? {}
+      })),
+      ...appTools
+    ];
   } catch (err) {
     // Reconnect already tried once. If we still failed here, this is a real
     // problem (gateway down, URL misconfigured, etc.) — log it loudly so the
@@ -209,7 +225,8 @@ export async function listTools(): Promise<MCPToolDescription[]> {
     // longer hidden the way it was before this change.
     const msg = err instanceof Error ? err.message : String(err);
     console.error('[mcp-client] listTools failed after reconnect:', msg);
-    return [];
+    // App-side tools don't depend on the gateway — keep offering them.
+    return appTools;
   }
 }
 

--- a/ui/src/lib/harness-patterns/tools.server.ts
+++ b/ui/src/lib/harness-patterns/tools.server.ts
@@ -6,6 +6,7 @@
 
 import { assertServerOnImport } from './assert.server'
 import { listTools as mcpListTools } from './mcp-client.server'
+import { appToolNamespace } from '../app-tools/index.server'
 import type { ToolSet, MCPToolDescription } from './types'
 
 assertServerOnImport()
@@ -131,8 +132,9 @@ for (const t of [
  * Infer server name from tool name.
  *
  * 1. Strip MCP gateway prefix (mcp__gateway__toolName → toolName)
- * 2. Check KNOWN_TOOL_SERVERS lookup
- * 3. Fall back to heuristic (verb prefix stripping, underscore/hyphen split)
+ * 2. App-side tools declare their own namespace (#110)
+ * 3. Check KNOWN_TOOL_SERVERS lookup
+ * 4. Fall back to heuristic (verb prefix stripping, underscore/hyphen split)
  */
 export function inferServer(toolName: string): string {
   // Handle MCP gateway format: mcp__server-name__tool_name → infer from tool_name part
@@ -140,6 +142,13 @@ export function inferServer(toolName: string): string {
     const parts = toolName.split('__')
     const actualToolName = parts[parts.length - 1]
     return inferServer(actualToolName)
+  }
+
+  // App-side tools carry an explicit namespace, so grouping never depends on
+  // the name heuristic (which would mis-bucket e.g. `list_graph_messages`).
+  const appNs = appToolNamespace(toolName)
+  if (appNs) {
+    return appNs
   }
 
   // Check known mapping first

--- a/ui/src/routes/api/auth/callback.ts
+++ b/ui/src/routes/api/auth/callback.ts
@@ -22,6 +22,7 @@ import {
   DEFAULT_SESSION_TTL_SECONDS,
 } from "~/lib/auth/session-store.server";
 import { upsertUser } from "~/lib/auth/users.server";
+import { saveUserTokenCache } from "~/lib/auth/user-tokens.server";
 import { isEmailAllowed } from "~/lib/auth/allowList";
 
 interface Handshake {
@@ -87,15 +88,16 @@ export async function GET(event: APIEvent): Promise<Response> {
       tenantId: identity.tenantId,
     });
 
-    const sessionId = await createSession(
-      {
-        userId: identity.userId,
-        email: identity.email,
-        displayName: identity.displayName,
-        homeAccountId,
-      },
-      { tokenCache },
-    );
+    // Persist the MSAL cache per-user (encrypted) so Graph can be called as
+    // this user later — including from runs with no live session (#110).
+    await saveUserTokenCache(identity.userId, tokenCache, homeAccountId);
+
+    const sessionId = await createSession({
+      userId: identity.userId,
+      email: identity.email,
+      displayName: identity.displayName,
+      homeAccountId,
+    });
 
     return redirect(
       "/",


### PR DESCRIPTION
## Pattern C — per-user Microsoft Graph access (#110)

Calls Graph **as the signed-in user**, so Entra enforces each request's delegated
scope rather than an over-privileged org token guarded by app code. Builds
directly on the Entra SSO from #119.

Live-verified: a read call through the **Microsoft 365** agent returns the
signed-in user's own data end-to-end (encrypted per-user store → decrypt →
silent acquisition → Graph → app-side tool dispatch).

### The decision: `acquireTokenSilent`, not the OBO grant

Despite the issue title, the On-Behalf-Of grant is the wrong mechanism for this
topology. OBO serves a *middle-tier API*: a separate client signs in, receives a
token scoped to our API, calls us, and we exchange that assertion. Since #119
this app **is** the confidential OIDC client — the browser holds an opaque
session cookie, not a token — so there is no assertion to exchange, and we
already hold the user's refresh token. `acquireTokenSilent` gives the same
delegated per-user token with less machinery: no `api://…/access_as_user` scope
and nothing to configure under "Expose an API".

`acquireTokenOnBehalfOf` becomes necessary only if a distinct client
authenticates to Entra itself and then calls our API (e.g. giving the iOS
Shortcut its own client id). The token-cache plumbing here is the seam for that.

### What's in it

- **Encrypted per-user token store** (`user_tokens`, keyed by the Entra `oid`).
  Per-user rather than per-session because background runs
  (`runAgentInBackground`) have only a `userId` — the session-scoped cache #119
  shipped would leave them with no credential. AES-256-GCM at rest
  (`TOKEN_ENCRYPTION_KEY`, HKDF-derived from `AUTH_SESSION_SECRET` when unset;
  fails closed rather than storing plaintext). Rewritten after each acquisition,
  since Entra rotates refresh tokens.
- **App-side tool transport** — a third transport beside the MCP gateway and the
  sandbox, dispatched in `callTool`. Necessary because the gateway executes every
  user's calls as one shared principal and cannot inject per-user credentials
  (#107); routing Graph through it would forfeit delegated scope. The registry is
  generic, so Pattern B (#109) vault tools drop in the same way.
- **Three read tools + agent**: `graph_me`, `graph_calendar_today`,
  `graph_mail_recent`, exposed by a new `microsoft-365` agent.
- **All connector scopes requested at sign-in**, because adding one later forces
  every user to re-authenticate and background runs have no user present to
  consent. `AZURE_GRAPH_SCOPES` trims the set without a code change.
- **Docs**: new `docs/MICROSOFT_GRAPH.md` owns the mechanism;
  `deploy/entra-setup.md` trimmed to tenant/operator concerns; corrected a stale
  claim in `UI_ARCHITECTURE.md` (the session row no longer holds the token cache).

### Security posture

Two invariants, both tested: no advertised schema carries a user or token field
(a caller-supplied `userId` is ignored in favour of the request scope), and the
credential is attached inside `graphFetch` so it never reaches a tool body, log,
result or event.

Cross-user isolation is asserted under deliberately interleaved concurrent calls
and **mutation-checked**: hoisting the MSAL client to a module-level singleton —
the bug those tests exist to catch — fails them; reverting makes them pass.

### Please look closely at

1. **Refresh tokens now persist indefinitely** in `user_tokens` until explicitly
   disconnected. Deliberate — it is what makes background runs work — but a real
   change in posture. One key protects all caches, so it belongs in a secret
   store in production, not `.env`.
2. **`auth_sessions.token_cache`** (plaintext, from #119) is no longer written but
   deliberately **not dropped here**: code deployed from `main` still writes it,
   and dropping it from a feature branch broke sign-in once already. Dropping it
   is post-merge cleanup.

### Verification

- `tsc --noEmit`: 17 errors, unchanged from the pre-existing baseline; none in
  new code.
- Suite: **1005 passed / 1 skipped** (from 939), including the isolation suites.
- `vinxi build` passes — msal-node stays out of the client bundle.
- Live read call confirmed through the agent.

### Follow-ups (not here)

- Write tools (create event / send mail) with a confirmation gate. The
  `withApproval` pattern was removed in #125, so a write tool wires its own pause
  from the surviving primitives (`pauseContext` / `resumeHarness` /
  `approveAction`).
- Files/SharePoint connector — scopes are consented, no tool yet.
- Drop the legacy `token_cache` column; set a dedicated `TOKEN_ENCRYPTION_KEY`
  before more users sign in (cheapest while only one cache exists).

Closes #110.
