### PR TITLE
feat(tools): Microsoft 365 file search, browse, and Data Stash ingestion

### DIFF
--- a/docs/DATA_STASH.md
+++ b/docs/DATA_STASH.md
@@ -46,6 +46,12 @@ query ─────────────────────── embe
 
 Auth follows the existing posture (dev-bypass aware; see `lib/auth/dev-bypass.ts`). Ingest runs two ways: **explicitly** via `POST /api/stash/ingest`, or **automatically on upload** when the session's agent composes a `retriever` wired to the redis backend (see [Harness-aware ingest](#harness-aware-ingest-the-retriever-pattern) below). Either way it needs an embedding backend and binds the corpus to one model.
 
+Documents don't only arrive over HTTP: the `graph_file_ingest` app tool calls
+`storeDocument` + `ingestStashDocument` in-process to copy one of the signed-in
+person's Microsoft 365 files into the session's stash, under the same store/ingest
+contract as the upload route — see
+[MICROSOFT_GRAPH.md](MICROSOFT_GRAPH.md#files--the-data-stash).
+
 ## Harness-aware ingest (the `retriever` pattern)
 
 The Data Stash adapts to the agent's harness composition:

--- a/docs/MICROSOFT_GRAPH.md
+++ b/docs/MICROSOFT_GRAPH.md
@@ -13,21 +13,23 @@ machinery see [UI_ARCHITECTURE.md §3](UI_ARCHITECTURE.md).
 ## What it can do today
 
 The **Microsoft 365** agent (`lib/harness-client/examples/microsoft-365.server.ts`)
-exposes three **read-only** tools:
+exposes four tools. All of them only ever **read** from Microsoft 365:
 
 | Tool | Reads | Scope used |
 |------|-------|-----------|
 | `graph_me` | own profile (name, UPN, job title, office) | `User.Read` |
 | `graph_calendar_today` | own calendar for a given day (`day_offset`) | `Calendars.ReadWrite` |
 | `graph_mail_recent` | own inbox, newest first, optional `unread_only` | `Mail.Read` |
+| `graph_file_ingest` | one own OneDrive/SharePoint file → the Data Stash | `Files.Read.All` |
 
 Enough for "what does my day look like?" — the agent's loop calls several tools
-in one turn and the synthesizer writes the briefing.
+in one turn and the synthesizer writes the briefing — plus "pull that
+spreadsheet in and chart it", which is [the file bridge](#files--the-data-stash).
 
 **Consented scopes exceed implemented tools.** The sign-in request also carries
-`Mail.Send`, `Files.Read.All` and `Sites.Read.All` (see the setup doc for why
-consent is taken up front). No tool exposes them, so the model cannot use them:
-a granted scope is not a capability — capability comes from a registered tool.
+`Mail.Send` and `Sites.Read.All` (see the setup doc for why consent is taken up
+front). No tool exposes them, so the model cannot use them: a granted scope is
+not a capability — capability comes from a registered tool.
 
 **Writes.** None yet. Adding one is the same shape as a read tool, but it should
 carry a confirmation gate: creating an event emails real invitations, and
@@ -52,8 +54,9 @@ callTool(name, args)                    ← harness-patterns/mcp-client.server.t
    └─ else              → MCP gateway
         │
 runAppTool                              ← app-tools/registry.server.ts
-   ├─ userId = getRequestUserId()        ← AsyncLocalStorage, not args
-   └─ def.execute(args, {userId}) → {success, data} | {success:false, error}
+   ├─ userId    = getRequestUserId()     ← AsyncLocalStorage, not args
+   ├─ sessionId = getRequestSessionId()  ← idem; null off the request path
+   └─ def.execute(args, ctx) → {success, data} | {success:false, error}
         │
 tool definition                          ← app-tools/graph.server.ts
    └─ graphFetch(userId, '/me/calendarView?…', {scopes, headers})
@@ -69,6 +72,7 @@ graphFetch                               ← auth/graph-token.server.ts
 | Module | Sole responsibility |
 |--------|--------------------|
 | `harness-patterns/mcp-client.server.ts` | dispatch: which transport owns this tool name |
+| `lib/harness-client/request-user.server.ts` | the ambient `{userId, sessionId}` of a run |
 | `lib/app-tools/registry.server.ts` | resolve identity, execute, never throw |
 | `lib/app-tools/graph.server.ts` | Graph paths, `$select`, response shaping |
 | `lib/auth/graph-token.server.ts` | token acquisition, rotation, attach credential |
@@ -114,7 +118,7 @@ seam for that.
 
 ## Identity and isolation
 
-Two invariants shape the design:
+Three invariants shape the design:
 
 1. **Tokens resolve from the request, never from arguments.** No advertised
    schema has a user or token field, so the model cannot ask for another
@@ -122,12 +126,18 @@ Two invariants shape the design:
    `getRequestUserId()`.
 2. **The credential is attached inside `graphFetch`** and never returned, so no
    tool body, log line, tool result or event can carry it.
+3. **The destination resolves the same way as the identity.** A tool that
+   *writes* somewhere per-conversation (only `graph_file_ingest` today) takes its
+   `sessionId` from `getRequestSessionId()`, not from args — otherwise the model
+   could name another conversation's stash. Same reasoning as (1): anything the
+   model can name, it can point elsewhere.
 
-Four mechanisms keep concurrent users apart:
+Five mechanisms keep concurrent users apart:
 
 | Layer | Mechanism |
 |-------|-----------|
 | Identity | `getRequestUserId()` reads AsyncLocalStorage — per-request context |
+| Destination | `getRequestSessionId()` from the same store — stash writes can't cross conversations |
 | MSAL client | constructed per call; only that user's cache is deserialized into it |
 | Token store | `user_tokens.user_id` is the primary key; every query is `WHERE user_id = $1` |
 | Provenance | no server action accepts a `userId`; all derive it from `requireUser()` → session cookie |
@@ -136,9 +146,14 @@ Four mechanisms keep concurrent users apart:
 deliberately interleaved concurrent calls, and were mutation-checked: hoisting
 the MSAL client to a module-level singleton fails them.
 
-**Fail-closed:** a tool called outside any `runWithUserId` scope is refused
-rather than guessing an identity. Both entry points establish the scope —
-`runTurn` (interactive) and `runAgentInBackground` (async).
+**Fail-closed:** a tool called outside any request scope is refused rather than
+guessing an identity, and a stash-writing tool with no `sessionId` in scope is
+refused rather than guessing a conversation. All three entry points establish the
+scope via `runWithRequestContext({userId, sessionId}, …)` — `runTurn` and
+`resolveApproval` (interactive) and `runAgentInBackground` (async, where the
+run id *is* the session id). The older `runWithUserId(userId, …)` survives as a
+thin wrapper that sets `sessionId: null`, which is exactly right for callers with
+no conversation: session-dependent tools then refuse instead of picking one.
 
 **Accepted limit:** one encryption key protects every stored cache. Users cannot
 reach each other's tokens, but a leaked key plus database access would expose
@@ -170,6 +185,66 @@ than failing the run.
 > `auth_sessions.token_cache` column. It is no longer written; dropping it is
 > post-merge cleanup, deliberately not done from a feature branch because code
 > deployed from `main` still writes it.
+
+---
+
+## Files → the Data Stash
+
+`graph_file_ingest` is the one tool that doesn't hand its result to the model. It
+copies a file the person already owns into **this conversation's** Data Stash, so
+the machinery that already exists for uploads — retriever search, the sandbox
+`/work` sync, the file viewer, chat citations — works on Microsoft 365 content
+with no second pipeline. See [DATA_STASH.md](DATA_STASH.md) for that side.
+
+```
+graph_file_ingest {item_id, drive_id?, filename?}
+  │  sessionId = getRequestSessionId()      ← refuse if null (never guess a stash)
+  ├─ GET  {base}?$select=name,file,size,webUrl     ← metadata FIRST
+  │     ├─ no `file` facet        → refuse (it's a folder)
+  │     └─ size > MAX_CONTENT_BYTES → refuse *before* downloading
+  ├─ GET  {base}/content   (responseType: 'base64')
+  ├─ storeDocument({sessionId, filename, mimeType, content, encoding?})
+  └─ void ingestStashDocument(sessionId, doc.id)   ← fire-and-forget
+        → {documentId, filename, mimeType, size, ingesting, webUrl}
+```
+
+`{base}` is `/me/drive/items/{id}` or `/drives/{drive}/items/{id}`; both id
+segments are URL-encoded so a crafted id cannot escape into another path.
+
+**Why metadata is a separate call.** It is the only way to know the size before
+the bytes are in this process's heap — a 4 GB video would otherwise be downloaded
+and base64'd purely to be rejected. It also supplies the true filename and MIME
+type. A missing `size` (Graph reports one for every file in practice) is not
+treated as oversized; `storeDocument` re-checks the limit on the decoded bytes.
+
+**Text vs. binary** mirrors the upload route's intake decision, and matters more
+than it looks: a base64 document that isn't convertible is marked
+`ingestStatus: 'failed'` by the ingest layer. So `isTextMime` types are decoded
+to UTF-8 and stored as text (the chunker reads `content` directly); everything
+else keeps its exact bytes as base64. The background ingest is fired only when
+the result can become text — text, or a convertible binary with
+`STASH_CONVERT_DOCS=1`.
+
+Unlike `POST /api/stash/upload`, it does **not** additionally require the
+session's agent to compose a redis retriever: calling this tool is an explicit
+request to make the file usable, and a retriever added later reads an
+already-indexed corpus.
+
+### The `/content` redirect and the bearer token
+
+`/content` answers **302** to a pre-authenticated CDN URL
+(`*.sharepoint.com`, `*.files.1drv.com`) carrying its own short-lived token in
+the query string. Sending our delegated bearer token to that host would be a
+credential leak to a third party, so this was checked rather than assumed:
+
+> Verified on this runtime (Node 22.21 / undici 6.22): `fetch` follows the
+> redirect and **strips `Authorization` cross-origin**, per the Fetch standard.
+> Same-origin (Graph → Graph) redirects keep it. `Accept` *is* forwarded — hence
+> `Accept: */*` in binary mode rather than asking a blob endpoint for JSON.
+
+So the default `redirect: 'follow'` is safe and `redirect: 'manual'` plus a bare
+second fetch would add moving parts for no gain. If a future runtime changes that
+behaviour, the fix belongs in `graphFetch` (one place), not in tool bodies.
 
 ---
 

--- a/docs/MICROSOFT_GRAPH.md
+++ b/docs/MICROSOFT_GRAPH.md
@@ -12,24 +12,37 @@ machinery see [UI_ARCHITECTURE.md §3](UI_ARCHITECTURE.md).
 
 ## What it can do today
 
-The **Microsoft 365** agent (`lib/harness-client/examples/microsoft-365.server.ts`)
-exposes four tools. All of them only ever **read** from Microsoft 365:
+Six registered `graph` tools. All of them only ever **read** from Microsoft 365:
 
 | Tool | Reads | Scope used |
 |------|-------|-----------|
 | `graph_me` | own profile (name, UPN, job title, office) | `User.Read` |
 | `graph_calendar_today` | own calendar for a given day (`day_offset`) | `Calendars.ReadWrite` |
 | `graph_mail_recent` | own inbox, newest first, optional `unread_only` | `Mail.Read` |
+| `graph_files_search` | files across own OneDrive **and** every reachable SharePoint site | `Files.Read.All` + `Sites.Read.All` |
+| `graph_files_list` | own OneDrive root, or one folder's children | `Files.Read.All` |
 | `graph_file_ingest` | one own OneDrive/SharePoint file → the Data Stash | `Files.Read.All` |
 
 Enough for "what does my day look like?" — the agent's loop calls several tools
-in one turn and the synthesizer writes the briefing — plus "pull that
+in one turn and the synthesizer writes the briefing — plus "find last quarter's
+budget in Finance", which is [file discovery](#finding-a-file), and "pull that
 spreadsheet in and chart it", which is [the file bridge](#files--the-data-stash).
 
-**Consented scopes exceed implemented tools.** The sign-in request also carries
-`Mail.Send` and `Sites.Read.All` (see the setup doc for why consent is taken up
-front). No tool exposes them, so the model cannot use them: a granted scope is
-not a capability — capability comes from a registered tool.
+**The agent composes five of the six.** The **Microsoft 365** agent
+(`lib/harness-client/examples/microsoft-365.server.ts`) takes an explicit
+allowlist, `MICROSOFT_365_TOOLS`, and `graph_file_ingest` is deliberately not in
+it: ingestion puts a file's bytes in the Data Stash, which is reachable only
+through a **retriever pattern**, and that agent has none. Exposing it would
+advertise a capability whose payoff the agent can't deliver — the model would
+ingest a file, get a document id, and be unable to read a word of it. Search and
+browse are the half of the file story that works without a retriever. An agent
+that *does* compose a retriever should compose the ingest tool too.
+
+**Consented scopes still exceed implemented tools.** The sign-in request also
+carries `Mail.Send` (see the setup doc for why consent is taken up front). No
+tool exposes it, so the model cannot use it: a granted scope is not a capability
+— capability comes from a registered tool. `Sites.Read.All` was in that unused
+set until `graph_files_search` claimed it.
 
 **Writes.** None yet. Adding one is the same shape as a read tool, but it should
 carry a confirmation gate: creating an event emails real invitations, and
@@ -74,7 +87,7 @@ graphFetch                               ← auth/graph-token.server.ts
 | `harness-patterns/mcp-client.server.ts` | dispatch: which transport owns this tool name |
 | `lib/harness-client/request-user.server.ts` | the ambient `{userId, sessionId}` of a run |
 | `lib/app-tools/registry.server.ts` | resolve identity, execute, never throw |
-| `lib/app-tools/graph.server.ts` | Graph paths, `$select`, response shaping |
+| `lib/app-tools/graph.server.ts` | Graph paths, `$select`, KQL composition, response shaping |
 | `lib/auth/graph-token.server.ts` | token acquisition, rotation, attach credential |
 | `lib/auth/user-tokens.server.ts` | encrypted per-user cache, keyed by `oid` |
 | `lib/auth/secret-crypto.server.ts` | AES-256-GCM envelope for stored secrets |
@@ -111,7 +124,14 @@ seam for that.
 `inferServer()` reads each tool's declared `namespace`, so they group as
 `tools.graph`. Consequences:
 
-- The `microsoft-365` agent picks up new graph tools with **no agent change**.
+- A newly registered graph tool appears in `tools.graph` for **every** consumer
+  with no registry change — discovery is automatic.
+- **Composition is not.** The `microsoft-365` agent filters `tools.graph` through
+  `MICROSOFT_365_TOOLS`, so a new tool reaches *that* agent only when its name is
+  added to that list. This was previously automatic, and stopped being so once a
+  registered tool existed that the agent shouldn't have (see above). The filter
+  runs allowlist-first (`MICROSOFT_365_TOOLS.filter(available)`), so a name that
+  isn't registered drops out instead of being handed to the loop.
 - App tools stay available when the **gateway is down** — they run in-process.
 
 ---
@@ -188,9 +208,110 @@ than failing the run.
 
 ---
 
+## Finding a file
+
+Two read tools stand in front of the Data Stash bridge. Both return the **same
+flattened item shape**, so a file found either way is addressable by
+`graph_file_ingest` with nothing for the model to reformat:
+
+| | `graph_files_search` | `graph_files_list` |
+|---|---|---|
+| Call | `POST /search/query`, `entityTypes: ["driveItem"]` | `GET /me/drive/root/children`, or `…/items/{id}/children` |
+| Reaches | own OneDrive **and** every SharePoint site the person can open | one known drive + folder |
+| Arguments | `query`, and optional `site`, `file_type`, `limit` (1–25, default 10) | optional `folder_item_id`, `drive_id`, `limit` (1–50, default 20) |
+| Adds to the shape | `snippet` — the matched text | `isFolder`, `child_count` |
+| Scopes | `Files.Read.All` + `Sites.Read.All` | `Files.Read.All` |
+
+```
+{ name, path, site, modified, size, drive_id, item_id, webUrl }
+```
+
+`drive_id` + `item_id` are **always** surfaced: that pair is what identifies a
+file to a tool that acts on one, so a search is only useful if it survives the
+flattening. `path` is the containing folder relative to the drive root (`/` at
+the root itself), and `site` is the SharePoint hostname — enough for a model to
+cite where something lives without a second call.
+
+### The app owns the query language
+
+Microsoft Search speaks **KQL**, which has clause grammar (`AND`, `OR`,
+parentheses) and property restrictions (`filetype:pdf`, `path:"…"`, `size>1000`).
+A model writing that string would be authoring the query's *structure* out of
+text it doesn't control — one stray `"` in a filename it echoed back and the
+restriction we added is closed and a different one opened. So it never writes
+KQL. `graph_files_search` takes structured arguments and composes every clause:
+
+| Argument | Becomes | Reduction applied |
+|---|---|---|
+| `query` | bare terms | quotes, `(` `)`, `:` `<` `>` `=` and control chars removed; KQL's uppercase-only `AND`/`OR`/`NOT`/`NEAR`/`ONEAR`/`XRANK` lowercased into ordinary words |
+| `file_type` | `filetype:docx` | leading alphanumeric run only, lowercased (`docx" OR filetype:exe` → `filetype:docx`) |
+| `site` | `path:"https://…"` | quotes + control chars removed, then **all** whitespace |
+
+**Why strip rather than escape.** KQL publishes no escape sequence for a `"`
+inside a value. An "escaped" quote would be a contract we invented and hoped the
+parser agreed with; removal is the only handling whose behaviour is knowable.
+Control characters go with it — they would split the request line.
+
+**Why no caller whitespace inside a clause.** A stray space in a restriction
+makes Search stop reading it as a restriction and treat the rest as free text — it
+*widens* the search silently instead of erroring. `filetype:` is alphanumeric by
+construction and the `path:` URL has its whitespace closed up (a URL has none),
+and the whitespace pass runs *after* the character removal, because removing a
+quote can itself leave a gap behind.
+
+The composed KQL is returned to the model as the result's `query`, so a filter
+that didn't bite is visible rather than guessed at. Terms first, restrictions
+after: KQL's default operator is AND.
+
+There is no `site:` operator in Graph KQL (that one is Purview eDiscovery only);
+`path:` is the documented way to scope to a site. `listItem` and `site` are
+freely combinable with `driveItem` in one `entityTypes` request, but they would
+fold list rows and site pages into what is meant to be a *file* search.
+
+### Flattening a search hit
+
+Graph nests a hit three deep — `value[].hitsContainers[].hits[].resource` — and
+decorates it. `shapeSearchHits` unwraps that, and four details are deliberate:
+
+- **`<cN>` markers are stripped.** Search wraps each matched term in the summary
+  as `<c0>term</c0>`, and marks elided text `<ddd/>`. To a model that is broken
+  markup it may well reproduce, so the markers go and the elision becomes `…`.
+- **`snippet` is capped at 300 chars**, the same budget as a mail preview: a page
+  of matched text per hit is how a 25-result search blows a turn.
+- **`item_id` is the resource's own `id`.** `parentReference.id` is the *folder*
+  the file sits in — using it would point every downstream call at the wrong
+  resource. When a hit arrives without its resource, `hitId` is the fallback
+  (for a driveItem it *is* the item id).
+- **`total` is Graph's count when it reports one**, and `null` otherwise. Search
+  omits it for some result sets, and a fabricated `0` reads as "nothing found".
+
+No `fields` is sent in the search request. Unlike `$select` it *replaces* the
+returned resource properties, and a hit stripped of `parentReference` has no
+`drive_id` — the very handoff the tool exists to produce. The shaping function is
+the allowlist instead, so no raw Graph payload reaches the model either way.
+
+`parentReference.path` arrives as `/drives/{id}/root:/Finance/Q3%20Reports`;
+`drivePath` drops the addressing prefix and decodes the segments. A malformed
+escape keeps its raw text rather than failing the result.
+
+### Why there is no `recent` mode
+
+The obvious third browse mode would be `/me/drive/recent`, with
+`/me/drive/sharedWithMe` beside it. Both are **deprecated and already
+degrading**: `sharedWithMe` is currently clamped to roughly one result by a live
+Microsoft mitigation, and both stop returning data in **November 2026**, with no
+replacement endpoint. A tool mode on top of that would teach a model to reach for
+something that then quietly returns nothing. If "files I touched lately" is
+wanted, `GET /me/drive/search(q=…)` (note: no `/root`) is the surface that still
+reaches shared items — and being a search, it belongs in `graph_files_search`.
+
+---
+
 ## Files → the Data Stash
 
-`graph_file_ingest` is the one tool that doesn't hand its result to the model. It
+`graph_file_ingest` is the one tool that doesn't hand its result to the model. Its
+`item_id` / `drive_id` arguments are exactly what [file discovery](#finding-a-file)
+returns, so the two halves compose without the model inventing an identifier. It
 copies a file the person already owns into **this conversation's** Data Stash, so
 the machinery that already exists for uploads — retriever search, the sandbox
 `/work` sync, the file viewer, chat citations — works on Microsoft 365 content
@@ -257,24 +378,31 @@ behaviour, the fix belongs in `graphFetch` (one place), not in tool bodies.
 
 ```ts
 registerAppTool({
-  name: "graph_files_recent",
+  name: "graph_contacts_search",
   namespace: "graph",
   description: "…acts as the current user; no user or token argument.",
   inputSchema: { type: "object", properties: { … }, additionalProperties: false },
   execute: async (args, { userId }) =>
-    shape(await graphFetch(userId, "/me/drive/recent?$top=10", {
-      scopes: ["Files.Read.All"],
+    shape(await graphFetch(userId, "/me/contacts?$select=displayName,emailAddresses&$top=10", {
+      scopes: ["Contacts.Read"],
     })),
 });
 ```
 
-That's the whole change — no auth, dispatch or agent wiring to touch. Guidelines
-that keep turns small and safe:
+3. To let the **Microsoft 365 agent** use it, add the name to
+   `MICROSOFT_365_TOOLS` in `examples/microsoft-365.server.ts`. Registration alone
+   makes it discoverable everywhere, but that agent composes an allowlist.
+
+No auth or dispatch wiring to touch. Guidelines that keep turns small and safe:
 
 - Always `$select` explicit fields; never hand a raw Graph payload to the model.
-- Shape and truncate (e.g. mail previews are capped at 300 chars).
+  Where an endpoint has no `$select` (the search API's `fields` is not one), the
+  shaping function is the allowlist.
+- Shape and truncate (mail previews and search snippets are capped at 300 chars).
 - Pass the **narrowest** scope the call needs, not the whole consented set.
 - Keep the schema free of any user/credential field.
+- If the endpoint has a query language, **compose it in the tool** from structured
+  arguments — see [the app owns the query language](#the-app-owns-the-query-language).
 
 ### Calendar time zones
 

--- a/docs/deploy/entra-setup.md
+++ b/docs/deploy/entra-setup.md
@@ -124,8 +124,10 @@ to sign in again** (their stored refresh token must cover it), and background ru
 have no user present to consent mid-run. One consent, done.
 
 A granted scope is not a capability. The model can only do what a *registered
-tool* exposes, and today that is the read-only `graph_me`. Any future write tool
-should carry its own confirmation gate.
+tool* exposes — see
+[MICROSOFT_GRAPH.md](../MICROSOFT_GRAPH.md#what-it-can-do-today) for the current
+set, none of which writes to Microsoft 365. Any future write tool should carry
+its own confirmation gate.
 
 > ⚠️ **Order matters.** Every scope in the request must exist under **API
 > permissions** with consent granted *before* anyone signs in. A scope that is

--- a/ui/src/__tests__/agents/code-mode-catalog.test.ts
+++ b/ui/src/__tests__/agents/code-mode-catalog.test.ts
@@ -74,6 +74,8 @@ vi.mock('../../lib/harness-client/session.server', () => ({
 vi.mock('../../lib/harness-client/request-user.server', () => ({
   getRequestUserId: vi.fn(() => null),
   runWithUserId: (_uid: string, fn: () => Promise<unknown>) => fn(),
+  getRequestSessionId: vi.fn(() => null),
+  runWithRequestContext: (_c: unknown, fn: () => Promise<unknown>) => fn(),
 }))
 
 describe('code-mode agent — up-front ENABLED SERVERS catalog', () => {

--- a/ui/src/__tests__/agents/code-mode-fidelity.test.ts
+++ b/ui/src/__tests__/agents/code-mode-fidelity.test.ts
@@ -111,6 +111,8 @@ vi.mock('../../lib/harness-client/session.server', () => ({
 vi.mock('../../lib/harness-client/request-user.server', () => ({
   getRequestUserId: vi.fn(() => null),
   runWithUserId: (_uid: string, fn: () => Promise<unknown>) => fn(),
+  getRequestSessionId: vi.fn(() => null),
+  runWithRequestContext: (_c: unknown, fn: () => Promise<unknown>) => fn(),
 }))
 
 describe('code-mode agent — synth fidelity + script-hygiene guidance', () => {

--- a/ui/src/__tests__/agents/code-mode.test.ts
+++ b/ui/src/__tests__/agents/code-mode.test.ts
@@ -87,6 +87,8 @@ const getRequestUserIdMock = vi.fn(() => null as string | null)
 vi.mock('../../lib/harness-client/request-user.server', () => ({
   getRequestUserId: getRequestUserIdMock,
   runWithUserId: (_uid: string, fn: () => Promise<unknown>) => fn(),
+  getRequestSessionId: vi.fn(() => null),
+  runWithRequestContext: (_c: unknown, fn: () => Promise<unknown>) => fn(),
 }))
 
 describe('code-mode agent — router → routes(chain(actorCritic, synth))', () => {

--- a/ui/src/__tests__/lib/app-tools/graph-connectors.test.ts
+++ b/ui/src/__tests__/lib/app-tools/graph-connectors.test.ts
@@ -10,9 +10,12 @@ vi.mock("../../../lib/harness-patterns/assert.server", () => ({
 }));
 
 const getRequestUserId = vi.fn<() => string | null>(() => "oid-1");
+const getRequestSessionId = vi.fn<() => string | null>(() => "sess-1");
 vi.mock("../../../lib/harness-client/request-user.server", () => ({
   getRequestUserId: () => getRequestUserId(),
+  getRequestSessionId: () => getRequestSessionId(),
   runWithUserId: (_u: string, fn: () => Promise<unknown>) => fn(),
+  runWithRequestContext: (_c: unknown, fn: () => Promise<unknown>) => fn(),
 }));
 
 const graphFetch = vi.fn();
@@ -41,6 +44,7 @@ function lastCall() {
 beforeEach(() => {
   vi.clearAllMocks();
   getRequestUserId.mockReturnValue("oid-1");
+  getRequestSessionId.mockReturnValue("sess-1");
   graphFetch.mockResolvedValue({ value: [] });
 });
 

--- a/ui/src/__tests__/lib/app-tools/graph-file-ingest.test.ts
+++ b/ui/src/__tests__/lib/app-tools/graph-file-ingest.test.ts
@@ -1,0 +1,307 @@
+/**
+ * `graph_file_ingest` — the Microsoft Graph → Data Stash bridge (#110).
+ *
+ * Covers the contract the model and the stash both depend on: metadata before
+ * download (so the size guard can refuse first), text vs. binary storage,
+ * fire-and-forget ingest, a fail-closed refusal without a conversation in scope,
+ * and no credential/session field in the advertised schema.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../../../lib/harness-patterns/assert.server", () => ({
+  assertServerOnImport: vi.fn(),
+  assertServer: vi.fn(),
+  ServerOnlyError: class ServerOnlyError extends Error {},
+}));
+
+const getRequestUserId = vi.fn<() => string | null>(() => "oid-1");
+const getRequestSessionId = vi.fn<() => string | null>(() => "sess-1");
+vi.mock("../../../lib/harness-client/request-user.server", () => ({
+  getRequestUserId: () => getRequestUserId(),
+  getRequestSessionId: () => getRequestSessionId(),
+  runWithUserId: (_u: string, fn: () => Promise<unknown>) => fn(),
+  runWithRequestContext: (_c: unknown, fn: () => Promise<unknown>) => fn(),
+}));
+
+const graphFetch = vi.fn();
+vi.mock("../../../lib/auth/graph-token.server", () => ({
+  graphFetch: (...a: unknown[]) => graphFetch(...a),
+  GRAPH_BASE: "https://graph.microsoft.com/v1.0",
+  DEFAULT_GRAPH_SCOPES: ["User.Read"],
+}));
+
+/** The store is mocked so the test never needs Redis; `MAX_CONTENT_BYTES` is
+ *  re-declared at the real value so the size guard is exercised as shipped. */
+const MAX_CONTENT_BYTES = 5 * 1024 * 1024;
+const storeDocument = vi.fn();
+vi.mock("../../../lib/document-store.server", () => ({
+  MAX_CONTENT_BYTES,
+  storeDocument: (...a: unknown[]) => storeDocument(...a),
+}));
+
+const ingestStashDocument = vi.fn<(sessionId: string, docId: string) => Promise<null>>(
+  async () => null,
+);
+vi.mock("../../../lib/document-ingest.server", () => ({
+  ingestStashDocument: (s: string, d: string) => ingestStashDocument(s, d),
+}));
+
+import { runAppTool, appToolDescriptions } from "../../../lib/app-tools/index.server";
+import { driveItemPath, shapeDriveItem } from "../../../lib/app-tools/graph.server";
+
+interface IngestResultShape {
+  documentId: string;
+  filename: string;
+  mimeType: string;
+  size: number;
+  ingesting: boolean;
+  webUrl: string | null;
+}
+
+/** Graph answers metadata first, then content — in that order. */
+function graphAnswers(
+  meta: Record<string, unknown>,
+  content = Buffer.from("hello stash").toString("base64"),
+) {
+  graphFetch.mockReset();
+  graphFetch.mockImplementation(async (_userId: string, path: string) =>
+    path.endsWith("/content") ? content : meta,
+  );
+}
+
+const FILE_META = {
+  name: "notes.md",
+  file: { mimeType: "text/markdown" },
+  size: 11,
+  webUrl: "https://contoso.sharepoint.com/notes.md",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getRequestUserId.mockReturnValue("oid-1");
+  getRequestSessionId.mockReturnValue("sess-1");
+  storeDocument.mockImplementation(async (input: { content: string }) => ({
+    ...input,
+    id: "doc-1",
+    size: Buffer.byteLength(input.content, "utf8"),
+    uploadedAt: 1,
+  }));
+  ingestStashDocument.mockResolvedValue(null);
+});
+
+describe("advertisement", () => {
+  it("registers graph_file_ingest with no credential/user/session field", () => {
+    const def = appToolDescriptions().find((t) => t.name === "graph_file_ingest");
+    expect(def).toBeDefined();
+    const schema = JSON.stringify(def!.inputSchema).toLowerCase();
+    for (const bad of [
+      "token",
+      "credential",
+      "secret",
+      "userid",
+      "user_id",
+      "session",
+      "oid",
+    ]) {
+      expect(schema, `schema leaks ${bad}`).not.toContain(bad);
+    }
+    expect(def!.inputSchema).toMatchObject({ required: ["item_id"] });
+  });
+});
+
+describe("driveItemPath", () => {
+  it("defaults to the caller's own drive and encodes ids", () => {
+    expect(driveItemPath("01ABC")).toBe("/me/drive/items/01ABC");
+    expect(driveItemPath("a/../b")).toBe("/me/drive/items/a%2F..%2Fb");
+  });
+
+  it("targets a named drive when given one", () => {
+    expect(driveItemPath("01ABC", "b!drive")).toBe("/drives/b!drive/items/01ABC");
+  });
+});
+
+describe("shapeDriveItem", () => {
+  it("reads name/mime/size/webUrl and flags files vs folders", () => {
+    expect(shapeDriveItem(FILE_META)).toEqual({
+      name: "notes.md",
+      mimeType: "text/markdown",
+      size: 11,
+      webUrl: "https://contoso.sharepoint.com/notes.md",
+      isFile: true,
+    });
+    expect(shapeDriveItem({ name: "Docs", folder: { childCount: 3 } }).isFile).toBe(false);
+    expect(shapeDriveItem(null)).toMatchObject({ name: null, size: null, isFile: false });
+  });
+});
+
+describe("happy path", () => {
+  it("reads metadata with an explicit $select, then downloads as base64", async () => {
+    graphAnswers(FILE_META);
+    const res = await runAppTool("graph_file_ingest", { item_id: "01ABC" });
+    expect(res.success).toBe(true);
+
+    const [metaCall, contentCall] = graphFetch.mock.calls as Array<
+      [string, string, { scopes?: string[]; responseType?: string }]
+    >;
+    expect(metaCall[0]).toBe("oid-1"); // scoped user, never an argument
+    expect(metaCall[1]).toBe("/me/drive/items/01ABC?$select=name,file,size,webUrl");
+    expect(metaCall[2].scopes).toEqual(["Files.Read.All"]);
+    expect(metaCall[2].responseType).toBeUndefined();
+
+    expect(contentCall[1]).toBe("/me/drive/items/01ABC/content");
+    expect(contentCall[2].responseType).toBe("base64");
+    expect(contentCall[2].scopes).toEqual(["Files.Read.All"]);
+  });
+
+  it("stores text formats as UTF-8 and fires the background ingest", async () => {
+    graphAnswers(FILE_META);
+    const res = await runAppTool("graph_file_ingest", { item_id: "01ABC" });
+
+    expect(storeDocument).toHaveBeenCalledWith({
+      sessionId: "sess-1", // from request scope
+      filename: "notes.md",
+      mimeType: "text/markdown",
+      content: "hello stash", // decoded, not base64
+      ingestStatus: "pending",
+    });
+    await vi.waitFor(() => expect(ingestStashDocument).toHaveBeenCalledWith("sess-1", "doc-1"));
+
+    expect(res.data).toEqual<IngestResultShape>({
+      documentId: "doc-1",
+      filename: "notes.md",
+      mimeType: "text/markdown",
+      size: 11,
+      ingesting: true,
+      webUrl: "https://contoso.sharepoint.com/notes.md",
+    });
+    // The bytes never travel back to the model.
+    expect(JSON.stringify(res.data)).not.toContain("hello stash");
+  });
+
+  it("keeps a non-convertible binary as base64 and does NOT ingest it", async () => {
+    const png = Buffer.from([0x89, 0x50, 0x4e, 0x47]).toString("base64");
+    graphAnswers({ name: "chart.png", file: { mimeType: "image/png" }, size: 4 }, png);
+
+    const res = await runAppTool("graph_file_ingest", { item_id: "01PNG" });
+    expect(storeDocument).toHaveBeenCalledWith({
+      sessionId: "sess-1",
+      filename: "chart.png",
+      mimeType: "image/png",
+      content: png,
+      encoding: "base64",
+    });
+    // Ingest would only mark it 'failed' (no converter for images).
+    expect(ingestStashDocument).not.toHaveBeenCalled();
+    expect((res.data as IngestResultShape).ingesting).toBe(false);
+  });
+
+  it("ingests a convertible binary (docx) when the converter is enabled", async () => {
+    vi.stubEnv("STASH_CONVERT_DOCS", "1");
+    const docx = Buffer.from("PK").toString("base64");
+    graphAnswers(
+      {
+        name: "spec.docx",
+        file: {
+          mimeType:
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        },
+        size: 4,
+      },
+      docx,
+    );
+
+    const res = await runAppTool("graph_file_ingest", { item_id: "01DOCX" });
+    expect(storeDocument).toHaveBeenCalledWith(
+      expect.objectContaining({ encoding: "base64", ingestStatus: "pending" }),
+    );
+    await vi.waitFor(() => expect(ingestStashDocument).toHaveBeenCalledWith("sess-1", "doc-1"));
+    expect((res.data as IngestResultShape).ingesting).toBe(true);
+    vi.unstubAllEnvs();
+  });
+
+  it("honours a drive_id and a filename override, and falls back on a missing MIME", async () => {
+    graphAnswers({ name: "raw", file: {}, size: 11 });
+    const res = await runAppTool("graph_file_ingest", {
+      item_id: "01ABC",
+      drive_id: "drive-9",
+      filename: "renamed.csv",
+    });
+    expect(graphFetch.mock.calls[0][1]).toContain("/drives/drive-9/items/01ABC");
+    expect((res.data as IngestResultShape).filename).toBe("renamed.csv");
+    // No file.mimeType → guessed from the (overridden) filename.
+    expect((res.data as IngestResultShape).mimeType).toBe("text/csv");
+  });
+});
+
+describe("refusals", () => {
+  it("fails closed with no conversation in scope, before touching Graph", async () => {
+    getRequestSessionId.mockReturnValue(null);
+    graphAnswers(FILE_META);
+    const res = await runAppTool("graph_file_ingest", { item_id: "01ABC" });
+
+    expect(res.success).toBe(false);
+    expect(res.error).toMatch(/conversation/i);
+    expect(graphFetch).not.toHaveBeenCalled();
+    expect(storeDocument).not.toHaveBeenCalled();
+  });
+
+  it("rejects an oversized file without downloading it", async () => {
+    graphAnswers({ ...FILE_META, name: "huge.csv", size: MAX_CONTENT_BYTES + 1 });
+    const res = await runAppTool("graph_file_ingest", { item_id: "01BIG" });
+
+    expect(res.success).toBe(false);
+    expect(res.error).toMatch(/above the Data Stash limit/i);
+    // Metadata only — the content call never happened.
+    expect(graphFetch).toHaveBeenCalledTimes(1);
+    expect(storeDocument).not.toHaveBeenCalled();
+  });
+
+  it("accepts a file exactly at the limit", async () => {
+    graphAnswers({ ...FILE_META, size: MAX_CONTENT_BYTES });
+    const res = await runAppTool("graph_file_ingest", { item_id: "01EDGE" });
+    expect(res.success).toBe(true);
+    expect(graphFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("proceeds when Graph reports no size (the store re-checks the limit)", async () => {
+    graphAnswers({ name: "notes.md", file: { mimeType: "text/markdown" } });
+    const res = await runAppTool("graph_file_ingest", { item_id: "01NOSIZE" });
+    expect(res.success).toBe(true);
+    expect(storeDocument).toHaveBeenCalled();
+  });
+
+  it("refuses a folder (no file facet) instead of downloading nothing", async () => {
+    graphAnswers({ name: "Reports", folder: { childCount: 2 } });
+    const res = await runAppTool("graph_file_ingest", { item_id: "01FOLDER" });
+    expect(res.success).toBe(false);
+    expect(res.error).toMatch(/no file content|folder/i);
+    expect(graphFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("requires item_id", async () => {
+    const res = await runAppTool("graph_file_ingest", { item_id: "  " });
+    expect(res.success).toBe(false);
+    expect(res.error).toMatch(/item_id is required/i);
+    expect(graphFetch).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a sign-in-needed failure as a failed result, not a throw", async () => {
+    graphFetch.mockReset();
+    graphFetch.mockRejectedValue(new Error("sign in to connect Microsoft 365"));
+    const res = await runAppTool("graph_file_ingest", { item_id: "01ABC" });
+    expect(res.success).toBe(false);
+    expect(res.error).toMatch(/sign in/i);
+    expect(res.data).toBeNull();
+  });
+
+  it("reports a content response that isn't bytes", async () => {
+    graphFetch.mockReset();
+    graphFetch.mockImplementation(async (_u: string, path: string) =>
+      path.endsWith("/content") ? null : FILE_META,
+    );
+    const res = await runAppTool("graph_file_ingest", { item_id: "01ABC" });
+    expect(res.success).toBe(false);
+    expect(res.error).toMatch(/no content/i);
+    expect(storeDocument).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/__tests__/lib/app-tools/graph-file-ingest.test.ts
+++ b/ui/src/__tests__/lib/app-tools/graph-file-ingest.test.ts
@@ -197,7 +197,7 @@ describe("happy path", () => {
 
   it("ingests a convertible binary (docx) when the converter is enabled", async () => {
     vi.stubEnv("STASH_CONVERT_DOCS", "1");
-    const docx = Buffer.from("PK").toString("base64");
+    const docx = Buffer.from([0x50, 0x4b, 0x03, 0x04]) /* "PK" + zip magic */.toString("base64");
     graphAnswers(
       {
         name: "spec.docx",

--- a/ui/src/__tests__/lib/app-tools/graph-files.test.ts
+++ b/ui/src/__tests__/lib/app-tools/graph-files.test.ts
@@ -1,0 +1,663 @@
+/**
+ * `graph_files_search` + `graph_files_list` — finding a Microsoft 365 file (#110).
+ *
+ * Two contracts are load-bearing here and both are asserted rather than assumed:
+ *
+ * 1. **The app owns the query language.** The model passes structured arguments;
+ *    every KQL clause is composed server-side. So the tests feed hostile values
+ *    (quotes, `filetype:` restrictions, boolean operators, control characters) and
+ *    assert the composed query still has exactly the structure *we* put there.
+ * 2. **The flattened shape is the handoff.** `drive_id` + `item_id` are what
+ *    `graph_file_ingest` takes, so they must survive Graph's nesting, a missing
+ *    `resource`, and a OneDrive shortcut stub — and `item_id` must never be the
+ *    parent folder's id.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../../../lib/harness-patterns/assert.server", () => ({
+  assertServerOnImport: vi.fn(),
+  assertServer: vi.fn(),
+  ServerOnlyError: class ServerOnlyError extends Error {},
+}));
+
+const getRequestUserId = vi.fn<() => string | null>(() => "oid-1");
+const getRequestSessionId = vi.fn<() => string | null>(() => "sess-1");
+vi.mock("../../../lib/harness-client/request-user.server", () => ({
+  getRequestUserId: () => getRequestUserId(),
+  getRequestSessionId: () => getRequestSessionId(),
+  runWithUserId: (_u: string, fn: () => Promise<unknown>) => fn(),
+  runWithRequestContext: (_c: unknown, fn: () => Promise<unknown>) => fn(),
+}));
+
+const graphFetch = vi.fn();
+vi.mock("../../../lib/auth/graph-token.server", () => ({
+  graphFetch: (...a: unknown[]) => graphFetch(...a),
+  GRAPH_BASE: "https://graph.microsoft.com/v1.0",
+  DEFAULT_GRAPH_SCOPES: ["User.Read"],
+}));
+
+import { runAppTool, appToolDescriptions } from "../../../lib/app-tools/index.server";
+import {
+  composeFileQuery,
+  kqlTerms,
+  kqlUrlPhrase,
+  kqlFileType,
+  cleanSummary,
+  drivePath,
+  siteHost,
+  shapeFileRef,
+  shapeSearchHits,
+  shapeFileEntries,
+  type GraphFileHit,
+  type GraphFileEntry,
+  type GraphFileSearchResult,
+  type GraphFileListResult,
+} from "../../../lib/app-tools/graph.server";
+
+/** Last graphFetch call as [userId, path, init]. */
+function lastCall() {
+  return graphFetch.mock.calls.at(-1) as [
+    string,
+    string,
+    {
+      method?: string;
+      scopes?: string[];
+      body?: { requests?: Array<Record<string, unknown>> };
+    },
+  ];
+}
+
+/** The single search request Graph was asked to run. */
+function searchRequest(): Record<string, unknown> {
+  const [, , init] = lastCall();
+  return init.body!.requests![0];
+}
+
+/** The KQL string the app composed for the last search call. */
+function sentQuery(): string {
+  return (searchRequest().query as { queryString: string }).queryString;
+}
+
+/** One fully-populated driveItem search hit, as Graph nests it. */
+const HIT = {
+  hitId: "01HITID",
+  rank: 1,
+  summary: "the <c0>quarterly</c0> <c1>budget</c1> was signed off<ddd/>",
+  resource: {
+    id: "01ITEMID",
+    name: "Q3 Budget.xlsx",
+    size: 20480,
+    webUrl: "https://contoso.sharepoint.com/sites/Finance/Q3%20Budget.xlsx",
+    lastModifiedDateTime: "2026-07-20T10:00:00Z",
+    file: { mimeType: "application/vnd.ms-excel" },
+    parentReference: {
+      driveId: "b!DRIVE",
+      // Deliberately different from resource.id: this is the *folder*.
+      id: "01PARENTFOLDER",
+      path: "/drives/b!DRIVE/root:/Finance/Q3%20Reports",
+      siteId: "contoso.sharepoint.com,11111111-1111-1111-1111-111111111111,22222222-2222-2222-2222-222222222222",
+    },
+  },
+};
+
+function searchResponse(hits: unknown[], total: number | null = hits.length) {
+  return {
+    value: [
+      {
+        hitsContainers: [{ hits, ...(total == null ? {} : { total }) }],
+      },
+    ],
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getRequestUserId.mockReturnValue("oid-1");
+  getRequestSessionId.mockReturnValue("sess-1");
+  graphFetch.mockResolvedValue(searchResponse([]));
+});
+
+// ============================================================================
+// Advertisement
+// ============================================================================
+
+describe("advertisement", () => {
+  it("registers both file tools with no credential/user/session field", () => {
+    const defs = appToolDescriptions().filter((t) =>
+      ["graph_files_search", "graph_files_list"].includes(t.name),
+    );
+    expect(defs).toHaveLength(2);
+
+    for (const def of defs) {
+      const schema = JSON.stringify(def.inputSchema).toLowerCase();
+      for (const bad of [
+        "token",
+        "credential",
+        "secret",
+        "userid",
+        "user_id",
+        "session",
+        "oid",
+      ]) {
+        expect(schema, `${def.name} leaks ${bad}`).not.toContain(bad);
+      }
+      expect(def.inputSchema).toMatchObject({ additionalProperties: false });
+    }
+  });
+
+  it("asks for a query and nothing else, and never advertises KQL", () => {
+    const search = appToolDescriptions().find((t) => t.name === "graph_files_search")!;
+    expect(search.inputSchema).toMatchObject({ required: ["query"] });
+    expect(Object.keys((search.inputSchema as { properties: object }).properties)).toEqual([
+      "query",
+      "site",
+      "file_type",
+      "limit",
+    ]);
+    // The model must not be invited to write query syntax.
+    expect(search.description?.toLowerCase()).not.toContain("kql");
+  });
+
+  it("leaves every graph_files_list argument optional (no args = OneDrive root)", () => {
+    const list = appToolDescriptions().find((t) => t.name === "graph_files_list")!;
+    expect(list.inputSchema).not.toHaveProperty("required");
+    expect(Object.keys((list.inputSchema as { properties: object }).properties)).toEqual([
+      "folder_item_id",
+      "drive_id",
+      "limit",
+    ]);
+    // The deprecated /me/drive/recent surface is deliberately not exposed.
+    expect(JSON.stringify(list.inputSchema)).not.toContain("recent");
+  });
+});
+
+// ============================================================================
+// KQL composition — one clause per argument, and only ours
+// ============================================================================
+
+describe("composeFileQuery", () => {
+  it("passes plain terms straight through", () => {
+    expect(composeFileQuery({ query: "quarterly budget" })).toBe("quarterly budget");
+  });
+
+  it("adds filetype: for file_type", () => {
+    expect(composeFileQuery({ query: "budget", fileType: "docx" })).toBe(
+      "budget filetype:docx",
+    );
+  });
+
+  it("adds path: for site, quoted because the value is a URL", () => {
+    expect(
+      composeFileQuery({ query: "budget", site: "https://contoso.sharepoint.com/sites/Finance" }),
+    ).toBe('budget path:"https://contoso.sharepoint.com/sites/Finance"');
+  });
+
+  it("combines all three, terms first", () => {
+    expect(
+      composeFileQuery({
+        query: "q3 budget",
+        site: "https://contoso.sharepoint.com/sites/Finance",
+        fileType: ".XLSX",
+      }),
+    ).toBe(
+      'q3 budget filetype:xlsx path:"https://contoso.sharepoint.com/sites/Finance"',
+    );
+  });
+
+  it("drops a filter that reduces to nothing rather than emitting a bare clause", () => {
+    expect(composeFileQuery({ query: "budget", fileType: "  " })).toBe("budget");
+    expect(composeFileQuery({ query: "budget", fileType: "!!!" })).toBe("budget");
+    expect(composeFileQuery({ query: "budget", site: "   " })).toBe("budget");
+  });
+
+  it("returns an empty string when nothing searchable survives", () => {
+    expect(composeFileQuery({ query: "" })).toBe("");
+    expect(composeFileQuery({ query: '"" (:)' })).toBe("");
+  });
+});
+
+describe("hostile input cannot restructure the query", () => {
+  // A model (or a filename it echoed back) trying to bolt its own restrictions
+  // onto ours: quotes to escape the phrase, a second filetype:, booleans, a
+  // grouped clause and a size comparison.
+  const HOSTILE = 'budget" OR filetype:exe OR (path:"https://evil.example" AND size>0) NOT';
+
+  it("strips the operators out of free text instead of honouring them", () => {
+    const kql = composeFileQuery({ query: HOSTILE });
+    expect(kql).toBe(
+      "budget or filetype exe or path https //evil.example and size 0 not",
+    );
+    // No quote to close, no colon to bind, no parenthesis to group.
+    expect(kql).not.toContain('"');
+    expect(kql).not.toContain(":");
+    expect(kql).not.toMatch(/[()<>=]/);
+  });
+
+  it("leaves exactly one filetype: clause — the one we composed", () => {
+    const kql = composeFileQuery({ query: HOSTILE, fileType: "pdf" });
+    expect(kql.match(/filetype:/g)).toHaveLength(1);
+    expect(kql.endsWith("filetype:pdf")).toBe(true);
+  });
+
+  it("leaves exactly one path: clause, with the attempt trapped inside its quotes", () => {
+    const kql = composeFileQuery({
+      query: HOSTILE,
+      site: 'https://contoso.sharepoint.com" OR path:"https://evil.example',
+    });
+    // Exactly two quotes — the pair kqlPhrase added — so everything between them
+    // is one value. A second restriction would need a quote of its own to close.
+    expect(kql.match(/"/g)).toHaveLength(2);
+    expect(kql.match(/path:"/g)).toHaveLength(1);
+    // The injected `path:` survives as literal text *inside* the phrase, where
+    // KQL reads it as part of the value rather than as a property restriction.
+    expect(kql).toContain(
+      'path:"https://contoso.sharepoint.comORpath:https://evil.example"',
+    );
+    expect(kql.endsWith('"')).toBe(true);
+  });
+
+  it("takes only the leading alphanumeric run of a hostile file_type", () => {
+    expect(kqlFileType('docx" OR filetype:exe')).toBe("filetype:docx");
+    expect(kqlFileType("../../etc/passwd")).toBe("filetype:etc");
+    expect(kqlFileType("PDF")).toBe("filetype:pdf");
+    expect(kqlFileType("...")).toBeNull();
+  });
+
+  it("removes control characters, which would otherwise split the request line", () => {
+    const nasty = `bud${String.fromCharCode(0)}get${String.fromCharCode(10)}filetype${String.fromCharCode(58)}exe${String.fromCharCode(127)}`;
+    expect(kqlTerms(nasty)).toBe("bud get filetype exe");
+    // A quoted URL keeps its colon (literal inside quotes, and a URL needs one)
+    // and closes up entirely — a restriction must not contain whitespace.
+    expect(kqlUrlPhrase(nasty)).toBe('"budgetfiletype:exe"');
+  });
+
+  it("keeps caller whitespace out of a filter clause (a space silently widens it)", () => {
+    // A space between `path:` and its value makes Search treat the rest as free
+    // text, so a padded/spaced site URL is closed up rather than passed on.
+    const kql = composeFileQuery({ query: "x", site: "  https://contoso.sharepoint.com/sites/A B  " });
+    expect(kql).toBe('x path:"https://contoso.sharepoint.com/sites/AB"');
+    expect(kql).not.toMatch(/path:\s/);
+  });
+
+  it("lowercases KQL's uppercase-only keywords, keeping the words", () => {
+    expect(kqlTerms("cats AND dogs NOT birds")).toBe("cats and dogs not birds");
+    // Lower case was never an operator, so it is left exactly as written.
+    expect(kqlTerms("cats and dogs")).toBe("cats and dogs");
+  });
+});
+
+// ============================================================================
+// graph_files_search
+// ============================================================================
+
+describe("graph_files_search", () => {
+  it("POSTs a driveItem search with the composed query and both file scopes", async () => {
+    const res = await runAppTool("graph_files_search", { query: "quarterly budget" });
+    expect(res.success).toBe(true);
+
+    const [userId, path, init] = lastCall();
+    expect(userId).toBe("oid-1"); // request-scoped, never an argument
+    expect(path).toBe("/search/query");
+    expect(init.method).toBe("POST");
+    expect(init.scopes).toEqual(["Files.Read.All", "Sites.Read.All"]);
+
+    expect(searchRequest()).toMatchObject({
+      entityTypes: ["driveItem"],
+      query: { queryString: "quarterly budget" },
+      from: 0,
+      size: 10,
+    });
+  });
+
+  it("sends no `fields` — it would replace the resource and drop parentReference", async () => {
+    await runAppTool("graph_files_search", { query: "x" });
+    // `fields` is not `$select`: naming any field removes the rest, and losing
+    // parentReference loses drive_id — the handoff this tool exists to produce.
+    expect(searchRequest()).not.toHaveProperty("fields");
+  });
+
+  it("clamps limit into 1..25", async () => {
+    await runAppTool("graph_files_search", { query: "x", limit: 999 });
+    expect(searchRequest().size).toBe(25);
+    await runAppTool("graph_files_search", { query: "x", limit: 0 });
+    expect(searchRequest().size).toBe(10); // 0 is falsy → default
+    await runAppTool("graph_files_search", { query: "x", limit: -5 });
+    expect(searchRequest().size).toBe(1);
+    await runAppTool("graph_files_search", { query: "x", limit: "junk" });
+    expect(searchRequest().size).toBe(10);
+  });
+
+  it("refuses before calling Graph when nothing searchable was given", async () => {
+    for (const args of [{}, { query: "   " }, { query: '":()' }]) {
+      const res = await runAppTool("graph_files_search", args);
+      expect(res.success).toBe(false);
+      expect(res.error).toMatch(/query is required/i);
+    }
+    expect(graphFetch).not.toHaveBeenCalled();
+  });
+
+  it("flattens a hit to the shape the ingest handoff needs", async () => {
+    graphFetch.mockResolvedValue(searchResponse([HIT], 42));
+    const res = await runAppTool("graph_files_search", { query: "budget" });
+
+    expect(res.data).toEqual<GraphFileSearchResult>({
+      query: "budget", // the KQL actually run, echoed back
+      total: 42,
+      results: [
+        {
+          name: "Q3 Budget.xlsx",
+          path: "Finance/Q3 Reports",
+          site: "contoso.sharepoint.com",
+          modified: "2026-07-20T10:00:00Z",
+          size: 20480,
+          snippet: "the quarterly budget was signed off…",
+          drive_id: "b!DRIVE",
+          item_id: "01ITEMID",
+          webUrl: "https://contoso.sharepoint.com/sites/Finance/Q3%20Budget.xlsx",
+        },
+      ],
+    });
+  });
+
+  it("reports the composed query, not the raw argument", async () => {
+    const res = await runAppTool("graph_files_search", {
+      query: "budget",
+      file_type: "pdf",
+    });
+    expect((res.data as GraphFileSearchResult).query).toBe("budget filetype:pdf");
+  });
+});
+
+describe("shapeSearchHits", () => {
+  it("uses the item's own id, never its parent folder's", () => {
+    const [hit] = shapeSearchHits(searchResponse([HIT])).results;
+    expect(hit.item_id).toBe("01ITEMID");
+    expect(hit.item_id).not.toBe("01PARENTFOLDER");
+  });
+
+  it("falls back to hitId when a hit came back without its resource", () => {
+    const [hit] = shapeSearchHits(searchResponse([{ hitId: "01BARE" }])).results;
+    expect(hit.item_id).toBe("01BARE");
+    expect(hit.name).toBeNull();
+    expect(hit.drive_id).toBeNull();
+  });
+
+  it("sums totals across containers and stays null when none reported one", () => {
+    expect(shapeSearchHits(searchResponse([HIT], null)).total).toBeNull();
+    const twoContainers = {
+      value: [{ hitsContainers: [{ hits: [HIT], total: 3 }, { hits: [], total: 4 }] }],
+    };
+    expect(shapeSearchHits(twoContainers).total).toBe(7);
+  });
+
+  it("tolerates missing and garbage payloads instead of throwing", () => {
+    expect(shapeSearchHits(null)).toEqual({ total: null, results: [] });
+    expect(shapeSearchHits({})).toEqual({ total: null, results: [] });
+    expect(shapeSearchHits({ value: "nope" })).toEqual({ total: null, results: [] });
+    expect(shapeSearchHits({ value: [{}] })).toEqual({ total: null, results: [] });
+    expect(shapeSearchHits({ value: [{ hitsContainers: [{ hits: "nope" }] }] })).toEqual({
+      total: null,
+      results: [],
+    });
+
+    const [hit] = shapeSearchHits(searchResponse([null, {}])).results;
+    expect(hit).toEqual<GraphFileHit>({
+      name: null,
+      path: null,
+      site: null,
+      modified: null,
+      size: null,
+      snippet: null,
+      drive_id: null,
+      item_id: null,
+      webUrl: null,
+    });
+  });
+
+  it("ignores a numeric-looking total that isn't a number", () => {
+    const bad = { value: [{ hitsContainers: [{ hits: [], total: "12" }] }] };
+    expect(shapeSearchHits(bad).total).toBeNull();
+  });
+});
+
+describe("cleanSummary", () => {
+  it("strips every <cN> highlight marker, however high N goes", () => {
+    expect(cleanSummary("<c0>a</c0> and <c1>b</c1> and <c12>c</c12>")).toBe(
+      "a and b and c",
+    );
+  });
+
+  it("turns Search's <ddd/> elision marker into an ellipsis", () => {
+    expect(cleanSummary("start<ddd/>end")).toBe("start…end");
+  });
+
+  it("truncates to 300 chars, the same budget as a mail preview", () => {
+    const long = cleanSummary(`<c0>${"x".repeat(1000)}</c0>`);
+    expect(long).toHaveLength(300);
+  });
+
+  it("collapses whitespace and nulls out empties and non-strings", () => {
+    expect(cleanSummary(" a \n  b ")).toBe("a b");
+    expect(cleanSummary("<c0></c0>")).toBeNull();
+    expect(cleanSummary(null)).toBeNull();
+    expect(cleanSummary(42)).toBeNull();
+  });
+});
+
+describe("drivePath", () => {
+  it("decodes a drive-relative path and drops the addressing prefix", () => {
+    expect(drivePath("/drive/root:/Reports/Q3%20Plans")).toBe("Reports/Q3 Plans");
+    expect(drivePath("/drives/b!ABC/root:/Finance")).toBe("Finance");
+  });
+
+  it("reports a drive-root item as /", () => {
+    expect(drivePath("/drive/root:")).toBe("/");
+    expect(drivePath("/drives/b!ABC/root:/")).toBe("/");
+  });
+
+  it("keeps a malformed escape rather than failing the whole result", () => {
+    expect(drivePath("/drive/root:/bad%zz")).toBe("bad%zz");
+  });
+
+  it("passes through a path with no root: marker, and nulls out non-strings", () => {
+    expect(drivePath("Shared Documents")).toBe("Shared Documents");
+    expect(drivePath(null)).toBeNull();
+    expect(drivePath("   ")).toBeNull();
+    expect(drivePath(42)).toBeNull();
+  });
+});
+
+describe("siteHost", () => {
+  it("keeps the hostname and drops the site/web guids", () => {
+    expect(siteHost("contoso.sharepoint.com,1111,2222")).toBe("contoso.sharepoint.com");
+  });
+
+  it("passes through an id with no hostname, and nulls out non-strings", () => {
+    expect(siteHost("1111")).toBe("1111");
+    expect(siteHost(null)).toBeNull();
+    expect(siteHost("  ")).toBeNull();
+  });
+});
+
+// ============================================================================
+// graph_files_list
+// ============================================================================
+
+describe("graph_files_list", () => {
+  beforeEach(() => {
+    graphFetch.mockResolvedValue({ value: [] });
+  });
+
+  it("lists the OneDrive root with an explicit $select when given no arguments", async () => {
+    const res = await runAppTool("graph_files_list", {});
+    expect(res.success).toBe(true);
+    expect((res.data as GraphFileListResult).location).toBe("onedrive-root");
+
+    const [userId, path, init] = lastCall();
+    expect(userId).toBe("oid-1");
+    expect(path).toBe(
+      "/me/drive/root/children?$select=id,name,file,folder,size,webUrl," +
+        "lastModifiedDateTime,parentReference,remoteItem&$top=20",
+    );
+    expect(init.scopes).toEqual(["Files.Read.All"]);
+    expect(init.method).toBeUndefined(); // a GET
+  });
+
+  it("lists a folder's children, in the caller's own drive by default", async () => {
+    const res = await runAppTool("graph_files_list", { folder_item_id: "01FOLDER" });
+    expect((res.data as GraphFileListResult).location).toBe("folder");
+    expect(lastCall()[1]).toContain("/me/drive/items/01FOLDER/children?$select=");
+  });
+
+  it("targets a named drive and encodes a crafted folder id", async () => {
+    await runAppTool("graph_files_list", {
+      folder_item_id: "a/../b",
+      drive_id: "b!DRIVE",
+    });
+    expect(lastCall()[1]).toContain("/drives/b!DRIVE/items/a%2F..%2Fb/children");
+  });
+
+  it("clamps limit into 1..50", async () => {
+    await runAppTool("graph_files_list", { limit: 999 });
+    expect(lastCall()[1]).toContain("$top=50");
+    await runAppTool("graph_files_list", { limit: 0 });
+    expect(lastCall()[1]).toContain("$top=20"); // 0 is falsy → default
+    await runAppTool("graph_files_list", { limit: -5 });
+    expect(lastCall()[1]).toContain("$top=1");
+  });
+
+  it("never reaches the deprecated /me/drive/recent, even if asked to", async () => {
+    // The argument doesn't exist; passing it must not change the location.
+    const res = await runAppTool("graph_files_list", { recent: true });
+    expect((res.data as GraphFileListResult).location).toBe("onedrive-root");
+    expect(lastCall()[1]).not.toContain("recent?");
+    expect(lastCall()[1]).toContain("/me/drive/root/children");
+  });
+
+  it("flags folders with a child count and files without one", async () => {
+    graphFetch.mockResolvedValue({
+      value: [
+        {
+          id: "01F",
+          name: "Reports",
+          folder: { childCount: 3 },
+          parentReference: { driveId: "b!D", path: "/drive/root:" },
+        },
+        {
+          id: "01X",
+          name: "notes.md",
+          file: { mimeType: "text/markdown" },
+          size: 12,
+          lastModifiedDateTime: "2026-07-01T00:00:00Z",
+          webUrl: "https://contoso-my.sharepoint.com/notes.md",
+          parentReference: { driveId: "b!D", path: "/drive/root:/Inbox" },
+        },
+      ],
+    });
+    const items = (await runAppTool("graph_files_list", {})).data as GraphFileListResult;
+
+    expect(items.items[0]).toEqual<GraphFileEntry>({
+      name: "Reports",
+      path: "/",
+      site: null,
+      modified: null,
+      size: null,
+      drive_id: "b!D",
+      item_id: "01F",
+      webUrl: null,
+      isFolder: true,
+      child_count: 3,
+    });
+    expect(items.items[1]).toMatchObject({
+      name: "notes.md",
+      path: "Inbox",
+      isFolder: false,
+      child_count: null,
+    });
+  });
+
+  it("reports an empty folder as 0 children, not as a file", () => {
+    const [entry] = shapeFileEntries({ value: [{ folder: {} }] });
+    expect(entry.isFolder).toBe(true);
+    expect(entry.child_count).toBeNull();
+    const [counted] = shapeFileEntries({ value: [{ folder: { childCount: 0 } }] });
+    expect(counted.child_count).toBe(0);
+  });
+
+  it("unwraps a shortcut stub so the ids address the real file", () => {
+    const [entry] = shapeFileEntries({
+      value: [
+        {
+          id: "01SHORTCUT",
+          name: "Shared Finance",
+          parentReference: { driveId: "b!MYDRIVE", path: "/drive/root:" },
+          remoteItem: {
+            id: "01REALITEM",
+            name: "Finance",
+            folder: { childCount: 9 },
+            parentReference: {
+              driveId: "b!OTHERDRIVE",
+              path: "/drives/b!OTHERDRIVE/root:/Sites",
+              siteId: "contoso.sharepoint.com,1111,2222",
+            },
+          },
+        },
+      ],
+    });
+    expect(entry).toMatchObject({
+      item_id: "01REALITEM",
+      drive_id: "b!OTHERDRIVE",
+      site: "contoso.sharepoint.com",
+      path: "Sites",
+      isFolder: true,
+      child_count: 9,
+    });
+  });
+
+  it("tolerates missing and garbage payloads", () => {
+    expect(shapeFileEntries(null)).toEqual([]);
+    expect(shapeFileEntries({ value: "nope" })).toEqual([]);
+    expect(shapeFileEntries({ value: [null] })[0]).toMatchObject({
+      name: null,
+      item_id: null,
+      isFolder: false,
+      child_count: null,
+    });
+    expect(shapeFileEntries({ value: [{ folder: "nope" }] })[0].isFolder).toBe(false);
+  });
+
+  it("surfaces a sign-in-needed failure as a failed result, not a throw", async () => {
+    graphFetch.mockRejectedValue(new Error("sign in to connect Microsoft 365"));
+    const res = await runAppTool("graph_files_list", {});
+    expect(res.success).toBe(false);
+    expect(res.error).toMatch(/sign in/i);
+    expect(res.data).toBeNull();
+  });
+});
+
+describe("shapeFileRef", () => {
+  it("reuses the ingest tool's field extraction for name/size/webUrl", () => {
+    expect(shapeFileRef(HIT.resource)).toMatchObject({
+      name: "Q3 Budget.xlsx",
+      size: 20480,
+      webUrl: HIT.resource.webUrl,
+    });
+  });
+
+  it("returns an all-null ref for junk rather than throwing", () => {
+    expect(shapeFileRef(undefined)).toEqual({
+      name: null,
+      path: null,
+      site: null,
+      modified: null,
+      size: null,
+      drive_id: null,
+      item_id: null,
+      webUrl: null,
+    });
+    expect(shapeFileRef({ size: "big", id: 42 })).toMatchObject({
+      size: null,
+      item_id: null,
+    });
+  });
+});

--- a/ui/src/__tests__/lib/app-tools/registry.test.ts
+++ b/ui/src/__tests__/lib/app-tools/registry.test.ts
@@ -14,9 +14,12 @@ vi.mock("../../../lib/harness-patterns/assert.server", () => ({
 }));
 
 const getRequestUserId = vi.fn<() => string | null>(() => "oid-1");
+const getRequestSessionId = vi.fn<() => string | null>(() => "sess-1");
 vi.mock("../../../lib/harness-client/request-user.server", () => ({
   getRequestUserId: () => getRequestUserId(),
+  getRequestSessionId: () => getRequestSessionId(),
   runWithUserId: (_u: string, fn: () => Promise<unknown>) => fn(),
+  runWithRequestContext: (_c: unknown, fn: () => Promise<unknown>) => fn(),
 }));
 
 const graphFetch = vi.fn();
@@ -39,6 +42,7 @@ import { shapeMe } from "../../../lib/app-tools/graph.server";
 beforeEach(() => {
   vi.clearAllMocks();
   getRequestUserId.mockReturnValue("oid-1");
+  getRequestSessionId.mockReturnValue("sess-1");
 });
 
 describe("registry wiring", () => {
@@ -102,6 +106,34 @@ describe("runAppTool", () => {
     const res = await runAppTool("test_echo", { a: 1 });
     expect(res.success).toBe(true);
     expect(res.data).toEqual({ args: { a: 1 }, user: "oid-1" });
+  });
+
+  it("passes the request-scoped sessionId to the executor (not from args)", async () => {
+    registerAppTool({
+      name: "test_ctx",
+      namespace: "test",
+      description: "ctx",
+      inputSchema: { type: "object", properties: {} },
+      execute: async (_args, ctx) => ({ ...ctx }),
+    });
+    getRequestSessionId.mockReturnValue("sess-real");
+    const res = await runAppTool("test_ctx", { sessionId: "attacker-session" });
+    expect(res.data).toEqual({ userId: "oid-1", sessionId: "sess-real" });
+  });
+
+  it("hands the executor sessionId: null when a user scope carries no session", async () => {
+    registerAppTool({
+      name: "test_ctx_null",
+      namespace: "test",
+      description: "ctx",
+      inputSchema: { type: "object", properties: {} },
+      execute: async (_args, ctx) => ({ ...ctx }),
+    });
+    // `runWithUserId` (background summarization, legacy call sites) — a user but
+    // no conversation. Session-dependent tools must see null, not a guess.
+    getRequestSessionId.mockReturnValue(null);
+    const res = await runAppTool("test_ctx_null", {});
+    expect(res.data).toEqual({ userId: "oid-1", sessionId: null });
   });
 });
 

--- a/ui/src/__tests__/lib/app-tools/user-isolation.test.ts
+++ b/ui/src/__tests__/lib/app-tools/user-isolation.test.ts
@@ -26,8 +26,13 @@ vi.mock("../../../lib/auth/graph-token.server", () => ({
   },
 }));
 
-import { runWithUserId } from "../../../lib/harness-client/request-user.server";
-import { runAppTool } from "../../../lib/app-tools/index.server";
+import {
+  runWithUserId,
+  runWithRequestContext,
+  getRequestUserId,
+  getRequestSessionId,
+} from "../../../lib/harness-client/request-user.server";
+import { runAppTool, registerAppTool } from "../../../lib/app-tools/index.server";
 
 describe("request-scoped identity under concurrency", () => {
   it("keeps each user's identity separate across interleaved calls", async () => {
@@ -73,6 +78,52 @@ describe("request-scoped identity under concurrency", () => {
     expect(scoped.success).toBe(true);
     expect(unscoped.success).toBe(false);
     expect(unscoped.error).toMatch(/authenticated user/i);
+  });
+});
+
+describe("request-scoped conversation", () => {
+  // Echoes whatever context runAppTool resolved, after a yield — so a bleed
+  // between concurrent conversations shows up as a mismatched sessionId.
+  registerAppTool({
+    name: "test_echo_ctx",
+    namespace: "test",
+    description: "echo the resolved app-tool context",
+    inputSchema: { type: "object", properties: {} },
+    execute: async (_args, ctx) => {
+      await sleep(ctx.sessionId === "sess-A" ? 20 : 2);
+      return { ...ctx };
+    },
+  });
+
+  it("keeps each conversation's sessionId separate across interleaved calls", async () => {
+    const call = (userId: string, sessionId: string) =>
+      runWithRequestContext({ userId, sessionId }, async () => {
+        await sleep(1);
+        return runAppTool("test_echo_ctx", {});
+      });
+
+    const [a, b] = await Promise.all([
+      call("user-A", "sess-A"), // slow — B overtakes it
+      call("user-B", "sess-B"),
+    ]);
+
+    expect(a.data).toEqual({ userId: "user-A", sessionId: "sess-A" });
+    expect(b.data).toEqual({ userId: "user-B", sessionId: "sess-B" });
+  });
+
+  it("runWithUserId still establishes the user, with no session", async () => {
+    const res = await runWithUserId("user-legacy", async () => {
+      // The old accessor keeps its exact behaviour for existing callers.
+      expect(getRequestUserId()).toBe("user-legacy");
+      expect(getRequestSessionId()).toBeNull();
+      return runAppTool("test_echo_ctx", {});
+    });
+    expect(res.data).toEqual({ userId: "user-legacy", sessionId: null });
+  });
+
+  it("reads null for both outside any scope", () => {
+    expect(getRequestUserId()).toBeNull();
+    expect(getRequestSessionId()).toBeNull();
   });
 });
 

--- a/ui/src/__tests__/lib/auth/graph-token.test.ts
+++ b/ui/src/__tests__/lib/auth/graph-token.test.ts
@@ -192,4 +192,69 @@ describe("graphFetch", () => {
     vi.stubGlobal("fetch", vi.fn(async () => ({ ok: true, status: 204 })));
     await expect(graphFetch(USER, "/me")).resolves.toBeNull();
   });
+
+  it("asks for JSON by default and never sends a body-less Content-Type", async () => {
+    const fetchMock = vi.fn(async () => ({ ok: true, status: 200, json: async () => ({}) }));
+    vi.stubGlobal("fetch", fetchMock);
+    await graphFetch(USER, "/me");
+    const headers = (fetchMock.mock.calls[0] as unknown as [string, RequestInit])[1]
+      .headers as Record<string, string>;
+    expect(headers.Accept).toBe("application/json");
+    expect(headers["Content-Type"]).toBeUndefined();
+  });
+
+  describe("responseType: 'base64'", () => {
+    const BYTES = Uint8Array.from([0x89, 0x50, 0x4e, 0x47, 0x0d]);
+
+    function stubBinaryFetch() {
+      const fetchMock = vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        arrayBuffer: async () => BYTES.buffer,
+        json: async () => {
+          throw new Error("json() must not be called in binary mode");
+        },
+      }));
+      vi.stubGlobal("fetch", fetchMock);
+      return fetchMock;
+    }
+
+    it("returns the raw bytes base64-encoded", async () => {
+      stubBinaryFetch();
+      await expect(
+        graphFetch(USER, "/me/drive/items/01ABC/content", { responseType: "base64" }),
+      ).resolves.toBe(Buffer.from(BYTES).toString("base64"));
+    });
+
+    it("asks for any content type — a blob endpoint has no JSON to give", async () => {
+      const fetchMock = stubBinaryFetch();
+      await graphFetch(USER, "/me/drive/items/01ABC/content", {
+        responseType: "base64",
+        scopes: ["Files.Read.All"],
+      });
+      const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+      const headers = init.headers as Record<string, string>;
+      expect(url).toBe(`${GRAPH_BASE}/me/drive/items/01ABC/content`);
+      expect(headers.Accept).toBe("*/*");
+      // Still delegated, and the 302 to the CDN is followed by fetch itself —
+      // which drops Authorization cross-origin (see graphFetch's doc comment).
+      expect(headers.Authorization).toBe("Bearer tok-abc");
+      expect(init.redirect).toBeUndefined();
+      expect(acquireTokenSilent).toHaveBeenCalledWith(
+        expect.objectContaining({ scopes: ["Files.Read.All"] }),
+      );
+    });
+
+    it("still maps 401/403 and 204 the same way", async () => {
+      vi.stubGlobal("fetch", vi.fn(async () => ({ ok: false, status: 403, statusText: "no" })));
+      await expect(
+        graphFetch(USER, "/x/content", { responseType: "base64" }),
+      ).rejects.toBeInstanceOf(GraphAuthRequiredError);
+
+      vi.stubGlobal("fetch", vi.fn(async () => ({ ok: true, status: 204 })));
+      await expect(
+        graphFetch(USER, "/x/content", { responseType: "base64" }),
+      ).resolves.toBeNull();
+    });
+  });
 });

--- a/ui/src/__tests__/lib/harness-client/examples/microsoft-365.test.ts
+++ b/ui/src/__tests__/lib/harness-client/examples/microsoft-365.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Microsoft 365 agent — what it composes out of `tools.graph` (#110).
+ *
+ * The agent takes an explicit allowlist rather than the whole namespace, and the
+ * interesting part is what's missing: `graph_file_ingest` is registered, and this
+ * agent must still not get it, because with no retriever pattern an ingested
+ * file's contents are unreachable for the rest of the turn.
+ *
+ * The harness barrel is stubbed so this stays a unit test of the composition —
+ * it asserts the exact tool list handed to the loop and its controller, which is
+ * not observable from a `ConfiguredPattern` afterwards.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../../../../lib/harness-patterns/assert.server", () => ({
+  assertServerOnImport: vi.fn(),
+  assertServer: vi.fn(),
+  ServerOnlyError: class ServerOnlyError extends Error {},
+}));
+
+vi.mock("../../../../lib/auth/graph-token.server", () => ({
+  graphFetch: vi.fn(),
+  GRAPH_BASE: "https://graph.microsoft.com/v1.0",
+  DEFAULT_GRAPH_SCOPES: ["User.Read"],
+}));
+
+vi.mock("../../../../lib/harness-client/request-user.server", () => ({
+  getRequestUserId: () => "oid-1",
+  getRequestSessionId: () => "sess-1",
+  runWithUserId: (_u: string, fn: () => Promise<unknown>) => fn(),
+  runWithRequestContext: (_c: unknown, fn: () => Promise<unknown>) => fn(),
+}));
+
+/** Whatever `Tools()` should report as the graph namespace for a given test. */
+let graphNamespace: string[] = [];
+
+const simpleLoop = vi.fn((controller: unknown, tools: string[], config: unknown) => ({
+  name: "simpleLoop",
+  fn: async () => undefined,
+  config,
+  // Not part of ConfiguredPattern — captured here purely so the test can see
+  // which tools the agent handed the loop.
+  tools,
+  controller,
+}));
+
+vi.mock("../../../../lib/harness-patterns", () => ({
+  simpleLoop: (c: unknown, t: string[], cfg: unknown) => simpleLoop(c, t, cfg),
+  synthesizer: (config: unknown) => ({
+    name: "synthesizer",
+    fn: async () => undefined,
+    config,
+  }),
+  Tools: async () => ({ graph: graphNamespace, all: graphNamespace }),
+  createLoopControllerAdapter: (tools: string[]) => ({ adapterTools: tools }),
+}));
+
+import {
+  microsoft365Agent,
+  MICROSOFT_365_TOOLS,
+} from "../../../../lib/harness-client/examples/microsoft-365.server";
+import { appToolNamespace, hasAppTool } from "../../../../lib/app-tools/index.server";
+
+/** The last `simpleLoop(controller, tools, config)` call the agent made. */
+function lastLoopCall(): [unknown, string[], Record<string, unknown>] {
+  return simpleLoop.mock.calls.at(-1) as [unknown, string[], Record<string, unknown>];
+}
+
+/** The tools the agent handed its loop on the last createPatterns() call. */
+function composedTools(): string[] {
+  return lastLoopCall()[1];
+}
+
+/** Every graph tool that exists, so the allowlist is filtering something real. */
+const ALL_GRAPH_TOOLS = [
+  "graph_me",
+  "graph_calendar_today",
+  "graph_mail_recent",
+  "graph_file_ingest",
+  "graph_files_search",
+  "graph_files_list",
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  graphNamespace = [...ALL_GRAPH_TOOLS];
+});
+
+describe("tool allowlist", () => {
+  it("names the five read tools the agent can actually use", () => {
+    expect([...MICROSOFT_365_TOOLS]).toEqual([
+      "graph_me",
+      "graph_calendar_today",
+      "graph_mail_recent",
+      "graph_files_search",
+      "graph_files_list",
+    ]);
+  });
+
+  it("excludes graph_file_ingest — which exists, so the exclusion is a decision", () => {
+    // If this tool ever stops being registered the assertion below is vacuous,
+    // so assert it *is* there first.
+    expect(hasAppTool("graph_file_ingest")).toBe(true);
+    expect([...MICROSOFT_365_TOOLS]).not.toContain("graph_file_ingest");
+  });
+
+  it("lists only names that are really registered under the graph namespace", () => {
+    // Catches a typo in the allowlist, which would otherwise fail silently by
+    // filtering the name away at composition time.
+    for (const name of MICROSOFT_365_TOOLS) {
+      expect(appToolNamespace(name), `${name} is not a registered graph tool`).toBe(
+        "graph",
+      );
+    }
+  });
+});
+
+describe("createPatterns", () => {
+  it("hands the loop the allowlist, not the whole graph namespace", async () => {
+    const patterns = await microsoft365Agent.createPatterns("test-session");
+
+    expect(composedTools()).toEqual([...MICROSOFT_365_TOOLS]);
+    expect(composedTools()).not.toContain("graph_file_ingest");
+    expect(patterns).toHaveLength(2);
+  });
+
+  it("gives the controller the same list as the loop (no wider allowlist)", async () => {
+    await microsoft365Agent.createPatterns("test-session");
+    const controller = lastLoopCall()[0] as { adapterTools: string[] };
+    expect(controller.adapterTools).toEqual([...MICROSOFT_365_TOOLS]);
+  });
+
+  it("drops an allowlisted tool that isn't available (gateway down, module unloaded)", async () => {
+    graphNamespace = ["graph_me", "graph_files_search"];
+    await microsoft365Agent.createPatterns("test-session");
+    expect(composedTools()).toEqual(["graph_me", "graph_files_search"]);
+  });
+
+  it("survives an empty or absent graph namespace", async () => {
+    graphNamespace = [];
+    await microsoft365Agent.createPatterns("test-session");
+    expect(composedTools()).toEqual([]);
+  });
+
+  it("keeps the loop config the agent depends on", async () => {
+    await microsoft365Agent.createPatterns("test-session");
+    expect(lastLoopCall()[2]).toMatchObject({
+      patternId: "microsoft-365",
+      liveEvents: true,
+      rememberPriorTurns: false,
+      maxTurns: 8,
+    });
+  });
+});

--- a/ui/src/lib/app-tools/graph.server.ts
+++ b/ui/src/lib/app-tools/graph.server.ts
@@ -5,14 +5,20 @@
  * resolves that user's delegated token server-side. Entra enforces the scope,
  * so we don't write a scoping guard and the model never sees a credential.
  *
- * First slice is deliberately `User.Read`-only — the scope already has tenant
- * admin consent, so the whole per-user token path is provable end-to-end with
- * no new tenant configuration. Mail/Files/Calendar tools slot in here once
- * their scopes are consented and added to the sign-in request
- * (`entra-config.server.ts`).
+ * First slice was deliberately `User.Read`-only — the scope already has tenant
+ * admin consent, so the whole per-user token path was provable end-to-end with
+ * no new tenant configuration. Further tools slot in here once their scopes are
+ * consented and added to the sign-in request (`entra-config.server.ts`).
+ *
+ * `graph_file_ingest` is the one tool that does more than read-and-shape: it
+ * bridges Microsoft 365 into the **Data Stash**, so a file the person already
+ * owns becomes something later turns (retriever, sandbox, file viewer) can use
+ * without the bytes ever passing through the model's context.
  */
 import { assertServerOnImport } from "../harness-patterns/assert.server";
 import { graphFetch } from "../auth/graph-token.server";
+import { conversionEnabled, isConvertible } from "../doc-convert.server";
+import { guessMimeType, isTextMime } from "../stash/upload-service.server";
 import { registerAppTool } from "./registry.server";
 
 assertServerOnImport();
@@ -244,5 +250,205 @@ registerAppTool({
       { scopes: ["User.Read"] },
     );
     return shapeMe(raw);
+  },
+});
+
+// ============================================================================
+// Files → Data Stash
+// ============================================================================
+
+/** Narrowest scope that can read a driveItem and its content. */
+const FILE_SCOPES = ["Files.Read.All"] as const;
+
+/** driveItem fields we need: enough to name, classify and size-check the file.
+ *  Explicit because a full driveItem carries a lot we'd never use. */
+const DRIVE_ITEM_SELECT = "name,file,size,webUrl";
+
+/** What the model gets back. Notably **not** the content: the bytes go to the
+ *  Data Stash, and `documentId` is how later turns reach them. */
+export interface GraphFileIngestResult {
+  documentId: string;
+  filename: string;
+  mimeType: string;
+  /** Stored size in bytes (original bytes, not the base64 expansion). */
+  size: number;
+  /** A background chunk→embed→index was started for this document. */
+  ingesting: boolean;
+  /** Provenance — the file's Microsoft 365 link, for citing back to the person. */
+  webUrl: string | null;
+}
+
+interface DriveItemMeta {
+  name: string | null;
+  mimeType: string | null;
+  /** Byte size, or null when Graph didn't report one. */
+  size: number | null;
+  webUrl: string | null;
+  isFile: boolean;
+}
+
+/**
+ * `/drives/{drive}/items/{item}` when a drive is named, else the caller's own
+ * OneDrive. Ids are URL-encoded so a crafted id cannot escape its path segment
+ * (`../`) and address an unrelated Graph resource.
+ */
+export function driveItemPath(itemId: string, driveId?: string | null): string {
+  const item = encodeURIComponent(itemId);
+  return driveId
+    ? `/drives/${encodeURIComponent(driveId)}/items/${item}`
+    : `/me/drive/items/${item}`;
+}
+
+/** Pick the four things we need off a driveItem, tolerating a partial payload. */
+export function shapeDriveItem(raw: unknown): DriveItemMeta {
+  const it = (raw ?? {}) as Record<string, unknown>;
+  const str = (v: unknown) => (typeof v === "string" && v.trim() ? v : null);
+  const file = it.file as Record<string, unknown> | undefined;
+  return {
+    name: str(it.name),
+    mimeType: str(file?.mimeType),
+    size: typeof it.size === "number" && Number.isFinite(it.size) ? it.size : null,
+    webUrl: str(it.webUrl),
+    // The `file` facet is what distinguishes a file from a folder or package —
+    // `$select=file` returns it for files only.
+    isFile: file != null && typeof file === "object",
+  };
+}
+
+registerAppTool({
+  name: "graph_file_ingest",
+  namespace: "graph",
+  description:
+    "Copy one of the signed-in person's own Microsoft 365 files (OneDrive or " +
+    "SharePoint) into this conversation's Data Stash, so later turns can search " +
+    "it, read it or hand it to the sandbox. Identify the file by item_id, " +
+    "optionally with drive_id for a shared/SharePoint drive. Text files become " +
+    "searchable automatically; other formats are stored as-is. Returns the stash " +
+    "document id and metadata — never the file contents. Acts as the current " +
+    "signed-in person.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      item_id: {
+        type: "string",
+        description: "Microsoft Graph driveItem id of the file to copy.",
+      },
+      drive_id: {
+        type: "string",
+        description:
+          "Drive holding the item. Omit for the signed-in person's own OneDrive.",
+      },
+      filename: {
+        type: "string",
+        description:
+          "Override the stored filename. Defaults to the name in Microsoft 365.",
+      },
+    },
+    required: ["item_id"],
+    additionalProperties: false,
+  },
+  execute: async (args, { userId, sessionId }): Promise<GraphFileIngestResult> => {
+    // Fail closed: the Data Stash is keyed by conversation, so without one in
+    // scope there is no correct place to put the file — and guessing would mean
+    // writing one person's file into another conversation's stash.
+    if (!sessionId) {
+      throw new Error(
+        "graph_file_ingest stores the file in the current conversation's Data Stash, " +
+          "and no conversation is in scope for this call. Run it from a chat turn or " +
+          "a triggered action run.",
+      );
+    }
+    const itemId = typeof args.item_id === "string" ? args.item_id.trim() : "";
+    if (!itemId) {
+      throw new Error("item_id is required — the Microsoft Graph driveItem id of the file.");
+    }
+    const driveId =
+      typeof args.drive_id === "string" ? args.drive_id.trim() || null : null;
+    const base = driveItemPath(itemId, driveId);
+
+    // Metadata first — and separately from the download — because it carries the
+    // size, which is how an oversized file is refused BEFORE its bytes are in
+    // this process's heap. It also gives the real filename and MIME type.
+    const meta = shapeDriveItem(
+      await graphFetch(userId, `${base}?$select=${DRIVE_ITEM_SELECT}`, {
+        scopes: FILE_SCOPES,
+      }),
+    );
+    if (!meta.isFile) {
+      throw new Error(
+        `Microsoft 365 item ${itemId} has no file content — it is probably a folder. ` +
+          "Pass the id of a file.",
+      );
+    }
+
+    // The Data Stash layer is imported lazily: it pulls in ioredis and the whole
+    // chunk/embed/vector stack, and `mcp-client.server.ts` imports this registry
+    // eagerly for *every* harness run — including deployments with no stash.
+    const { storeDocument, MAX_CONTENT_BYTES } = await import("../document-store.server");
+    // A missing size (Graph reports one for every file in practice) is not
+    // treated as oversized; `storeDocument` re-checks the limit on the decoded
+    // bytes, so an unreported giant still can't be stored.
+    if (meta.size != null && meta.size > MAX_CONTENT_BYTES) {
+      throw new Error(
+        `"${meta.name ?? itemId}" is ${meta.size} bytes, above the Data Stash limit of ` +
+          `${MAX_CONTENT_BYTES} bytes, so it was not downloaded. Use a smaller file or ` +
+          "an extract of this one.",
+      );
+    }
+
+    const override = typeof args.filename === "string" ? args.filename.trim() : "";
+    const filename = override || meta.name || `driveitem-${itemId}`;
+    const mimeType = meta.mimeType ?? guessMimeType(filename);
+
+    // Always download bytes, then decide how to STORE them — mirroring the
+    // upload route's intake: text formats go in as UTF-8 (the chunker reads
+    // `content` directly), anything else keeps its exact bytes as base64 so the
+    // `/work` round-trip and `?download` still serve the real file.
+    const encoded = await graphFetch(userId, `${base}/content`, {
+      scopes: FILE_SCOPES,
+      responseType: "base64",
+    });
+    if (typeof encoded !== "string") {
+      throw new Error(`Microsoft 365 returned no content for "${filename}".`);
+    }
+    const isText = isTextMime(mimeType);
+    const content = isText ? Buffer.from(encoded, "base64").toString("utf8") : encoded;
+
+    // Same gate as the upload route: a binary is only worth ingesting when we can
+    // turn it into text; otherwise `ingestStashDocument` would only mark it
+    // failed. Unlike that route we do NOT also require the agent to compose a
+    // redis retriever — calling this tool is an explicit request to make the file
+    // usable, and a retriever added later reads an already-indexed corpus.
+    const ingesting = isText || (conversionEnabled() && isConvertible(mimeType));
+
+    const doc = await storeDocument({
+      sessionId,
+      filename,
+      mimeType,
+      content,
+      ...(isText ? {} : { encoding: "base64" as const }),
+      // Persist 'pending' in the FIRST write (as the upload route does) so a
+      // status poll can never read a doc with no ingest status and flicker.
+      ...(ingesting ? { ingestStatus: "pending" as const } : {}),
+    });
+
+    if (ingesting) {
+      // Fire-and-forget, mirroring `POST /api/stash/upload`: embedding is slow
+      // and the tool result must come back inside the turn. Failures are
+      // recorded in the document's `ingestStatus`, which is why the rejection is
+      // swallowed here rather than surfaced.
+      void import("../document-ingest.server")
+        .then(({ ingestStashDocument }) => ingestStashDocument(sessionId, doc.id))
+        .catch(() => {});
+    }
+
+    return {
+      documentId: doc.id,
+      filename,
+      mimeType,
+      size: doc.size,
+      ingesting,
+      webUrl: meta.webUrl,
+    };
   },
 });

--- a/ui/src/lib/app-tools/graph.server.ts
+++ b/ui/src/lib/app-tools/graph.server.ts
@@ -14,6 +14,12 @@
  * bridges Microsoft 365 into the **Data Stash**, so a file the person already
  * owns becomes something later turns (retriever, sandbox, file viewer) can use
  * without the bytes ever passing through the model's context.
+ *
+ * `graph_files_search` and `graph_files_list` are how a file is *found* in the
+ * first place, and both hand back the `drive_id` + `item_id` pair that names a
+ * file to any tool acting on one. Search keeps the **query language on the
+ * server**: the model passes structured arguments and this module composes the
+ * KQL, so no model-authored operator can reshape the query it didn't write.
  */
 import { assertServerOnImport } from "../harness-patterns/assert.server";
 import { graphFetch } from "../auth/graph-token.server";
@@ -450,5 +456,499 @@ registerAppTool({
       ingesting,
       webUrl: meta.webUrl,
     };
+  },
+});
+
+// ============================================================================
+// Files — search and browse
+//
+// Both tools return the same flattened item shape and both reuse the drive
+// helpers above (`driveItemPath`, `shapeDriveItem`), so a file found here is
+// addressable by `graph_file_ingest` without the model reformatting anything.
+// ============================================================================
+
+/** Search reaches SharePoint as well as OneDrive, so it needs the sites scope on
+ *  top of the file scope. Kept separate from `FILE_SCOPES` so browsing and
+ *  ingesting stay on the narrower one. */
+const FILE_SEARCH_SCOPES = [...FILE_SCOPES, "Sites.Read.All"] as const;
+
+/** driveItem fields the browse tool reads. Explicit for the same reason as
+ *  `DRIVE_ITEM_SELECT`, plus `parentReference` (the drive id + folder path) and
+ *  `remoteItem` (a OneDrive root holds shortcuts to other drives as stubs). */
+const DRIVE_ITEM_LIST_SELECT =
+  "id,name,file,folder,size,webUrl,lastModifiedDateTime,parentReference,remoteItem";
+
+// ----------------------------------------------------------------------------
+// KQL composition — the app owns the query language
+//
+// Microsoft Search speaks KQL, which has clause grammar (`AND`, parentheses)
+// and property restrictions (`filetype:exe`, `path:"…"`, `size>1000`). A model
+// writing that string directly would be writing the query's *structure* from
+// untrusted-shaped text: one stray quote in a filename it echoes back and the
+// restriction we added is closed and a different one opened. So the model never
+// writes KQL. It passes plain terms plus structured filters, the functions below
+// compose every clause, and each user-supplied value is reduced to something
+// that can only ever be a value.
+// ----------------------------------------------------------------------------
+
+/** What can end a quoted value or break the request line: the quote itself,
+ *  plus C0 control characters and DEL. */
+const PHRASE_UNSAFE = /["\u0000-\u001f\u007f]+/g;
+
+/** For unquoted terms, also the operators: `(` `)` group clauses, and `:` `<`
+ *  `>` `=` are what bind a value to a managed property (`filetype:exe`). */
+const TERM_UNSAFE = /["():<>=\u0000-\u001f\u007f]+/g;
+
+/** KQL's boolean and ranking keywords, which it honours in upper case only. */
+const KQL_KEYWORDS = /\b(AND|OR|NOT|NEAR|ONEAR|XRANK)\b/g;
+
+/**
+ * Quote a URL as a KQL value — today the `path:` site restriction.
+ *
+ * The double quote is **stripped, not escaped**. KQL publishes no escape
+ * sequence for a quote inside a value, so an escaping implementation would be
+ * inventing a contract Microsoft doesn't define and hoping the parser agrees;
+ * removal is the only handling whose behaviour is knowable. Control characters
+ * go with it — they would split the request line.
+ *
+ * Then *all* whitespace goes: a URL contains none, and a single space inside a
+ * restriction makes Search stop reading it as a restriction and treat the rest as
+ * free text — a silently wider search rather than an error. Whitespace is handled
+ * last because removing an unsafe character can itself leave a gap behind.
+ */
+export function kqlUrlPhrase(value: string): string {
+  return `"${value.replace(PHRASE_UNSAFE, "").replace(/\s+/g, "")}"`;
+}
+
+/**
+ * Strip KQL grammar out of free-text terms while keeping them searchable.
+ *
+ * Quoting the whole thing would turn every multi-word request into an exact
+ * phrase match and defeat stemming, so the terms stay bare and the *operators*
+ * are removed instead: quotes and parentheses (clause structure), and `:` `<`
+ * `>` `=` (what makes `filetype:exe` or `size>1000` a property restriction).
+ * KQL's boolean keywords are uppercase-only, so lowercasing them leaves the
+ * caller's words intact while reducing them to ordinary search terms.
+ *
+ * What survives cannot open a clause, close one, or restrict a property — the
+ * only structure in the composed query is the structure we added.
+ */
+export function kqlTerms(value: string): string {
+  const cleaned = value.replace(TERM_UNSAFE, " ").replace(/\s+/g, " ").trim();
+  return cleaned.replace(KQL_KEYWORDS, (op) => op.toLowerCase());
+}
+
+/**
+ * `filetype:` clause from a supplied extension, or null when there isn't one.
+ *
+ * An extension is alphanumeric, so the leading alphanumeric run is taken and
+ * everything after it is discarded — `docx" OR filetype:exe` yields
+ * `filetype:docx`. That leaves no quoting question to get wrong. A leading dot
+ * (`.pdf`) is tolerated because models write it.
+ */
+export function kqlFileType(value: string): string | null {
+  const match = /[a-z0-9]+/i.exec(value.trim().replace(/^\.+/, ""));
+  return match ? `filetype:${match[0].toLowerCase()}` : null;
+}
+
+export interface FileSearchArgs {
+  /** Free-text terms from the caller. */
+  query: string;
+  /** SharePoint site URL to restrict to, composed as `path:"…"`. */
+  site?: string | null;
+  /** File extension to restrict to, composed as `filetype:…`. */
+  fileType?: string | null;
+}
+
+/**
+ * Compose the KQL sent to `/search/query`.
+ *
+ * Terms first, then the restrictions, joined by whitespace — KQL's default
+ * operator is AND, so this reads as "these words, in this site, of this type".
+ * Returns `""` when nothing survives sanitization, which the tool treats as a
+ * missing query rather than sending Graph an empty search.
+ *
+ * A restriction is fragile in one direction worth naming: a stray space inside
+ * the clause makes Search stop reading it as a restriction and treat the rest as
+ * free text — silently widening the search instead of failing. So no clause here
+ * contains caller-controlled whitespace: `filetype:` takes an alphanumeric run,
+ * and the `path:` URL has its whitespace removed rather than preserved.
+ */
+export function composeFileQuery({ query, site, fileType }: FileSearchArgs): string {
+  const parts: string[] = [];
+
+  const terms = kqlTerms(query ?? "");
+  if (terms) parts.push(terms);
+
+  const type = fileType?.trim() ? kqlFileType(fileType) : null;
+  if (type) parts.push(type);
+
+  // `path:` is the documented way to scope Microsoft Search to one site (KQL has
+  // no `site:` operator — that's Purview eDiscovery). The value is a URL, so it
+  // needs quoting: it contains `:` and `/`.
+  if (site?.trim()) parts.push(`path:${kqlUrlPhrase(site)}`);
+
+  return parts.join(" ");
+}
+
+// ----------------------------------------------------------------------------
+// Response flattening
+// ----------------------------------------------------------------------------
+
+/**
+ * Strip Microsoft Search's summary markup and truncate.
+ *
+ * Search wraps each matched term in the summary as `<c0>term</c0>` (one `<cN>`
+ * per term) and marks elided text as `<ddd/>`. To a model that is broken markup
+ * it may well try to reproduce, so the highlight markers go and the elision
+ * becomes an ellipsis. Capped at 300 chars, the same budget as
+ * `graph_mail_recent`'s preview, because a page of matched text per hit is how a
+ * 25-result search blows a turn.
+ */
+export function cleanSummary(raw: unknown): string | null {
+  if (typeof raw !== "string") return null;
+  const text = raw
+    .replace(/<\/?c\d+>/gi, "")
+    .replace(/<ddd\s*\/?>/gi, "…")
+    .replace(/\s+/g, " ")
+    .trim();
+  return text ? text.slice(0, 300) : null;
+}
+
+/**
+ * `parentReference.path` → a path a person could read.
+ *
+ * Graph reports it as `/drive/root:/Reports/Q3%20Plans` (or
+ * `/drives/{id}/root:/…`): an addressing prefix, a `root:` marker, then
+ * URL-encoded segments. The prefix is noise and the encoding reads as mojibake,
+ * so both go, leaving `Reports/Q3 Plans`. An item at the drive root has nothing
+ * after `root:` and is reported as `/`.
+ */
+export function drivePath(raw: unknown): string | null {
+  if (typeof raw !== "string" || !raw.trim()) return null;
+  const marker = raw.indexOf("root:");
+  const rel = (marker >= 0 ? raw.slice(marker + "root:".length) : raw).replace(/^\/+/, "");
+  if (!rel) return "/";
+  try {
+    return decodeURIComponent(rel);
+  } catch {
+    // A malformed escape (`%zz`) must not fail the whole search — a slightly
+    // ugly path is a better result than no results.
+    return rel;
+  }
+}
+
+/**
+ * Readable site from `parentReference.siteId`, which Graph reports as
+ * `contoso.sharepoint.com,{siteGuid},{webGuid}`. Only the hostname means
+ * anything to a person or to a model citing a source, so the guids are dropped.
+ * An id with no hostname is passed through rather than invented over.
+ */
+export function siteHost(raw: unknown): string | null {
+  if (typeof raw !== "string" || !raw.trim()) return null;
+  return raw.split(",")[0].trim() || null;
+}
+
+/** What a found file looks like, whether it came from search or from browsing. */
+export interface GraphFileRef {
+  name: string | null;
+  /** Containing folder relative to the drive root; `/` at the root itself. */
+  path: string | null;
+  /** SharePoint host the item lives on, or null for a plain OneDrive item. */
+  site: string | null;
+  modified: string | null;
+  size: number | null;
+  /** Half of the handoff to the tools that act on a file — always surfaced. */
+  drive_id: string | null;
+  /** The other half: the item's *own* id, not its parent's. */
+  item_id: string | null;
+  webUrl: string | null;
+}
+
+export interface GraphFileHit extends GraphFileRef {
+  /** Matched text, markup stripped. Null when Search returned no summary. */
+  snippet: string | null;
+}
+
+export interface GraphFileEntry extends GraphFileRef {
+  isFolder: boolean;
+  /** Items inside a folder; null for a file, so the model can tell "empty
+   *  folder" from "not a folder". */
+  child_count: number | null;
+}
+
+/**
+ * A OneDrive root listing contains shortcuts as well as files: "Add shortcut to
+ * My files" puts a stub driveItem in the root whose real identity sits under
+ * `remoteItem`. Unwrapping it keeps `drive_id` / `item_id` pointing at the file
+ * itself, because the stub's own ids address the shortcut — handing those to a
+ * tool that reads content would 404.
+ */
+function unwrapRemote(raw: unknown): Record<string, unknown> {
+  const it = (raw ?? {}) as Record<string, unknown>;
+  const remote = it.remoteItem;
+  return remote && typeof remote === "object"
+    ? { ...it, ...(remote as Record<string, unknown>) }
+    : it;
+}
+
+/**
+ * Flatten one driveItem — from a search hit or from a folder listing.
+ * Name/size/webUrl extraction is `shapeDriveItem`'s, so the two file paths can't
+ * drift apart on what a "file" looks like; the rest is the location the model
+ * needs to navigate or to hand the file on.
+ */
+export function shapeFileRef(raw: unknown): GraphFileRef {
+  const it = unwrapRemote(raw);
+  const base = shapeDriveItem(it);
+  const parent = (it.parentReference ?? {}) as Record<string, unknown>;
+  const str = (v: unknown) => (typeof v === "string" && v.trim() ? v : null);
+  return {
+    name: base.name,
+    path: drivePath(parent.path),
+    site: siteHost(parent.siteId),
+    modified: str(it.lastModifiedDateTime),
+    size: base.size,
+    drive_id: str(parent.driveId),
+    // `parentReference.id` is the *folder* the item sits in; using it here would
+    // point every downstream call at the wrong resource.
+    item_id: str(it.id),
+    webUrl: base.webUrl,
+  };
+}
+
+/**
+ * Flatten `/search/query`'s three levels of nesting
+ * (`value[].hitsContainers[].hits[].resource`) into one list.
+ *
+ * Hits arrive in rank order, so `rank` itself is dropped — a position in a list
+ * says the same thing in fewer tokens. `total` is summed over the containers
+ * that reported one and left null when none did, because Search omits it for
+ * some result sets and a fabricated 0 would read as "nothing found".
+ */
+export function shapeSearchHits(raw: unknown): {
+  total: number | null;
+  results: GraphFileHit[];
+} {
+  const responses = (raw as { value?: unknown[] })?.value;
+  if (!Array.isArray(responses)) return { total: null, results: [] };
+
+  const results: GraphFileHit[] = [];
+  let total: number | null = null;
+
+  for (const response of responses) {
+    const containers = (response as { hitsContainers?: unknown[] })?.hitsContainers;
+    if (!Array.isArray(containers)) continue;
+    for (const container of containers) {
+      const c = (container ?? {}) as { hits?: unknown[]; total?: unknown };
+      if (typeof c.total === "number" && Number.isFinite(c.total)) {
+        total = (total ?? 0) + c.total;
+      }
+      if (!Array.isArray(c.hits)) continue;
+      for (const hit of c.hits) {
+        const h = (hit ?? {}) as Record<string, unknown>;
+        const ref = shapeFileRef(h.resource);
+        results.push({
+          ...ref,
+          // For a driveItem hit `hitId` *is* the item id, which makes it the
+          // fallback when a hit came back without its resource expanded.
+          item_id: ref.item_id ?? (typeof h.hitId === "string" ? h.hitId : null),
+          snippet: cleanSummary(h.summary),
+        });
+      }
+    }
+  }
+  return { total, results };
+}
+
+/** Flatten a driveItem collection (a `children` listing) for browsing. */
+export function shapeFileEntries(raw: unknown): GraphFileEntry[] {
+  const items = (raw as { value?: unknown[] })?.value;
+  if (!Array.isArray(items)) return [];
+  return items.map((item) => {
+    const it = unwrapRemote(item);
+    const folder = it.folder as Record<string, unknown> | undefined;
+    // The `folder` facet is the counterpart of `file`: present on folders only.
+    const isFolder = folder != null && typeof folder === "object";
+    const count = folder?.childCount;
+    return {
+      ...shapeFileRef(it),
+      isFolder,
+      child_count:
+        isFolder && typeof count === "number" && Number.isFinite(count) ? count : null,
+    };
+  });
+}
+
+export interface GraphFileSearchResult {
+  /** The KQL the app composed, so the model can see how its arguments were
+   *  read — and correct them — instead of guessing why a filter didn't bite. */
+  query: string;
+  /** Graph's reported match count; null when Search didn't report one. */
+  total: number | null;
+  results: GraphFileHit[];
+}
+
+registerAppTool({
+  name: "graph_files_search",
+  namespace: "graph",
+  description:
+    "Search the files the signed-in person can open — their own OneDrive and " +
+    "every SharePoint site they have access to. Pass plain words in `query`: the " +
+    "app builds the search expression, so search syntax is neither needed nor " +
+    "honoured. Narrow with `site` (a SharePoint site URL) or `file_type` (an " +
+    "extension like docx or pdf). Returns each file's name, folder, site, " +
+    "modified date, size and a snippet of the matched text, plus the drive_id + " +
+    "item_id pair that identifies a file to the tools that act on one. Acts as " +
+    "the current signed-in person.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      query: {
+        type: "string",
+        description:
+          'Words to look for, e.g. "q3 budget forecast". Plain terms only — ' +
+          "operators and field:value syntax are stripped, not interpreted.",
+      },
+      site: {
+        type: "string",
+        description:
+          "Restrict to one SharePoint site, given as its URL " +
+          "(https://contoso.sharepoint.com/sites/Finance).",
+      },
+      file_type: {
+        type: "string",
+        description: "Restrict to one file extension, e.g. docx, xlsx, pdf.",
+      },
+      limit: {
+        type: "integer",
+        description: "How many files to return, 1-25 (default 10).",
+      },
+    },
+    required: ["query"],
+    additionalProperties: false,
+  },
+  execute: async (args, { userId }): Promise<GraphFileSearchResult> => {
+    const limit = Math.min(Math.max(Number(args.limit) || 10, 1), 25);
+    const query = composeFileQuery({
+      query: typeof args.query === "string" ? args.query : "",
+      site: typeof args.site === "string" ? args.site : null,
+      fileType: typeof args.file_type === "string" ? args.file_type : null,
+    });
+    if (!query) {
+      throw new Error(
+        "query is required — the words to look for, e.g. \"q3 budget\". " +
+          "Nothing searchable was left after the arguments were parsed.",
+      );
+    }
+
+    const raw = await graphFetch(userId, "/search/query", {
+      method: "POST",
+      scopes: FILE_SEARCH_SCOPES,
+      body: {
+        requests: [
+          {
+            // driveItem covers OneDrive *and* SharePoint document libraries in
+            // one request. `listItem` and `site` are combinable with it here,
+            // but they'd fold list rows and site pages into a *file* search.
+            entityTypes: ["driveItem"],
+            query: { queryString: query },
+            from: 0,
+            size: limit,
+            // Deliberately no `fields`: unlike `$select` it *replaces* the
+            // returned resource properties, and a hit stripped of
+            // `parentReference` loses `drive_id` — the handoff this tool exists
+            // to produce. `shapeSearchHits` is the allowlist instead, so no raw
+            // Graph payload reaches the model either way.
+          },
+        ],
+      },
+    });
+
+    const { total, results } = shapeSearchHits(raw);
+    return { query, total, results };
+  },
+});
+
+export interface GraphFileListResult {
+  /** Which place was listed, echoed back because the arguments select it
+   *  implicitly. */
+  location: "onedrive-root" | "folder";
+  items: GraphFileEntry[];
+}
+
+/**
+ * Browse a known location. Two modes — the person's OneDrive root, or one named
+ * folder in any drive they can reach.
+ *
+ * ## Why there is no `recent` mode
+ * The obvious third mode would be `/me/drive/recent` (and its sibling
+ * `/me/drive/sharedWithMe`), but both are **deprecated and already degrading**:
+ * `sharedWithMe` is currently clamped to roughly one result by a live Microsoft
+ * mitigation, and both stop returning data in **November 2026**, with no
+ * replacement endpoint. Shipping a tool mode on top of that would build a
+ * capability with a known expiry date and no migration path — a model would learn
+ * to reach for it and then quietly get nothing back. If "files I touched lately"
+ * is wanted later, `GET /me/drive/search(q=…)` (note: no `/root`) is the surface
+ * that still reaches shared items; it is a search, so it belongs in
+ * `graph_files_search`, not here.
+ */
+registerAppTool({
+  name: "graph_files_list",
+  namespace: "graph",
+  description:
+    "Browse the signed-in person's files instead of searching them. With no " +
+    "arguments, lists the top level of their own OneDrive; pass folder_item_id " +
+    "(plus drive_id for a SharePoint or shared drive) to list that folder's " +
+    "contents. Entries carry the same drive_id + item_id pair as a search result, " +
+    "and folders report isFolder + child_count so you can walk down into them. " +
+    "Use graph_files_search to find a file by its words instead. Acts as the " +
+    "current signed-in person.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      folder_item_id: {
+        type: "string",
+        description:
+          "driveItem id of the folder to list. Omit for the top level of the " +
+          "person's own OneDrive.",
+      },
+      drive_id: {
+        type: "string",
+        description:
+          "Drive holding that folder. Omit for the person's own OneDrive.",
+      },
+      limit: {
+        type: "integer",
+        description: "How many entries to return, 1-50 (default 20).",
+      },
+    },
+    additionalProperties: false,
+  },
+  execute: async (args, { userId }): Promise<GraphFileListResult> => {
+    const limit = Math.min(Math.max(Number(args.limit) || 20, 1), 50);
+    const folderId =
+      typeof args.folder_item_id === "string" ? args.folder_item_id.trim() : "";
+    const driveId =
+      typeof args.drive_id === "string" ? args.drive_id.trim() || null : null;
+
+    const location: GraphFileListResult["location"] = folderId
+      ? "folder"
+      : "onedrive-root";
+
+    const base = folderId
+      ? // Same encoded path builder as the ingest tool, so a crafted id can't
+        // escape its segment and address an unrelated resource.
+        `${driveItemPath(folderId, driveId)}/children`
+      : "/me/drive/root/children";
+
+    // No `$orderby`: children come back name-ordered already, and it is not
+    // supported on every drive type — a 400 here would break browsing outright.
+    const raw = await graphFetch(
+      userId,
+      `${base}?$select=${DRIVE_ITEM_LIST_SELECT}&$top=${limit}`,
+      { scopes: FILE_SCOPES },
+    );
+    return { location, items: shapeFileEntries(raw) };
   },
 });

--- a/ui/src/lib/app-tools/registry.server.ts
+++ b/ui/src/lib/app-tools/registry.server.ts
@@ -15,20 +15,31 @@
  * - The schema advertised to the model has **no credential field** (#107
  *   principle 1). The user id comes from `getRequestUserId()` at call time, so
  *   the model cannot choose whose data to read.
- * - Executors receive `{ userId }` and resolve tokens themselves; a token must
- *   never appear in args, results, logs or the event stream.
+ * - Executors receive `{ userId, sessionId }` and resolve tokens themselves; a
+ *   token must never appear in args, results, logs or the event stream.
  * - Errors become `{ success: false, error }` rather than throwing, so one
  *   failing tool degrades a turn instead of killing a run.
  */
 import { assertServerOnImport } from "../harness-patterns/assert.server";
 import type { ToolCallResult, MCPToolDescription } from "../harness-patterns/types";
-import { getRequestUserId } from "../harness-client/request-user.server";
+import {
+  getRequestUserId,
+  getRequestSessionId,
+} from "../harness-client/request-user.server";
 
 assertServerOnImport();
 
 export interface AppToolContext {
   /** Authenticated user id (Entra `oid`), resolved server-side. */
   userId: string;
+  /**
+   * Conversation this call belongs to, resolved server-side like `userId` — so a
+   * tool that writes into per-conversation storage (the Data Stash) cannot be
+   * pointed at someone else's conversation by the model. `null` off the request
+   * path (e.g. a background summarization); tools that need it must refuse
+   * rather than guess a session.
+   */
+  sessionId: string | null;
 }
 
 export interface AppToolDefinition {
@@ -76,9 +87,9 @@ export function __resetAppTools(): void {
 }
 
 /**
- * Execute a registered app tool. Resolves the caller's user id from the
- * request scope — established by `runWithUserId()` in both the interactive
- * path (`runTurn`) and background runs (`runAgentInBackground`).
+ * Execute a registered app tool. Resolves the caller's user id and conversation
+ * from the request scope — established by `runWithRequestContext()` in both the
+ * interactive path (`runTurn`) and background runs (`runAgentInBackground`).
  */
 export async function runAppTool(
   name: string,
@@ -92,7 +103,7 @@ export async function runAppTool(
   const userId = getRequestUserId();
   if (!userId) {
     // No user scope — e.g. a background summarization path outside
-    // runWithUserId. Refuse rather than guess an identity.
+    // runWithRequestContext. Refuse rather than guess an identity.
     return {
       success: false,
       data: null,
@@ -101,7 +112,10 @@ export async function runAppTool(
   }
 
   try {
-    return { success: true, data: await def.execute(args, { userId }) };
+    // sessionId may legitimately be null (a user scope without a conversation);
+    // it is the tool's job to refuse if it needs one.
+    const sessionId = getRequestSessionId();
+    return { success: true, data: await def.execute(args, { userId, sessionId }) };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     // Deliberately no stack/credential detail in the tool result — it flows

--- a/ui/src/lib/auth/graph-token.server.ts
+++ b/ui/src/lib/auth/graph-token.server.ts
@@ -197,6 +197,10 @@ export async function graphFetch(
       // Set last so a caller can never replace the credential or content type.
       Authorization: `Bearer ${token}`,
       Accept: wantsBytes ? "*/*" : "application/json",
+      // Decorated traffic is prioritized under Graph throttling; undecorated
+      // traffic is first to be shed. NONISV|<company>|<app>/<version> is the
+      // documented shape for internal (non-ISV) apps.
+      "User-Agent": "NONISV|DTSC|kg-agent/1.0",
       ...(init.body ? { "Content-Type": "application/json" } : {}),
     },
     ...(init.body ? { body: JSON.stringify(init.body) } : {}),

--- a/ui/src/lib/auth/graph-token.server.ts
+++ b/ui/src/lib/auth/graph-token.server.ts
@@ -155,6 +155,18 @@ async function resolveAccount(
  *
  * @param path Graph path beginning with `/` (e.g. `/me`), or an absolute URL
  *             (used for `@odata.nextLink` pagination).
+ *
+ * ## `responseType: 'base64'` and the `/content` redirect
+ * File downloads (`/drive/items/{id}/content`) answer **302** to a
+ * pre-authenticated CDN URL (`*.sharepoint.com`, `*.files.1drv.com`) that
+ * carries its own short-lived token in the query string. We deliberately let
+ * `fetch` follow it: per the Fetch standard — and verified on this runtime
+ * (Node 22 / undici 6) — `Authorization` is **stripped on a cross-origin
+ * redirect**, so our delegated bearer token never reaches the CDN, while the
+ * same-origin Graph→Graph case keeps it. `redirect: 'manual'` plus a bare
+ * follow-up fetch would achieve the same thing with more moving parts, so it
+ * isn't used. `Accept` *is* forwarded, hence `*​/*` in binary mode rather than
+ * asking a blob endpoint for JSON.
  */
 export async function graphFetch(
   userId: string,
@@ -166,10 +178,17 @@ export async function graphFetch(
     /** Extra request headers, e.g. `Prefer: outlook.timezone="Europe/Brussels"`.
      *  Cannot override Authorization — the credential is set here, not by callers. */
     headers?: Record<string, string>;
+    /**
+     * How to decode the response body. `'json'` (default) parses JSON;
+     * `'base64'` returns the raw bytes base64-encoded — the only faithful way to
+     * carry a binary file (xlsx/pdf/png) through the string-typed Data Stash.
+     */
+    responseType?: "json" | "base64";
   } = {},
 ): Promise<unknown> {
   const token = await getUserGraphToken(userId, init.scopes ?? DEFAULT_GRAPH_SCOPES);
   const url = path.startsWith("http") ? path : `${GRAPH_BASE}${path}`;
+  const wantsBytes = init.responseType === "base64";
 
   const res = await fetch(url, {
     method: init.method ?? "GET",
@@ -177,7 +196,7 @@ export async function graphFetch(
       ...init.headers,
       // Set last so a caller can never replace the credential or content type.
       Authorization: `Bearer ${token}`,
-      Accept: "application/json",
+      Accept: wantsBytes ? "*/*" : "application/json",
       ...(init.body ? { "Content-Type": "application/json" } : {}),
     },
     ...(init.body ? { body: JSON.stringify(init.body) } : {}),
@@ -197,5 +216,6 @@ export async function graphFetch(
     );
   }
   if (res.status === 204) return null;
+  if (wantsBytes) return Buffer.from(await res.arrayBuffer()).toString("base64");
   return res.json();
 }

--- a/ui/src/lib/harness-client/action-runner.server.ts
+++ b/ui/src/lib/harness-client/action-runner.server.ts
@@ -19,7 +19,7 @@
 import { assertServerOnImport } from "../harness-patterns/assert.server";
 import { harness, createContext, serializeContext } from "../harness-patterns";
 import { getOrBuildPatterns, saveSession, type SessionData } from "./session.server";
-import { runWithUserId } from "./request-user.server";
+import { runWithRequestContext } from "./request-user.server";
 import {
   saveConversation as dbSaveConversation,
   setConversationStatus as dbSetConversationStatus,
@@ -88,8 +88,10 @@ export async function seedActionRow(
  *
  * Always a fresh first run — it never `continueSession`s the seeded
  * placeholder (which would duplicate the user_message). Wrapped in
- * `runWithUserId` so pattern closures resolve the owner; settings fall back to
- * `DEFAULT_SETTINGS` (no request-scoped settings off the request path). The
+ * `runWithRequestContext` so pattern closures resolve the owner and the
+ * conversation (the `runId` *is* this run's sessionId — the route uses it as
+ * both the conversation id and the Data Stash session key); settings fall back
+ * to `DEFAULT_SETTINGS` (no request-scoped settings off the request path). The
  * harness itself never throws (it catches internally and returns an `error`
  * status), so the catch here only guards pattern-construction failures.
  */
@@ -101,7 +103,7 @@ export async function runAgentInBackground(
   trigger: ActionTrigger,
 ): Promise<void> {
   try {
-    await runWithUserId(userId, async () => {
+    await runWithRequestContext({ userId, sessionId: runId }, async () => {
       const patterns = await getOrBuildPatterns(runId, agentId);
       const agent = harness(...patterns);
       const result = await agent(message, runId, {

--- a/ui/src/lib/harness-client/actions.server.ts
+++ b/ui/src/lib/harness-client/actions.server.ts
@@ -37,7 +37,7 @@ import type { HarnessSettings } from "../settings";
 import { runWithSettings } from "../settings-context.server";
 import { getAuthenticatedUser } from "../auth/server";
 import { BYPASS_USER, isBypassEnabled } from "../auth/dev-bypass";
-import { runWithUserId } from "./request-user.server";
+import { runWithRequestContext } from "./request-user.server";
 
 // ============================================================================
 // Auth helper
@@ -106,10 +106,11 @@ async function runTurn(
   agentId: string,
   onEvent?: (event: ContextEvent) => void,
 ): Promise<HarnessResultScoped<SessionData>> {
-  // Establish the user-id scope so pattern closures that need to load
-  // per-conversation context at runtime (e.g. code-mode's tool allowlist
-  // reader) can resolve the right user without an explicit parameter.
-  return runWithUserId(userId, async () => {
+  // Establish the request scope so pattern closures and app-side tools that
+  // need per-conversation context at runtime (code-mode's tool-allowlist
+  // reader, `graph_file_ingest`'s Data Stash target) resolve the right user and
+  // conversation without an explicit parameter.
+  return runWithRequestContext({ userId, sessionId }, async () => {
     // If the user switched agent within an existing conversation, treat it as
     // a fresh conversation by ignoring the prior serialized context. The UI is
     // expected to mint a new sessionId on agent change, but we double-guard
@@ -173,7 +174,7 @@ async function resolveApproval(
   if (!loaded) {
     throw new Error("No active session");
   }
-  return runWithUserId(user.id, async () => {
+  return runWithRequestContext({ userId: user.id, sessionId }, async () => {
     const patterns = await getOrBuildPatterns(sessionId, loaded.agentId);
     const result = await resumeHarness(
       loaded.serializedContext,

--- a/ui/src/lib/harness-client/examples/microsoft-365.server.ts
+++ b/ui/src/lib/harness-client/examples/microsoft-365.server.ts
@@ -8,9 +8,11 @@
  *
  * Tools available: `graph_me` (profile), `graph_calendar_today` (today's
  * events), `graph_mail_recent` (inbox, optionally unread-only) — enough for a
- * "what does my day look like?" briefing. Further graph tools appear in
- * `tools.graph` automatically once registered, so this agent needs no change to
- * pick them up.
+ * "what does my day look like?" briefing — plus `graph_file_ingest`, which pulls
+ * one of the person's own OneDrive/SharePoint files into this conversation's Data
+ * Stash so later turns (retriever, sandbox) can work on it. Further graph tools
+ * appear in `tools.graph` automatically once registered, so this agent needs no
+ * change to pick them up.
  */
 "use server";
 

--- a/ui/src/lib/harness-client/examples/microsoft-365.server.ts
+++ b/ui/src/lib/harness-client/examples/microsoft-365.server.ts
@@ -6,13 +6,12 @@
  * delegated per-user token server-side (see `lib/app-tools/graph.server.ts`),
  * so Entra enforces the scope and no credential ever reaches the model.
  *
- * Tools available: `graph_me` (profile), `graph_calendar_today` (today's
- * events), `graph_mail_recent` (inbox, optionally unread-only) — enough for a
- * "what does my day look like?" briefing — plus `graph_file_ingest`, which pulls
- * one of the person's own OneDrive/SharePoint files into this conversation's Data
- * Stash so later turns (retriever, sandbox) can work on it. Further graph tools
- * appear in `tools.graph` automatically once registered, so this agent needs no
- * change to pick them up.
+ * Profile, today's calendar and recent inbox mail — enough for a "what does my
+ * day look like?" briefing, which the loop assembles from several calls in one
+ * turn — plus finding and browsing the person's OneDrive/SharePoint files.
+ *
+ * It composes an explicit subset of `tools.graph` rather than the whole
+ * namespace: see {@link MICROSOFT_365_TOOLS} for which tools, and why.
  */
 "use server";
 
@@ -26,9 +25,39 @@ import {
 import type { SessionData } from "../session.server";
 import type { AgentConfig } from "../registry.server";
 
+/**
+ * The graph tools this agent composes, in the order it should reach for them.
+ *
+ * **To give this agent another tool, add its name here.** An explicit list, not
+ * all of `tools.graph`, because "a tool exists" and "this agent can do something
+ * useful with it" are different questions — and for one tool the answer is no:
+ *
+ * `graph_file_ingest` is absent deliberately. It copies a file's bytes into the
+ * conversation's Data Stash, where they are reachable only through a retriever
+ * pattern — and this agent has none. Exposing it would advertise a capability
+ * whose payoff the agent can't deliver: the model would ingest a file, get back a
+ * document id, and have no way to read a word of it. The file tools it *does*
+ * have (search + browse) are the half that works without a retriever.
+ *
+ * Nothing here gates the *registry*: a newly registered graph tool still appears
+ * in `tools.graph` for every other consumer. This list only decides what this one
+ * agent's loop is handed.
+ */
+export const MICROSOFT_365_TOOLS = [
+  "graph_me",
+  "graph_calendar_today",
+  "graph_mail_recent",
+  "graph_files_search",
+  "graph_files_list",
+] as const;
+
 async function createPatterns(_sessionId: string): Promise<ConfiguredPattern<SessionData>[]> {
   const tools = await Tools();
-  const graphTools = tools.graph ?? [];
+  const available = new Set(tools.graph ?? []);
+  // Filtering the allowlist (rather than the namespace) keeps a tool that isn't
+  // registered — a typo, a module not imported — out of the loop's tool list
+  // instead of into it. Same shape as code-mode's meta-tool subset.
+  const graphTools = MICROSOFT_365_TOOLS.filter((t) => available.has(t));
 
   const graphPattern = simpleLoop<SessionData>(
     createLoopControllerAdapter(graphTools),

--- a/ui/src/lib/harness-client/request-user.server.ts
+++ b/ui/src/lib/harness-client/request-user.server.ts
@@ -1,28 +1,62 @@
 /**
- * Request-scoped user context for harness execution.
+ * Request-scoped execution context for harness runs.
  *
  * Mirrors `settings-context.server.ts`: a tiny AsyncLocalStorage that lets
- * pattern closures read the authenticated userId at runtime without
- * threading it through every signature.
+ * pattern closures and app-side tools read *who* and *which conversation* a
+ * call belongs to at runtime, without threading either through every signature.
  *
- * `runTurn` (actions.server.ts) wraps its body in `runWithUserId(userId, …)`.
- * Pattern factories that need to load per-conversation context inside their
- * closures (e.g. code-mode reading `data.codeModeAllowedTools`) call
- * `getRequestUserId()` at the point of execution.
+ * `runTurn` / `resolveApproval` (actions.server.ts) and `runAgentInBackground`
+ * (action-runner.server.ts) wrap their bodies in `runWithRequestContext(…)`.
+ * Consumers read `getRequestUserId()` / `getRequestSessionId()` at the point of
+ * execution — e.g. code-mode reading `data.codeModeAllowedTools`, or the
+ * `graph_file_ingest` app tool resolving the Data Stash session to write into.
+ *
+ * ## Why the sessionId belongs here and not in tool args
+ * Same reason as the userId (#107 principle 1): anything the model can name, the
+ * model can point somewhere else. A `session_id` argument would let one
+ * conversation write documents into another's stash. Both ids are therefore
+ * ambient and server-resolved, and callers handle `null` by refusing.
  */
 import { AsyncLocalStorage } from "node:async_hooks";
 import { assertServerOnImport } from "../harness-patterns/assert.server";
 
 assertServerOnImport();
 
-const userStore = new AsyncLocalStorage<string>();
-
-export function runWithUserId<T>(userId: string, fn: () => Promise<T>): Promise<T> {
-  return userStore.run(userId, fn);
+/** What a harness run knows about its own request. */
+export interface RequestContext {
+  /** Authenticated user id (Entra `oid`). */
+  userId: string;
+  /** Conversation/run this execution belongs to; `null` when there isn't one. */
+  sessionId: string | null;
 }
 
-/** Returns the request's userId, or null when called outside a runWithUserId
- *  scope (e.g. background summarization). Callers must handle null. */
+const requestStore = new AsyncLocalStorage<RequestContext>();
+
+/** Run `fn` with the full request context in scope. */
+export function runWithRequestContext<T>(
+  ctx: RequestContext,
+  fn: () => Promise<T>,
+): Promise<T> {
+  return requestStore.run(ctx, fn);
+}
+
+/**
+ * Back-compat wrapper for callers that only have a userId. Establishes the
+ * user scope with **no** session, so session-dependent tools fail closed rather
+ * than writing into a guessed conversation.
+ */
+export function runWithUserId<T>(userId: string, fn: () => Promise<T>): Promise<T> {
+  return runWithRequestContext({ userId, sessionId: null }, fn);
+}
+
+/** Returns the request's userId, or null when called outside a request scope
+ *  (e.g. background summarization). Callers must handle null. */
 export function getRequestUserId(): string | null {
-  return userStore.getStore() ?? null;
+  return requestStore.getStore()?.userId ?? null;
+}
+
+/** Returns the request's sessionId, or null outside a request scope — and also
+ *  inside a `runWithUserId` scope, which deliberately carries no session. */
+export function getRequestSessionId(): string | null {
+  return requestStore.getStore()?.sessionId ?? null;
 }


### PR DESCRIPTION
## Microsoft 365 files: find them, browse them, pull them into the Data Stash

Extends the per-user Graph access from #133 (Pattern C, #110) with file
**discovery** and the **bridge into the Data Stash**, so retrieved files reach
the sandbox (`/work/in`) and the retriever (chunk → embed → search) through the
existing pipeline. Read-only toward Microsoft 365 throughout.

### New tools (app-side, per-user)

| Tool | Does |
|---|---|
| `graph_files_search` | `POST /search/query` over `driveItem` — OneDrive **and** SharePoint, one call. Structured args (`query`, `site`, `file_type`, `limit`); **the app composes the KQL, the model never writes it.** |
| `graph_files_list` | browse OneDrive root or a folder (`/children`). No `recent` mode — `/me/drive/recent` and `sharedWithMe` are deprecated (degrading now, dead Nov 2026); the JSDoc records why so nobody re-adds them. |
| `graph_file_ingest` | metadata (size-guard **before** download) → content as base64 → `storeDocument` → background `ingestStashDocument`, mirroring the upload route's intake (text stored UTF-8 so it's chunkable; binary kept byte-exact). |

Search hits are flattened for the model: `<cN>`/`<ddd/>` markers stripped,
snippets capped at 300 chars, URL-encoded parent paths decoded, and every hit
carries `drive_id` + `item_id` (from `resource.id` — **not**
`parentReference.id`, which is the parent folder) so results hand off directly
to `graph_file_ingest`.

### Plumbing

- **Request scope now carries the sessionId** (`runWithRequestContext`;
  `runWithUserId` kept as a no-session wrapper). Same reasoning as the userId
  (#107): a `session_id` tool argument would let one conversation write into
  another's stash, so it is ambient and server-resolved; tools without one fail
  closed.
- **`graphFetch` gains `responseType: 'base64'`** for `/content` downloads.
  The 302 → CDN redirect was probed on this runtime (Node 22/undici): `fetch`
  strips `Authorization` on the cross-origin hop per spec, so the delegated
  bearer never reaches `*.sharepoint.com` — `redirect: 'manual'` is unnecessary.
  Reasoning recorded in the JSDoc.
- **Graph traffic is decorated** (`User-Agent: NONISV|DTSC|kg-agent/1.0`) —
  documented to receive prioritized treatment under Graph throttling.

### Agent exposure (deliberately selective)

`microsoft-365` now composes an explicit allowlist: profile, calendar, mail,
**search, list** — and *not* `graph_file_ingest`. The agent has no retriever
pattern, so an ingested file's contents would be unusable to it; the tool stays
registered and discoverable for the planned general assistant (sandbox +
retriever + ms-graph), where ingestion pays off in the same turn.

### KQL hardening

There is **no documented escape for `"` inside a KQL value**, so values are
stripped of unsafe characters rather than "escaped" (which would invent a
contract Microsoft doesn't define). Ordering matters and is tested: the
unsafe-character pass runs before whitespace removal, because stripping a quote
can otherwise *introduce* the space that silently degrades a `path:` clause to
free-text. Hostile-input tests cover injection attempts.

### Verification

- `tsc --noEmit`: 17 (pre-existing baseline; zero in touched files).
- Tests: **1115 passed / 2 skipped** (baseline 1058) — +57, including KQL
  composition/injection, marker stripping, path decoding, limit clamping,
  fail-closed-without-session, size guards, and schema checks (no
  user/token/session field advertised).
- A live search against the real tenant returned sensible results
  (graph-stash worktree). Deeper live coverage (ingest round-trip, `/children`
  `$select` behaviour) is the next step and may produce follow-up tweaks.

### Known limits / follow-ups

- **Loop/OneNote `package` items** are currently refused by `graph_file_ingest`
  (no `file` facet). Follow-up: accept them and route through Graph's
  server-side `?format=html` conversion — pending the Loop discovery probe.
- No write tools toward Microsoft 365; no pagination (tighten the query
  instead).

Part of #110's connector track.
