### PR TITLE
fix(harness): render controller history as ControllerAction JSON

### DIFF
--- a/ui/baml_src/actorCritic.baml
+++ b/ui/baml_src/actorCritic.baml
@@ -36,9 +36,9 @@ template_string ActorFewShots(few_shots: FewShot[]?) #"
   {% for ex in few_shots %}
 
   - User: {{ ex.user }}
-    Reasoning: {{ ex.reasoning }}
-    Tool: {{ ex.tool }}
-    Args: {{ ex.args }}
+    reasoning: {{ ex.reasoning }}
+    tool_name: {{ ex.tool }}
+    tool_args: {{ ex.args }}
   {% endfor %}
 
   ---
@@ -79,15 +79,17 @@ template_string ActorTaskFrame(intent: string, context: string?, user_message: s
 // attempts|length - 1 == attempt_n - 2, so `>=` fires on the last entry only
 // (strict `>` never fires — measured as 0% cache reads before the fix).
 // Result blocks use the system role; the wire coerces them to `user`.
+// Assistant entries render the recorded ControllerAction as JSON — the shape
+// `ctx.output_format` asks for. Same reasoning as simpleLoop's LoopTurnLog (see
+// the comment there): prior assistant messages are the model's own output, so a
+// prose history demonstrates a vocabulary that contradicts the response contract
+// and the demonstrations outnumber the instruction. Unlike simpleLoop, `is_final`
+// comes from the DATA here: the critic verifies and can reject, so an attempt
+// with is_final=true legitimately appears in history followed by another attempt.
 template_string ActorAttemptLog(attempts: Attempt[], attempt_n: int?) #"
   {% for attempt in attempts %}
   {{ _.role("assistant") }}
-  Attempt {{ attempt.n }} action:
-      {% if attempt.action.reasoning %}
-      Reasoning: {{ attempt.action.reasoning }}
-      {% endif %}
-  Tool: {{ attempt.action.tool_name }}
-  Args: {{ attempt.action.tool_args }}
+  {"reasoning": {{ attempt.action.reasoning | default("") | tojson }}, "tool_name": {{ attempt.action.tool_name | tojson }}, "tool_args": {{ attempt.action.tool_args | tojson }}, "status": {{ attempt.action.status | default("") | tojson }}, "is_final": {{ attempt.action.is_final | tojson }}}
       {% if loop.index0 >= (attempt_n - 2) %}
       {{ _.role("system", cache_control={"type": "ephemeral"}) }}
       {% else %}

--- a/ui/baml_src/simpleLoop.baml
+++ b/ui/baml_src/simpleLoop.baml
@@ -41,6 +41,13 @@
 //    expansions). See LoopPriorResults / LoopTurnLog for the details.
 
 // --- Section: few-shot examples (cached tier-1; empty when unset) -----------
+// Field labels deliberately match ControllerAction's field NAMES (reasoning /
+// tool_name / tool_args) rather than inventing a third vocabulary (the earlier
+// `Tool:` / `Args:` against the turn log's `Call:` / `Args:` against the schema's
+// `tool_name` / `tool_args`). Kept as a labelled list rather than a JSON object:
+// these live inside a user message and carry no status/is_final, so rendering
+// them as objects would demonstrate an ACTION MISSING REQUIRED FIELDS — the very
+// shape the turn log is careful not to model.
 template_string LoopFewShots(few_shots: FewShot[]?) #"
   {% if few_shots and few_shots|length > 0 %}
 
@@ -48,9 +55,9 @@ template_string LoopFewShots(few_shots: FewShot[]?) #"
   EXAMPLES (illustrative — adapt to the actual request, do not copy verbatim):
   {% for ex in few_shots %}
   - User: {{ ex.user }}
-    Reasoning: {{ ex.reasoning }}
-    Tool: {{ ex.tool }}
-    Args: {{ ex.args }}
+    reasoning: {{ ex.reasoning }}
+    tool_name: {{ ex.tool }}
+    tool_args: {{ ex.args }}
   {% endfor %}
   {% endif %}
 "#
@@ -84,17 +91,27 @@ template_string LoopPriorResults(turns_previous_runs: PriorResult[]?) #"
 // WRITES the extension. Expanded ref content renders inside the turn that
 // expanded it — as late as possible, so everything before stays a valid
 // cache prefix.
+// Each assistant entry is rendered as a COMPLETE ControllerAction object — the
+// same shape `ctx.output_format` asks for. This is load-bearing, not cosmetic:
+// an assistant turn is one of the model's OWN prior messages, and continuing the
+// form of its previous messages is a stronger prior than a trailing instruction.
+// Rendering history as prose (`Reasoning:` / `Call:` / `Args:`) put N
+// demonstrations of one vocabulary against one request for another, and the
+// demonstrations win — observed live as a complete, correct action emitted in
+// prose, failing BAML parsing with all five required fields "missing" (output
+// 412 tokens against a 32768 cap, so not truncation). The demonstration count
+// grows with turn depth, so deep loops were the most exposed. Rendered this way
+// the same copying instinct produces a valid action.
+//
+// `is_final` is a literal `false`: the loop breaks on a final action BEFORE
+// pushing a turn (`simpleLoop.server.ts` — `if (action.is_final || tool_name ===
+// 'Return') break`), so every turn that reaches this log is non-final by
+// construction. `tojson` does the quoting, so tool_args (itself JSON, full of
+// quotes) can't break out of its string.
 template_string LoopTurnLog(turns: LoopTurn[]) #"
   {% for turn in turns %}
   {{ _.role("assistant") }}
-  Turn {{ turn.n }} action:
-  {% if turn.reasoning %}
-  Reasoning: {{ turn.reasoning }}
-  {% endif %}
-  {% if turn.tool_call %}
-  Call: {{ turn.tool_call.tool }}
-  Args: {{ turn.tool_call.args }}
-  {% endif %}
+  {"reasoning": {{ turn.reasoning | default("") | tojson }}, "tool_name": {{ (turn.tool_call.tool if turn.tool_call else "") | tojson }}, "tool_args": {{ (turn.tool_call.args if turn.tool_call else "") | tojson }}, "status": {{ turn.status | default("") | tojson }}, "is_final": false}
   {% if loop.index0 >= turns|length - 2 %}
   {{ _.role("user", cache_control={"type": "ephemeral"}) }}
   {% else %}
@@ -162,7 +179,11 @@ function LoopController(
 
     {# ────────── VOLATILE TAIL · changes every turn, never cached ────────── #}
     {{ _.role("user") }}
-    Turn {{ turns|length + 1 }}. Decide the next action.
+    {# 0-indexed to match the turn log and the `n` the next turn is recorded
+       under: with one completed turn the log ends at "Turn 0 result" and this
+       asks for turn 1. The previous `+ 1` skipped a number, inviting the model
+       to infer a turn it had never seen. #}
+    Turn {{ turns|length }}. Decide the next action.
 
     {{ ctx.output_format }}
   "#

--- a/ui/baml_src/types.baml
+++ b/ui/baml_src/types.baml
@@ -20,6 +20,11 @@ class ToolDescription {
 class LoopTurn {
   n int @description("Turn number, 0-indexed")
   reasoning string? @description("Agent reasoning for this turn")
+  /// The turn's own user-facing status. Recorded so the assistant turn log can
+  /// replay a COMPLETE ControllerAction — a history entry missing required
+  /// fields would demonstrate exactly the malformed shape we want to prevent.
+  /// Optional because sessions serialized before this field exists still parse.
+  status string? @description("Short user-facing status message from this turn's action")
   tool_call ToolCall? @description("Tool invocation if any")
   tool_result ToolResult? @description("Tool execution result if any")
   expansions ExpandedRef[]? @description("Refs resolved into tool_args this turn via ref:<id>")

--- a/ui/src/__tests__/lib/harness-patterns/controller-history-format.test.ts
+++ b/ui/src/__tests__/lib/harness-patterns/controller-history-format.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Controller history format — the assistant turns in a controller prompt must
+ * demonstrate the SAME shape the controller is asked to produce.
+ *
+ * Why this suite exists: `LoopController` / `ActorController` render past turns
+ * as real ASSISTANT messages, i.e. as the model's own prior output. Continuing
+ * the form of its previous messages is a stronger prior for a model than a
+ * trailing format instruction, so when history was rendered as prose
+ * (`Reasoning:` / `Call:` / `Args:`) the prompt held N demonstrations of one
+ * vocabulary against one request for another. Observed live: a complete, correct
+ * action emitted as prose, failing BAML with all five required fields "missing"
+ * — 412 output tokens against a 32768 cap, so not a truncation. Because the
+ * demonstrations accumulate one per turn while the instruction stays a single
+ * line, deep loops are the most exposed.
+ *
+ * These assertions are the guard: every assistant block must parse as a
+ * complete ControllerAction, and the legacy prose labels must not come back.
+ */
+import { describe, it, expect, beforeAll } from 'vitest'
+
+// b.request builds the HTTP body without sending; it still resolves the client,
+// which needs the env var to exist.
+process.env.ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY || 'offline-render-test'
+
+type Block = { type: string; text?: string }
+type Msg = { role: string; content: Block[] | string }
+type Body = { system?: unknown; messages: Msg[] }
+
+let b: typeof import('../../../../baml_client').b
+
+beforeAll(async () => {
+  b = (await import('../../../../baml_client')).b
+})
+
+const TOOLS = [{ name: 'search', description: 'Search files', args_schema: '{"query":"string"}' }]
+
+/** Args that would break naive string interpolation: quotes, backslash, newline. */
+const NASTY_ARGS = '{"query":"say \\"hi\\"","path":"C:\\\\tmp","note":"line1\nline2"}'
+
+const TURNS = [
+  {
+    n: 0,
+    reasoning: 'search broadly first',
+    status: 'Searching files',
+    tool_call: { tool: 'search', args: '{"query":"budget"}' },
+    tool_result: { tool: 'search', success: true, result: '3 hits' },
+  },
+  // No reasoning, no status — a turn serialized before those fields existed.
+  {
+    n: 1,
+    tool_call: { tool: 'search', args: NASTY_ARGS },
+    tool_result: { tool: 'search', success: true, result: '1 hit' },
+  },
+  // No tool_call at all — must still render a parseable action.
+  {
+    n: 2,
+    reasoning: 'nothing to call',
+    status: 'Thinking',
+    tool_result: { tool: 'search', success: false, result: '', error: 'timeout' },
+  },
+]
+
+const ATTEMPTS = [
+  {
+    n: 1,
+    action: {
+      reasoning: 'write the script',
+      tool_name: 'write_file',
+      tool_args: NASTY_ARGS,
+      status: 'Writing',
+      is_final: false,
+    },
+    result: 'written',
+  },
+  // is_final=true legitimately appears in actor history: the critic verifies and
+  // can reject, so the loop continues after it.
+  {
+    n: 2,
+    action: {
+      reasoning: 'done',
+      tool_name: 'run',
+      tool_args: '{"cmd":"python x.py"}',
+      status: 'Running',
+      is_final: true,
+    },
+    result: 'ok',
+    feedback: 'not verified yet — check the output',
+  },
+]
+
+const ACTION_KEYS = ['reasoning', 'tool_name', 'tool_args', 'status', 'is_final'] as const
+
+function assistantTexts(body: Body): string[] {
+  const out: string[] = []
+  for (const m of body.messages) {
+    if (m.role !== 'assistant') continue
+    const blocks = typeof m.content === 'string' ? [{ type: 'text', text: m.content }] : m.content
+    for (const blk of blocks) if (blk.text?.trim()) out.push(blk.text.trim())
+  }
+  return out
+}
+
+function allText(body: Body): string {
+  return JSON.stringify(body)
+}
+
+describe('controller history renders as ControllerAction JSON', () => {
+  it('LoopController: every assistant turn parses as a complete action', async () => {
+    const req = await b.request.LoopController(
+      'find the budget', 'find the budget', TOOLS, TURNS as never, null, null, null,
+    )
+    const body = req.body.json() as Body
+    const texts = assistantTexts(body)
+
+    expect(texts).toHaveLength(TURNS.length)
+    for (const text of texts) {
+      const parsed = JSON.parse(text) as Record<string, unknown>
+      expect(Object.keys(parsed).sort()).toEqual([...ACTION_KEYS].sort())
+      expect(typeof parsed.reasoning).toBe('string')
+      expect(typeof parsed.tool_name).toBe('string')
+      expect(typeof parsed.tool_args).toBe('string')
+      expect(typeof parsed.status).toBe('string')
+      expect(typeof parsed.is_final).toBe('boolean')
+    }
+  })
+
+  it('LoopController: tool_args survives quotes, backslashes and newlines intact', async () => {
+    const req = await b.request.LoopController(
+      'x', 'x', TOOLS, TURNS as never, null, null, null,
+    )
+    const body = req.body.json() as Body
+    const args = assistantTexts(body).map((t) => (JSON.parse(t) as { tool_args: string }).tool_args)
+    // Round-trips byte-for-byte: the escaping is done by the JSON serializer,
+    // so a tool_args value cannot break out of its own string.
+    expect(args).toContain(NASTY_ARGS)
+  })
+
+  it('LoopController: a completed turn is never advertised as final', async () => {
+    // The loop breaks BEFORE recording a final action, so history is non-final
+    // by construction; rendering `true` here would teach the model to end early.
+    const req = await b.request.LoopController(
+      'x', 'x', TOOLS, TURNS as never, null, null, null,
+    )
+    const body = req.body.json() as Body
+    for (const text of assistantTexts(body)) {
+      expect((JSON.parse(text) as { is_final: boolean }).is_final).toBe(false)
+    }
+  })
+
+  it('ActorController: every attempt parses, and is_final comes from the data', async () => {
+    const req = await b.request.ActorController(
+      'build it', 'build it', TOOLS, ATTEMPTS as never, null, null, 3, 5,
+    )
+    const body = req.body.json() as Body
+    const parsed = assistantTexts(body).map((t) => JSON.parse(t) as Record<string, unknown>)
+
+    expect(parsed).toHaveLength(ATTEMPTS.length)
+    for (const p of parsed) expect(Object.keys(p).sort()).toEqual([...ACTION_KEYS].sort())
+    // The critic rejected attempt 2 despite is_final — history must say so
+    // rather than flattening it to false.
+    expect(parsed.map((p) => p.is_final)).toEqual([false, true])
+  })
+
+  it('the legacy prose vocabulary is gone from both prompts', async () => {
+    const loop = (await b.request.LoopController(
+      'x', 'x', TOOLS, TURNS as never, null, null,
+      [{ user: 'find X', reasoning: 'search', tool: 'search', args: '{"query":"X"}' }],
+    )).body.json() as Body
+    const actor = (await b.request.ActorController(
+      'x', 'x', TOOLS, ATTEMPTS as never, null,
+      [{ user: 'build X', reasoning: 'write', tool: 'write_file', args: '{}' }], 3, 5,
+    )).body.json() as Body
+
+    for (const body of [loop, actor]) {
+      const text = allText(body)
+      // Prose action labels. `Call:`/`Args:`/`Tool:` were three different names
+      // for fields the schema calls tool_name/tool_args.
+      expect(text).not.toMatch(/Turn \d+ action:/)
+      expect(text).not.toMatch(/Attempt \d+ action:/)
+      expect(text).not.toMatch(/\\nCall: /)
+      expect(text).not.toMatch(/\\nArgs: /)
+      expect(text).not.toMatch(/\\n {4}Tool: /)
+      // Result blocks keep their prose labels — they are environment messages,
+      // not demonstrations of the model's output contract.
+      expect(text).toMatch(/Turn \d+ result:|Attempt \d+ result:/)
+    }
+  })
+
+  it('the turn counter agrees with the history it follows', async () => {
+    // History is 0-indexed (`Turn 0 result`), so with N completed turns the ask
+    // is for turn N. The previous `N + 1` skipped a number, inviting the model
+    // to infer a turn it had never seen.
+    const req = await b.request.LoopController(
+      'x', 'x', TOOLS, TURNS as never, null, null, null,
+    )
+    const text = allText(req.body.json() as Body)
+    expect(text).toContain(`Turn ${TURNS.length}. Decide the next action.`)
+    expect(text).not.toContain(`Turn ${TURNS.length + 1}. Decide the next action.`)
+  })
+})

--- a/ui/src/__tests__/lib/harness-patterns/prompt-caching-loop.test.ts
+++ b/ui/src/__tests__/lib/harness-patterns/prompt-caching-loop.test.ts
@@ -206,8 +206,9 @@ describe('simpleLoop (scheme B) — real loop, rendered per turn', () => {
     const bodies = await runLoop()
     // the tail is the turn counter + output format, and it DOES change
     const tails = bodies.map((b) => tailAfterLastMarker(b).map((blk) => blk.text).join('\n'))
-    expect(tails[0]).toContain('Turn 1. Decide the next action.')
-    expect(tails[1]).toContain('Turn 2. Decide the next action.')
+    // 0-indexed: iteration 1 has no completed turns and asks for turn 0.
+    expect(tails[0]).toContain('Turn 0. Decide the next action.')
+    expect(tails[1]).toContain('Turn 1. Decide the next action.')
     expect(tails[0]).not.toBe(tails[1])
   })
 })

--- a/ui/src/__tests__/lib/harness-patterns/prompt-caching.test.ts
+++ b/ui/src/__tests__/lib/harness-patterns/prompt-caching.test.ts
@@ -118,7 +118,8 @@ describe('LoopController prompt-caching layout', () => {
     expect(tier2.text).toContain('[ref:ev_1] search: Found 3 nodes about X')
     // volatile tail: turn counter + output format, never cached
     expect(tail.cache_control).toBeUndefined()
-    expect(tail.text).toContain('Turn 1. Decide the next action.')
+    // 0-indexed, matching the `n` the first turn is recorded under.
+    expect(tail.text).toContain('Turn 0. Decide the next action.')
   })
 
   it('history renders as chronological assistant/user pairs', async () => {
@@ -129,8 +130,9 @@ describe('LoopController prompt-caching layout', () => {
 
     const all = blocks(body)
     const a1 = all.find((blk) => blk.role === 'assistant')
-    expect(a1?.text).toContain('Turn 1 action:')
-    expect(a1?.text).toContain('Call: get_neo4j_schema')
+    // Assistant turns replay the recorded action as ControllerAction JSON — the
+    // shape the controller is asked to emit. See controller-history-format.test.ts.
+    expect(JSON.parse(a1?.text ?? '{}')).toMatchObject({ tool_name: 'get_neo4j_schema' })
     const r1 = all.find((blk) => blk.text?.includes('Turn 1 result:'))
     expect(r1?.role).toBe('user')
     expect(r1?.text).toContain('(Person)-[:KNOWS]->(Person)')
@@ -238,7 +240,8 @@ describe('ActorController prompt-caching layout (production scheme)', () => {
     const body = await renderActor(ATTEMPTS)
     const all = blocks(body)
     const a1 = all.find((blk) => blk.role === 'assistant')
-    expect(a1?.text).toContain('Attempt 1 action:')
+    // Attempts replay as ControllerAction JSON, matching the requested shape.
+    expect(JSON.parse(a1?.text ?? '{}')).toMatchObject({ tool_name: 'code-mode' })
     const r1 = all.find((blk) => blk.text?.includes('Attempt 1 result:'))
     expect(r1?.role).toBe('user') // authored as system, coerced on the wire
     expect(r1?.cache_control).toBeUndefined()

--- a/ui/src/lib/harness-patterns/patterns/simpleLoop.server.ts
+++ b/ui/src/lib/harness-patterns/patterns/simpleLoop.server.ts
@@ -362,6 +362,7 @@ export function simpleLoop<T extends SimpleLoopData>(
           turns.push({
             n: turn,
             reasoning: action.reasoning,
+            status: action.status,
             tool_call: { tool: EXPAND_TOOL_NAME, args: action.tool_args },
             tool_result: {
               tool: EXPAND_TOOL_NAME,
@@ -476,6 +477,9 @@ export function simpleLoop<T extends SimpleLoopData>(
         turns.push({
           n: turn,
           reasoning: action.reasoning,
+          // Carried so the assistant turn log can replay a complete
+          // ControllerAction rather than one missing required fields.
+          status: action.status,
           tool_call: { tool: action.tool_name, args: action.tool_args },
           tool_result: {
             tool: action.tool_name,


### PR DESCRIPTION
## Controller history now demonstrates the shape it asks for

A controller prompt renders past turns as real **assistant** messages — the
model's own prior output. Continuing the form of its previous messages is a
stronger prior than a trailing format instruction, so rendering history as prose
(`Reasoning:` / `Call:` / `Args:`) put N demonstrations of one vocabulary against
a single request for another. The demonstrations won.

### The failure

Caught in a live `microsoft-365` run. Turn 2 emitted this:

```
Turn 2 action:
Reasoning: The search results include files from multiple SharePoint sites…
Call: graph_files_list
Args: {"limit": 20}
```

A complete, *correct* decision — in the wrong envelope. BAML rejected it with all
five required fields "missing". `outputTokens: 412` against a 32768 cap, so **not
the truncation** that produces the same error text (worth noting: two distinct
root causes share one error signature, which is why this hid).

### Measured, not inferred

The export captured the failing request verbatim, so it could be replayed —
identical bytes, only the history rendering changed:

| Variant | Parsed as a complete action |
|---|---|
| **A** — prose history, exactly as sent | **5 / 15** |
| **B** — history as `ControllerAction` JSON | **15 / 15** |

A 67% failure rate on one turn-2 search loop. Not a rare glitch. And since each
turn appends another prose demonstration while the instruction stays one line,
exposure **grows with turn depth** — deep loops (neo4j refinement, sandbox
actors) were the most affected, not the shallow one that happened to surface it.

Caveat: B bundles the turn-counter fix below. Implausible as the driver of an
effect this size, but not isolated.

### The change

Both controllers replay a recorded action as the object `ctx.output_format` asks
for, so the same copying instinct now produces valid output:

- **`is_final` differs by pattern, deliberately.** simpleLoop renders a literal
  `false` — the loop breaks on a final action *before* pushing a turn, so history
  is non-final by construction. actorCritic renders it from the data — the critic
  verifies and can reject, so an attempt claiming final legitimately precedes
  another attempt.
- **`LoopTurn.status` is carried through**, optional so sessions serialized
  before the field still parse. Without it the replay would be an action missing
  required fields — exactly the shape being guarded against.
- **Few-shot labels use the schema's field names.** There were three vocabularies
  for two fields (`Tool:`/`Args:` in the examples, `Call:`/`Args:` in the log,
  `tool_name`/`tool_args` in the schema). They stay a labelled list rather than
  an object: carrying no status/is_final, rendering them as objects would
  demonstrate an incomplete action.
- **The turn counter is 0-indexed** to match the log it follows. `turns|length + 1`
  printed "Turn 2" after a log ending at "Turn 0", inviting the model to infer a
  turn it had never seen.

`tojson` does the quoting, so `tool_args` — itself JSON, full of quotes — cannot
break out of its own string. Asserted against args containing quotes,
backslashes and newlines.

Result blocks keep their prose labels: they are environment messages, not
demonstrations of the model's output contract.

### What deliberately did NOT change

A prose-shaped fallback parser would have salvaged this exact call (`json-repair`
is already in the tree). It is left out on purpose: adding it would keep the
contradiction and stop us seeing it. Worth adding later as a net, not instead of
this.

### Verification

- New `controller-history-format.test.ts`: every assistant block parses as a
  complete `ControllerAction`; `tool_args` round-trips byte-for-byte; simpleLoop
  history is never final while actorCritic's reflects the data; the legacy prose
  labels are asserted **gone**; the turn counter matches its log.
- Edge cases covered: a turn with no reasoning, no status, and no `tool_call` at
  all (a pre-existing serialized turn) still renders a parseable action.
- #122's cache suites still pass — marker placement is untouched. The changed
  prefix text invalidates existing cached prefixes once.
- **1121 passed / 2 skipped** (+6). `tsc --noEmit`: 17, unchanged baseline.

Found while reviewing a Microsoft 365 session export; unrelated to that feature
and separated from #136 on purpose — this touches every `simpleLoop` and
`actorCritic` agent.
